### PR TITLE
Remove flow function return types

### DIFF
--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -13,6 +13,49 @@ export default class FlowTransformer extends Transformer {
       this.rootTransformer.processClass();
       return true;
     }
+    if (this.tokens.matches([":"])) {
+      return this.processColon();
+    }
+    return false;
+  }
+
+  processColon(): boolean {
+    const colonToken = this.tokens.currentToken();
+    const colonIndex = this.tokens.currentIndex();
+    const prevToken = this.tokens.tokens[colonIndex - 1];
+    if (prevToken.type.label === ")") {
+      // Possibly the end of an argument list.
+      const startParenIndex = prevToken.contextStartIndex! - 1;
+      if (
+        this.tokens.matchesAtIndex(startParenIndex - 2, ["function"]) ||
+        this.tokens.matchesAtIndex(startParenIndex - 1, ["function"])
+      ) {
+        this.tokens.removeInitialToken();
+        this.rootTransformer.removeTypeExpression();
+        return true;
+      }
+      const endIndex = this.rootTransformer.skipTypeExpression(colonIndex + 1);
+      if (endIndex !== null) {
+        const nextToken = this.tokens.tokens[endIndex];
+        if (
+          nextToken.type.label === "{" &&
+          (colonToken.contextName === "object" || colonToken.contextName === "class")
+        ) {
+          this.rootTransformer.removeToTokenIndex(endIndex);
+          return true;
+        }
+      }
+
+      const eagerArrowEndIndex = this.rootTransformer.skipTypeExpression(colonIndex + 1, true);
+      if (eagerArrowEndIndex !== null) {
+        const eagerArrowNextToken = this.tokens.tokens[eagerArrowEndIndex];
+        if (eagerArrowNextToken.type.label === "=>") {
+          this.rootTransformer.removeToTokenIndex(eagerArrowEndIndex);
+          return true;
+        }
+      }
+    }
+
     return false;
   }
 }

--- a/src/util/TokenUtil.ts
+++ b/src/util/TokenUtil.ts
@@ -1,0 +1,19 @@
+import {TokenType} from "../TokenProcessor";
+
+/**
+ * An "atom" in this context is a token that is an expression all by itself,
+ * like an identifier or a literal.
+ */
+export function isTypeExpressionAtom(tokenType: TokenType): boolean {
+  return ["name", "num", "false", "true", "null", "void", "this"].includes(tokenType.label);
+}
+
+export function isTypeExpressionPrefix(tokenType: TokenType): boolean {
+  // typeof isn't considered a prefix operator because its operand is an
+  // identifier, not a type.
+  return ["?"].includes(tokenType.label);
+}
+
+export function isTypeBinop(tokenType: TokenType): boolean {
+  return ["|", "&"].includes(tokenType.label);
+}

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -35,4 +35,43 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes function return type annotations", () => {
+    assertResult(
+      `
+      function f(): number {
+        return 3;
+      }
+      const g = (): number => 4;
+      function h():{}|{}{}{}
+      const o = {
+        foo(): string | number {
+          return 'hi';
+        }
+      }
+      class C {
+        bar(): void {
+          console.log('Hello');
+        }
+      }
+    `,
+      `${PREFIX}
+      function f() {
+        return 3;
+      }
+      const g = () => 4;
+      function h(){}{}
+      const o = {
+        foo() {
+          return 'hi';
+        }
+      }
+      class C {
+        bar() {
+          console.log('Hello');
+        }
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We do this by looking at nearby tokens to see if it's an arrow function, normal
function, object literal function, or class body function. This also requires
carefully walking forward by one type, which is needed to distinguish an object
`{` from the start of the function body.

It may be better to compute this at parse time, or some similar system, but
hopefully I'll be able to get things working and then can iterate from there.