### PR TITLE
Rework token preprocessing to fix ranges

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -22,6 +22,7 @@ export type Token = {
   value: any;
   contextName?: TokenContext;
   contextStartIndex?: number;
+  parentContextStartIndex?: number | null;
 };
 
 export default class TokenProcessor {
@@ -126,6 +127,12 @@ export default class TokenProcessor {
    */
   nextToken(): void {
     this.tokenIndex++;
+  }
+
+  expectToken(label: string): void {
+    if (this.tokens[this.tokenIndex].type.label !== label) {
+      throw new Error(`Expected token ${label}`);
+    }
   }
 
   finish(): string {

--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -4,6 +4,11 @@ export default function augmentTokens(code: string, tokens: Array<Token>): void 
   new TokenPreprocessor(new TokenProcessor(code, tokens)).preprocess();
 }
 
+type ContextInfo = {
+  context: TokenContext;
+  startIndex: number;
+};
+
 /**
  * Class that does a scan through the tokens to establish the "context" for each
  * token (like whether it's in a block or an object literal) and some other
@@ -11,100 +16,106 @@ export default function augmentTokens(code: string, tokens: Array<Token>): void 
  * element from an object shorthand.
  */
 class TokenPreprocessor {
+  private contextStack: Array<ContextInfo> = [];
+
   constructor(readonly tokens: TokenProcessor) {}
 
   preprocess(): void {
-    this.processToToken("eof", "block");
+    this.processRegion([], ["eof"], "block");
   }
 
-  private processToToken(closingTokenLabel: string, context: TokenContext): void {
-    this.processRegion([closingTokenLabel], context);
+  private processToToken(
+    openingTokenLabel: string,
+    closingTokenLabel: string,
+    context: TokenContext,
+  ): void {
+    this.processRegion([openingTokenLabel], [closingTokenLabel], context);
   }
 
-  private processRegion(closingTokenLabels: Array<string>, context: TokenContext): void {
-    const contextStartIndex = this.tokens.currentIndex();
+  private processRegion(
+    openingTokenLabels: Array<string>,
+    closingTokenLabels: Array<string>,
+    context: TokenContext,
+    {followingLabels = []}: {followingLabels?: Array<string>} = {},
+  ): void {
+    this.contextStack.push({context, startIndex: this.tokens.currentIndex()});
 
     const advance = () => {
       const token = this.tokens.currentToken();
-      token.contextName = context;
-      token.contextStartIndex = contextStartIndex;
+      const contextInfo = this.contextStack[this.contextStack.length - 1];
+      const parentContextInfo = this.contextStack[this.contextStack.length - 2];
+      token.contextName = contextInfo.context;
+      token.contextStartIndex = contextInfo.startIndex;
+      token.parentContextStartIndex = parentContextInfo ? parentContextInfo.startIndex : null;
       this.tokens.nextToken();
     };
 
+    for (const label of openingTokenLabels) {
+      this.tokens.expectToken(label);
+      advance();
+    }
+
     let pendingClass = false;
     while (true) {
-      if (this.tokens.isAtEnd()) {
-        throw new Error("Unexpected end of program when preprocessing tokens.");
-      }
-
-      if (this.tokens.matches(closingTokenLabels)) {
+      if (this.tokens.matches([...closingTokenLabels, ...followingLabels])) {
         for (let i = 0; i < closingTokenLabels.length; i++) {
           advance();
         }
         break;
       }
-      const lastToken = this.tokens.tokens[this.tokens.currentIndex() - 1];
-      const token = this.tokens.currentToken();
-      advance();
 
-      // Keywords can be property values, so bail out if we're after a dot.
-      if (!lastToken || lastToken.type.label !== ".") {
-        if (
-          token.type.label === "if" ||
-          token.type.label === "for" ||
-          token.type.label === "while" ||
-          token.type.label === "catch" ||
-          token.type.label === "function"
-        ) {
-          // Code of the form TOKEN (...) BLOCK
-          if (token.type.label === "function" && this.tokens.matches(["name"])) {
-            advance();
-          }
-          if (this.tokens.matches(["("])) {
-            advance();
-            this.processToToken(")", "parens");
-            if (this.tokens.matches(["{"])) {
-              advance();
-              this.processToToken("}", "block");
-            }
-            continue;
-          }
-        } else if (
-          token.type.label === "=>" ||
-          token.type.label === "else" ||
-          token.type.label === "try" ||
-          token.type.label === "finally" ||
-          token.type.label === "do" ||
-          token.type.label === "}" ||
-          token.type.label === ")" ||
-          (token.type.label === ";" && context === "block")
-        ) {
-          if (this.tokens.matches(["{"])) {
-            advance();
-            this.processToToken("}", "block");
-            continue;
-          }
-        } else if (token.type.label === "class") {
-          pendingClass = true;
-          continue;
-        } else if (token.type.label === "default") {
-          if (this.tokens.matches([":", "{"])) {
-            advance();
-            advance();
-            this.processToToken("}", "block");
-            continue;
-          }
-        }
+      if (this.tokens.isAtEnd()) {
+        throw new Error("Unexpected end of program when preprocessing tokens.");
       }
 
-      if (token.type.label === "name") {
+      if (this.startsWithKeyword(["if", "for", "while", "catch"])) {
+        // Code of the form TOKEN (...) BLOCK
+        if (this.tokens.matches(["("])) {
+          this.tokens.expectToken("(");
+          advance();
+          this.processToToken("(", ")", "parens");
+          if (this.tokens.matches(["{"])) {
+            this.processToToken("{", "}", "block");
+          }
+        } else {
+          advance();
+        }
+      } else if (this.startsWithKeyword(["function"])) {
+        advance();
+        if (this.tokens.matches(["name"])) {
+          advance();
+        }
+        // TODO: Handle return type annotations.
+        if (this.tokens.matches(["{"])) {
+          this.processToToken("(", ")", "parens");
+          if (this.tokens.matches(["{"])) {
+            this.processToToken("{", "}", "block");
+          }
+        }
+      } else if (
+        this.startsWithKeyword(["=>", "else", "try", "finally", "do"]) ||
+        (this.tokens.matches([";"]) && context === "block")
+      ) {
+        advance();
+        if (this.tokens.matches(["{"])) {
+          this.processToToken("{", "}", "block");
+        }
+      } else if (this.startsWithKeyword(["class"])) {
+        advance();
+        pendingClass = true;
+      } else if (this.startsWithKeyword(["default"])) {
+        advance();
+        if (this.tokens.matches([":", "{"])) {
+          advance();
+          this.processToToken("{", "}", "block");
+        }
+      } else if (this.tokens.matches(["name"])) {
+        advance();
         if (context === "class" && this.tokens.matches(["("])) {
           // Process class method.
-          advance();
-          this.processToToken(")", "parens");
+          this.processToToken("(", ")", "parens");
           if (this.tokens.matches(["{"])) {
-            advance();
-            this.processToToken("}", "block");
+            this.processToToken("{", "}", "block");
           }
         } else if (
           context === "object" &&
@@ -113,43 +124,60 @@ class TokenPreprocessor {
             this.tokens.matchesAtRelativeIndex(-2, ["{"]))
         ) {
           // Process object method.
-          advance();
-          this.processToToken(")", "parens");
+          this.processToToken("(", ")", "parens");
           if (this.tokens.matches(["{"])) {
-            advance();
-            this.processToToken("}", "block");
+            this.processToToken("{", "}", "block");
           }
         }
-      } else if (token.type.label === "case") {
-        this.processToToken(":", "switchCaseCondition");
+      } else if (this.tokens.matches(["case"])) {
+        this.processToToken("case", ":", "switchCaseCondition");
         if (this.tokens.matches(["{"])) {
-          advance();
-          this.processToToken("}", "block");
+          this.processToToken("{", "}", "block");
         }
-      } else if (token.type.label === "jsxTagStart") {
-        this.processToToken("jsxTagEnd", "jsxTag");
+      } else if (this.tokens.matches(["jsxTagStart"])) {
+        this.processToToken("jsxTagStart", "jsxTagEnd", "jsxTag");
         // Non-self-closing tag, so use jsxChild context for the body.
         if (!this.tokens.matchesAtRelativeIndex(-2, ["/"])) {
           // All / tokens will be in JSX tags.
-          this.processRegion(["jsxTagStart", "/"], "jsxChild");
-          this.processToToken("jsxTagEnd", "jsxTag");
+          this.processRegion([], [], "jsxChild", {followingLabels: ["jsxTagStart", "/"]});
+          this.processToToken("jsxTagStart", "jsxTagEnd", "jsxTag");
         }
-      } else if (token.type.label === "{") {
-        if (pendingClass && lastToken.type.label !== "extends") {
-          this.processToToken("}", "class");
+      } else if (this.tokens.matches(["{"])) {
+        if (
+          this.tokens.matchesAtRelativeIndex(-1, [")"]) ||
+          this.tokens.matchesAtRelativeIndex(-1, ["}"])
+        ) {
+          this.processToToken("{", "}", "block");
+        } else if (pendingClass && !this.tokens.matchesAtRelativeIndex(-1, ["extends"])) {
+          this.processToToken("{", "}", "class");
           pendingClass = false;
         } else if (context === "jsxTag" || context === "jsxChild") {
-          this.processToToken("}", "jsxExpression");
+          this.processToToken("{", "}", "jsxExpression");
         } else {
-          this.processToToken("}", "object");
+          this.processToToken("{", "}", "object");
         }
-      } else if (token.type.label === "[") {
-        this.processToToken("]", "brackets");
-      } else if (token.type.label === "(") {
-        this.processToToken(")", "parens");
-      } else if (token.type.label === "${") {
-        this.processToToken("}", "templateExpr");
+      } else if (this.tokens.matches(["["])) {
+        this.processToToken("[", "]", "brackets");
+      } else if (this.tokens.matches(["("])) {
+        this.processToToken("(", ")", "parens");
+      } else if (this.tokens.matches(["${"])) {
+        this.processToToken("${", "}", "templateExpr");
+      } else {
+        advance();
       }
     }
+
+    this.contextStack.pop();
+  }
+
+  /**
+   * Keywords can be property values, so don't consider them if we're after a
+   * dot.
+   */
+  startsWithKeyword(keywords: Array<string>): boolean {
+    return (
+      !this.tokens.matchesAtRelativeIndex(-1, ["."]) &&
+      keywords.some((keyword) => this.tokens.matches([keyword]))
+    );
   }
 }

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -25,7 +25,7 @@ export default class FlowTransformer extends Transformer {
     const prevToken = this.tokens.tokens[colonIndex - 1];
     if (prevToken.type.label === ")") {
       // Possibly the end of an argument list.
-      const startParenIndex = prevToken.contextStartIndex! - 1;
+      const startParenIndex = prevToken.contextStartIndex!;
       if (
         this.tokens.matchesAtIndex(startParenIndex - 2, ["function"]) ||
         this.tokens.matchesAtIndex(startParenIndex - 1, ["function"])

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -103,10 +103,10 @@ export default class ReactDisplayNameTransformer extends Transformer {
     if (!this.tokens.matches(["(", "{"])) {
       return false;
     }
-    // Currently augmentTokenContext starts the block at one after the {, so we
-    // expect any displayName key to be in that context. We need to ignore other
-    // other contexts to avoid matching nested displayName keys.
-    const objectStartIndex = index + 2;
+    // The block starts on the {, and we expect any displayName key to be in
+    // that context. We need to ignore other other contexts to avoid matching
+    // nested displayName keys.
+    const objectStartIndex = index + 1;
 
     for (; index < this.tokens.tokens.length; index++) {
       const token = this.tokens.tokens[index];

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -134,7 +134,7 @@ export default class RootTransformer {
         !this.tokens.matchesName("implements") &&
         !(
           this.tokens.matches(["{"]) &&
-          this.tokens.currentToken().contextStartIndex === classToken.contextStartIndex
+          this.tokens.currentToken().parentContextStartIndex === classToken.contextStartIndex
         )
       ) {
         this.processToken();

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -167,6 +167,25 @@ describe("transform imports", () => {
     );
   });
 
+  it("transforms export class with complex superclass containing an open-brace", () => {
+    assertResult(
+      `
+      export class A extends b(C({})) {
+        d() {
+          return e;
+        }
+      }
+    `,
+      `${PREFIX}${ESMODULE_PREFIX}
+       class A extends b(C({})) {
+        d() {
+          return e;
+        }
+      } exports.A = A;
+    `,
+    );
+  });
+
   it("allows exporting names directly", () => {
     assertResult(
       `

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -12,18 +12,18 @@ if (foo) {
       `\
 Location  Label  Context   Value        beforeExpr startsExpr rightAssociative isLoop isAssign prefix postfix binop
 1:1-1:3   if     block(0)  if                                                                                      
-1:4-1:5   (      block(0)               beforeExpr startsExpr                                                      
-1:5-1:8   name   parens(2) foo                     startsExpr                                                      
-1:8-1:9   )      parens(2)                                                                                         
-1:10-1:11 {      block(0)               beforeExpr startsExpr                                                      
-2:3-2:10  name   block(5)  console                 startsExpr                                                      
-2:10-2:11 .      block(5)                                                                                          
-2:11-2:14 name   block(5)  log                     startsExpr                                                      
-2:14-2:15 (      block(5)               beforeExpr startsExpr                                                      
-2:15-2:29 string parens(9) Hello world!            startsExpr                                                      
-2:29-2:30 )      parens(9)                                                                                         
-2:30-2:31 ;      block(5)               beforeExpr                                                                 
-3:1-3:2   }      block(5)                                                                                          
+1:4-1:5   (      parens(1)              beforeExpr startsExpr                                                      
+1:5-1:8   name   parens(1) foo                     startsExpr                                                      
+1:8-1:9   )      parens(1)                                                                                         
+1:10-1:11 {      block(4)               beforeExpr startsExpr                                                      
+2:3-2:10  name   block(4)  console                 startsExpr                                                      
+2:10-2:11 .      block(4)                                                                                          
+2:11-2:14 name   block(4)  log                     startsExpr                                                      
+2:14-2:15 (      parens(8)              beforeExpr startsExpr                                                      
+2:15-2:29 string parens(8) Hello world!            startsExpr                                                      
+2:29-2:30 )      parens(8)                                                                                         
+2:30-2:31 ;      block(4)               beforeExpr                                                                 
+3:1-3:2   }      block(4)                                                                                          
 3:2-3:2   eof    block(0)                                                                                          `,
     );
   });


### PR DESCRIPTION
Now, contexts start at their first token, which also means that for one edge
case we need to keep the parent context start index as well.