### PR TITLE
Improve repl formatting and add babylon metadata

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -7,7 +7,7 @@ export type TokenContext =
   | "jsxTag"
   | "jsxChild"
   | "jsxExpression"
-  | "interpolatedExpression"
+  | "templateExpr"
   | "switchCaseCondition";
 
 export type TokenType = {

--- a/src/augmentTokenContext.ts
+++ b/src/augmentTokenContext.ts
@@ -144,7 +144,7 @@ export default function augmentTokenContext(tokens: Array<Token>): void {
       } else if (token.type.label === "(") {
         processToToken(")", "parens");
       } else if (token.type.label === "${") {
-        processToToken("}", "interpolatedExpression");
+        processToToken("}", "templateExpr");
       }
     }
   }

--- a/src/util/formatTokens.ts
+++ b/src/util/formatTokens.ts
@@ -7,15 +7,21 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
     return "";
   }
 
+  const typeKeys = Object.keys(tokens[0].type).filter(
+    (k) => k !== "updateContext" && k !== "label" && k !== "keyword",
+  );
+
+  const headings = ["Location", "Label", "Context", "Value", ...typeKeys];
+
   const lines = new LinesAndColumns(code);
-  const allTokenComponents = tokens.map(getTokenComponents);
-  const padding = allTokenComponents[0].map((t) => 0);
-  for (const components of allTokenComponents) {
+  const rows = [headings, ...tokens.map(getTokenComponents)];
+  const padding = headings.map(() => 0);
+  for (const components of rows) {
     for (let i = 0; i < components.length; i++) {
       padding[i] = Math.max(padding[i], components[i].length);
     }
   }
-  return allTokenComponents
+  return rows
     .map((components) => components.map((component, i) => component.padEnd(padding[i])).join(" "))
     .join("\n");
 
@@ -24,7 +30,17 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
       formatRange(token.start, token.end),
       token.type.label,
       `${token.contextName}(${token.contextStartIndex})`,
-      token.value != null ? String(token.value) : "",
+      token.value != null ? truncate(String(token.value), 14) : "",
+      ...typeKeys.map((key) => {
+        const value = token.type[key];
+        if (value === true) {
+          return key;
+        } else if (value === false || value === null) {
+          return "";
+        } else {
+          return String(value);
+        }
+      }),
     ];
   }
 
@@ -39,5 +55,13 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
     } else {
       return `${location.line + 1}:${location.column + 1}`;
     }
+  }
+}
+
+function truncate(s: string, length: number): string {
+  if (s.length > length) {
+    return `${s.slice(0, length - 3)}...`;
+  } else {
+    return s;
   }
 }

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -10,20 +10,21 @@ if (foo) {
   console.log('Hello world!');
 }`),
       `\
-1:1-1:3   if     block(0)  if          
-1:4-1:5   (      block(0)              
-1:5-1:8   name   parens(2) foo         
-1:8-1:9   )      parens(2)             
-1:10-1:11 {      block(0)              
-2:3-2:10  name   block(5)  console     
-2:10-2:11 .      block(5)              
-2:11-2:14 name   block(5)  log         
-2:14-2:15 (      block(5)              
-2:15-2:29 string parens(9) Hello world!
-2:29-2:30 )      parens(9)             
-2:30-2:31 ;      block(5)              
-3:1-3:2   }      block(5)              
-3:2-3:2   eof    block(0)              `,
+Location  Label  Context   Value        beforeExpr startsExpr rightAssociative isLoop isAssign prefix postfix binop
+1:1-1:3   if     block(0)  if                                                                                      
+1:4-1:5   (      block(0)               beforeExpr startsExpr                                                      
+1:5-1:8   name   parens(2) foo                     startsExpr                                                      
+1:8-1:9   )      parens(2)                                                                                         
+1:10-1:11 {      block(0)               beforeExpr startsExpr                                                      
+2:3-2:10  name   block(5)  console                 startsExpr                                                      
+2:10-2:11 .      block(5)                                                                                          
+2:11-2:14 name   block(5)  log                     startsExpr                                                      
+2:14-2:15 (      block(5)               beforeExpr startsExpr                                                      
+2:15-2:29 string parens(9) Hello world!            startsExpr                                                      
+2:29-2:30 )      parens(9)                                                                                         
+2:30-2:31 ;      block(5)               beforeExpr                                                                 
+3:1-3:2   }      block(5)                                                                                          
+3:2-3:2   eof    block(0)                                                                                          `,
     );
   });
 });

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -170,7 +170,7 @@ class App extends Component {
               isReadOnly={true}
               isPlaintext={true}
               options={{
-                lineNumbers: (n) => String(n - 1)
+                lineNumbers: (n) => n > 1 ? String(n - 2) : null
               }}
             />
           )}


### PR DESCRIPTION
We now show a header line that shows all of the available babylon flags, and
format flags in a way that's easy to scan. I also made it so the strings don't
get too long so that the table is always somewhat readable.