### PR TITLE
Properly handle object literal types

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -228,8 +228,7 @@ class TokenPreprocessor {
         !this.tokens.matchesAtRelativeIndex(-2, ["."])) ||
       this.tokens.matchesAtRelativeIndex(1, ["for"]) ||
       this.tokens.matchesAtRelativeIndex(1, ["while"]) ||
-      this.tokens.matchesAtRelativeIndex(1, ["do"]) ||
-      this.tokens.matchesAtRelativeIndex(1, ["{"])
+      this.tokens.matchesAtRelativeIndex(1, ["do"])
     );
   }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -121,4 +121,21 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes object types within classes", () => {
+    assertResult(
+      `
+      class A {
+        x: number = 2;
+        y: {} = {};
+      }
+    `,
+      `${PREFIX}
+      class A {
+        x = 2;
+        y = {};
+      }
+    `,
+    );
+  });
 });

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -58,7 +58,10 @@ function runBabel() {
     ];
   }
   return runAndProfile(() =>
-    Babel.transform(config.code, {plugins: babelPlugins, parserOpts: {plugins: ['jsx', 'flow']}}).code
+    Babel.transform(config.code, {
+      plugins: babelPlugins,
+      parserOpts: {plugins: ['jsx', 'flow', 'classProperties']}
+    }).code
   );
 }
 


### PR DESCRIPTION
We were improperly recognizing `: {` as indicating a label, when actually it
could be a type annotation with an object type. This breaks an obscure use of
labels, which will need a better solution in the future.