### PR TITLE
Fully remove bare class field type declarations

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -142,6 +142,17 @@ class TokenPreprocessor {
           if (this.tokens.matches(["{"])) {
             this.processToToken("{", "}", "block");
           }
+        } else if (context === "class" && this.tokens.matches([":"]) && ternaryDepth === 0) {
+          // Process typed class field.
+          const identifierTokenIndex = this.tokens.currentIndex() - 1;
+          this.advance();
+          this.processTypeExpression();
+          if (!this.tokens.matches(["="])) {
+            const identifierToken = this.tokens.tokens[identifierTokenIndex];
+            identifierToken.contextName = "type";
+            identifierToken.contextStartIndex = identifierTokenIndex;
+            identifierToken.parentContextStartIndex = this.getContextInfo().startIndex;
+          }
         } else if (
           context === "object" &&
           this.tokens.matches(["("]) &&
@@ -237,7 +248,8 @@ class TokenPreprocessor {
   }
 
   /**
-   * Starting at a colon type,
+   * Starting at a colon type, walk forward a full type expression, marking all
+   * tokens as being type tokens.
    */
   private processTypeExpression({disallowArrow = false}: {disallowArrow?: boolean} = {}): void {
     this.contextStack.push({context: "type", startIndex: this.tokens.currentIndex()});

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -16,6 +16,10 @@ export default class FlowTransformer extends Transformer {
     if (this.tokens.matches([":"])) {
       return this.processColon();
     }
+    if (this.tokens.currentToken().contextName === "type") {
+      this.tokens.removeInitialToken();
+      return true;
+    }
     return false;
   }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -138,4 +138,19 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes bare object type definitions", () => {
+    assertResult(
+      `
+      class A {
+        x: number;
+      }
+    `,
+      `${PREFIX}
+      class A {
+        ;
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Rather than leaving a lone class field declaration, we completely remove the
declaration so that class field syntax isn't necessary.