### PR TITLE
Add initial code for flow transform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   rules: {
     "class-methods-use-this": "off",
     "import/extensions": "off",
+    "import/prefer-default-export": "off",
     "no-constant-condition": ["error", {"checkLoops": false}],
     "no-continue": "off",
     "no-empty-function": "off",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import JSXTransformer from "./transformers/JSXTransformer";
 import ReactDisplayNameTransformer from "./transformers/ReactDisplayNameTransformer";
 import Transformer from "./transformers/Transformer";
 
-const DEFAULT_BABYLON_PLUGINS = ["jsx", "objectRestSpread"];
+const DEFAULT_BABYLON_PLUGINS = ["jsx", "flow", "objectRestSpread"];
 
-export type Transform = "jsx" | "imports" | "add-module-exports" | "react-display-name";
+export type Transform = "jsx" | "imports" | "flow" | "add-module-exports" | "react-display-name";
 
 export type Options = {
   transforms?: Array<Transform>;

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -1,0 +1,7 @@
+import Transformer from "./Transformer";
+
+export default class FlowTransformer extends Transformer {
+  process(): boolean {
+    return false;
+  }
+}

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -3,15 +3,13 @@ import TokenProcessor from "../TokenProcessor";
 import IdentifierReplacer from "./IdentifierReplacer";
 import Transformer from "./Transformer";
 
-export default class JSXTransformer implements Transformer {
+export default class JSXTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
     readonly identifierReplacer: IdentifierReplacer,
-  ) {}
-
-  preprocess(): void {
-    // Do nothing.
+  ) {
+    super();
   }
 
   process(): boolean {
@@ -20,14 +18,6 @@ export default class JSXTransformer implements Transformer {
       return true;
     }
     return false;
-  }
-
-  getPrefixCode(): string {
-    return "";
-  }
-
-  getSuffixCode(): string {
-    return "";
   }
 
   /**

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -11,14 +11,14 @@ import Transformer from "./Transformer";
  * - It does not handle `export default React.createClass`, using the filename,
  *   since Sucrase currently does not know the name of the current file.
  */
-export default class ReactDisplayNameTransformer implements Transformer {
+export default class ReactDisplayNameTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
     readonly identifierReplacer: IdentifierReplacer,
-  ) {}
-
-  preprocess(): void {}
+  ) {
+    super();
+  }
 
   process(): boolean {
     const startIndex = this.tokens.currentIndex();
@@ -137,13 +137,5 @@ export default class ReactDisplayNameTransformer implements Transformer {
     return (
       this.tokens.matchesAtIndex(index, [")"]) || this.tokens.matchesAtIndex(index, [",", ")"])
     );
-  }
-
-  getPrefixCode(): string {
-    return "";
-  }
-
-  getSuffixCode(): string {
-    return "";
   }
 }

--- a/src/transformers/Transformer.ts
+++ b/src/transformers/Transformer.ts
@@ -1,7 +1,14 @@
-export default interface Transformer {
-  preprocess(): void;
+export default abstract class Transformer {
+  preprocess(): void {}
+
   // Return true if anything was processed, false otherwise.
-  process(): boolean;
-  getPrefixCode(): string;
-  getSuffixCode(): string;
-};
+  abstract process(): boolean;
+
+  getPrefixCode(): string {
+    return "";
+  }
+
+  getSuffixCode(): string {
+    return "";
+  }
+}

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -1,0 +1,25 @@
+import {PREFIX} from "./prefixes";
+import {assertResult} from "./util";
+
+describe("transform flow", () => {
+  it("removes `import type` statements", () => {
+    assertResult(
+      `
+      import type {a} from 'b';
+      import c from 'd';
+      import type from 'e';
+      import {f, type g} from 'h';
+      import {type i, type j} from 'k';
+      import type L from 'L';
+    `,
+      `${PREFIX}
+      
+      var _d = require('d'); var _d2 = _interopRequireDefault(_d);
+      var _e = require('e'); var _e2 = _interopRequireDefault(_e);
+      var _h = require('h');
+      
+      
+    `,
+    );
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,11 +1,11 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 
-import { transform, Transform } from '../src';
+import {transform, Transform} from "../src";
 
 export function assertResult(
   code: string,
   expectedResult: string,
-  transforms: Array<Transform> = ['jsx', 'imports', 'react-display-name']
+  transforms: Array<Transform> = ["jsx", "imports", "react-display-name", "flow"],
 ): void {
   assert.equal(transform(code, {transforms}), expectedResult);
 }

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -4,8 +4,11 @@ import './App.css';
 import {getVersion} from 'sucrase';
 
 import {
-  TRANSFORMS, INITIAL_CODE,
-  DEFAULT_COMPARE_WITH_BABEL, DEFAULT_SHOW_TOKENS, DEFAULT_TRANSFORMS
+  TRANSFORMS,
+  INITIAL_CODE,
+  DEFAULT_COMPARE_WITH_BABEL,
+  DEFAULT_SHOW_TOKENS,
+  DEFAULT_TRANSFORMS,
 } from './Constants';
 import Editor from './Editor';
 import OptionBox from './OptionBox';
@@ -106,8 +109,8 @@ class App extends Component {
         <div className="App-options">
           <OptionBox
             title="Transforms"
-            options={TRANSFORMS.map(({name}) => ({
-              text: name,
+            options={TRANSFORMS.map(({name, isExperimental}) => ({
+              text: name + (isExperimental ? ' (experimental)' : ''),
               checked: Boolean(this.state.selectedTransforms[name]),
               onToggle: () => {
                 this.setState({

--- a/website/src/Constants.js
+++ b/website/src/Constants.js
@@ -20,6 +20,7 @@ export default App;
 export const TRANSFORMS = [
   {name: 'jsx', babelName: 'transform-react-jsx'},
   {name: 'imports', babelName: 'transform-es2015-modules-commonjs'},
+  {name: 'flow', babelName: 'transform-flow-strip-types', isExperimental: true},
   {name: 'react-display-name', babelName: 'transform-react-display-name'},
   {name: 'add-module-exports', babelName: 'add-module-exports'},
 ];

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -58,7 +58,7 @@ function runBabel() {
     ];
   }
   return runAndProfile(() =>
-    Babel.transform(config.code, {plugins: babelPlugins,}).code
+    Babel.transform(config.code, {plugins: babelPlugins, parserOpts: {plugins: ['jsx', 'flow']}}).code
   );
 }
 
@@ -69,6 +69,7 @@ function runAndProfile(runOperation) {
     const time = performance.now() - start;
     return {code, time};
   } catch (e) {
+    console.error(e);
     return {code: e.message, time: null};
   }
 }

--- a/website/src/getTokens.js
+++ b/website/src/getTokens.js
@@ -4,7 +4,7 @@ export default function getTokens(code) {
   try {
     const ast = babylon.parse(
       code,
-      {tokens: true, sourceType: 'module', plugins: ['jsx', 'objectRestSpread']}
+      {tokens: true, sourceType: 'module', plugins: ['jsx', 'objectRestSpread', 'flow']}
     );
     return formatTokens(ast.tokens);
   } catch (e) {


### PR DESCRIPTION
This adds the flow transform as an option, adds a transformer (which does
nothing for now), and changes the import code to properly handle `type` in
various places. The behavior to copy from babel is that if the declaration is
`import type` or if the declaration has only `type` imports.

This does not yet try to handle the flow transform without the import transform.

The new transform is in the repl but marked as experimental since it's
incomplete. I probably won't publish until the transform is in better shape, but
the code is still publishable.