### PR TITLE
Remove implements from class declarations and expressions

### DIFF
--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -1,7 +1,18 @@
+import {RootTransformer} from "../index";
+import TokenProcessor from "../TokenProcessor";
 import Transformer from "./Transformer";
 
 export default class FlowTransformer extends Transformer {
+  constructor(readonly rootTransformer: RootTransformer, readonly tokens: TokenProcessor) {
+    super();
+  }
+
   process(): boolean {
+    // We need to handle all classes specially in order to remove `implements`.
+    if (this.tokens.matches(["class"])) {
+      this.rootTransformer.processClass();
+      return true;
+    }
     return false;
   }
 }

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -22,4 +22,17 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes `implements` from a class declaration", () => {
+    assertResult(
+      `
+      class A implements B {}
+      class C extends D implements E {}
+    `,
+      `${PREFIX}
+      class A {}
+      class C extends D {}
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This moves some class processing code into RootTransformer, so probbably there's
a better way to think about factoring all of this in the long run. Also, like
with `import type`, I handle it always rather than producing invalid JS if the
flow transform is disabled.