### PR TITLE
Rework flow implementation to recognize all types after colons

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -8,7 +8,8 @@ export type TokenContext =
   | "jsxChild"
   | "jsxExpression"
   | "templateExpr"
-  | "switchCaseCondition";
+  | "switchCaseCondition"
+  | "type";
 
 export type TokenType = {
   label: string;
@@ -115,6 +116,10 @@ export default class TokenProcessor {
 
   currentToken(): Token {
     return this.tokens[this.tokenIndex];
+  }
+
+  tokenAtRelativeIndex(relativeIndex: number): Token {
+    return this.tokens[this.tokenIndex + relativeIndex];
   }
 
   currentIndex(): number {

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -20,42 +20,12 @@ export default class FlowTransformer extends Transformer {
   }
 
   processColon(): boolean {
-    const colonToken = this.tokens.currentToken();
-    const colonIndex = this.tokens.currentIndex();
-    const prevToken = this.tokens.tokens[colonIndex - 1];
-    if (prevToken.type.label === ")") {
-      // Possibly the end of an argument list.
-      const startParenIndex = prevToken.contextStartIndex!;
-      if (
-        this.tokens.matchesAtIndex(startParenIndex - 2, ["function"]) ||
-        this.tokens.matchesAtIndex(startParenIndex - 1, ["function"])
-      ) {
-        this.tokens.removeInitialToken();
-        this.rootTransformer.removeTypeExpression();
-        return true;
-      }
-      const endIndex = this.rootTransformer.skipTypeExpression(colonIndex + 1);
-      if (endIndex !== null) {
-        const nextToken = this.tokens.tokens[endIndex];
-        if (
-          nextToken.type.label === "{" &&
-          (colonToken.contextName === "object" || colonToken.contextName === "class")
-        ) {
-          this.rootTransformer.removeToTokenIndex(endIndex);
-          return true;
-        }
-      }
-
-      const eagerArrowEndIndex = this.rootTransformer.skipTypeExpression(colonIndex + 1, true);
-      if (eagerArrowEndIndex !== null) {
-        const eagerArrowNextToken = this.tokens.tokens[eagerArrowEndIndex];
-        if (eagerArrowNextToken.type.label === "=>") {
-          this.rootTransformer.removeToTokenIndex(eagerArrowEndIndex);
-          return true;
-        }
+    if (this.tokens.tokenAtRelativeIndex(1).contextName === "type") {
+      this.tokens.removeInitialToken();
+      while (this.tokens.currentToken().contextName === "type") {
+        this.tokens.removeToken();
       }
     }
-
     return false;
   }
 }

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -2,7 +2,6 @@ import ImportProcessor from "../ImportProcessor";
 import {Transform} from "../index";
 import NameManager from "../NameManager";
 import TokenProcessor from "../TokenProcessor";
-import {isTypeBinop, isTypeExpressionAtom, isTypeExpressionPrefix} from "../util/TokenUtil";
 import FlowTransformer from "./FlowTransformer";
 import ImportTransformer from "./ImportTransformer";
 import JSXTransformer from "./JSXTransformer";
@@ -150,115 +149,5 @@ export default class RootTransformer {
     this.tokens.copyExpectedToken("{");
     this.processBalancedCode();
     this.tokens.copyExpectedToken("}");
-  }
-
-  removeTypeExpression(): void {
-    const expressionEnd = this.skipTypeExpression(this.tokens.currentIndex());
-    if (expressionEnd === null) {
-      throw new Error("Expected to find a type expression.");
-    }
-    this.removeToTokenIndex(expressionEnd);
-  }
-
-  removeToTokenIndex(index: number): void {
-    while (this.tokens.currentIndex() < index) {
-      this.tokens.removeToken();
-    }
-  }
-
-  /**
-   * disallowError says that we should NOT traverse arrow types. This is
-   * specifically when trying to parse a return type on an arrow function, which
-   * can lead to an ambiguity like this:
-   *
-   * f = (): number => number => 4;
-   *
-   * The proper parsing here is just `number` for the return type.
-   */
-  skipTypeExpression(index: number, disallowArrow: boolean = false): number | null {
-    const tokens = this.tokens.tokens;
-    while (isTypeExpressionPrefix(tokens[index].type)) {
-      index++;
-    }
-
-    const firstToken = tokens[index];
-    if (isTypeExpressionAtom(firstToken.type)) {
-      // Identifier, number, etc, or function type with that as the param.
-      index++;
-      if (!disallowArrow && this.tokens.matchesAtIndex(index, ["=>"])) {
-        index++;
-        const nextIndex = this.skipTypeExpression(index);
-        if (nextIndex === null) {
-          return null;
-        }
-        index = nextIndex;
-      }
-    } else if (firstToken.type.label === "{") {
-      index++;
-      index = this.skipBalancedCode(index, "{", "}");
-      index++;
-    } else if (firstToken.type.label === "[") {
-      index++;
-      index = this.skipBalancedCode(index, "[", "]");
-      index++;
-    } else if (firstToken.type.label === "(") {
-      // Either a parenthesized expression or an arrow function.
-      index++;
-      index = this.skipBalancedCode(index, "(", ")");
-      index++;
-      if (!disallowArrow && this.tokens.matchesAtIndex(index, ["=>"])) {
-        index++;
-        const nextIndex = this.skipTypeExpression(index);
-        if (nextIndex === null) {
-          return null;
-        }
-        index = nextIndex;
-      }
-    } else if (firstToken.type.label === "typeof") {
-      index += 2;
-    } else {
-      // Unrecognized token, so bail out.
-      return null;
-    }
-
-    // We're already one past the end of a valid expression, so see if it's
-    // possible to expand to the right.
-    while (true) {
-      const token = tokens[index];
-
-      // Check if there's any indication that we can expand forward, and do so.
-      if (isTypeBinop(token.type)) {
-        index++;
-        const nextIndex = this.skipTypeExpression(index);
-        if (nextIndex === null) {
-          return null;
-        }
-        index = nextIndex;
-      } else if (token.type.label === ".") {
-        // Normal member access, so process the dot and the identifier.
-        index += 2;
-      } else if (this.tokens.matches(["[", "]"])) {
-        index += 2;
-      } else {
-        break;
-      }
-    }
-    return index;
-  }
-
-  skipBalancedCode(index: number, openTokenLabel: string, closeTokenLabel: string): number {
-    let depth = 0;
-    while (!this.tokens.isAtEnd()) {
-      if (this.tokens.matchesAtIndex(index, [openTokenLabel])) {
-        depth++;
-      } else if (this.tokens.matchesAtIndex(index, [closeTokenLabel])) {
-        if (depth === 0) {
-          break;
-        }
-        depth--;
-      }
-      index++;
-    }
-    return index;
   }
 }

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -74,4 +74,21 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes types in parameters and variable declarations", () => {
+    assertResult(
+      `
+      function foo(x: number, y: A | B): void {
+        const a: string = "Hello";
+        const b = (a: number);
+      }
+    `,
+      `${PREFIX}
+      function foo(x, y) {
+        const a = "Hello";
+        const b = (a);
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This is a more general mechanism that handles all cases that a colon token might
appear and marks the tokens as type tokens if it's a type. There are still some
possible issues, like `?` operators within `type` declarations, but this seems
to work pretty well on normal code samples.