### PR TITLE
Remove type parameters from function declarations

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -9,7 +9,8 @@ export type TokenContext =
   | "jsxExpression"
   | "templateExpr"
   | "switchCaseCondition"
-  | "type";
+  | "type"
+  | "typeParameter";
 
 export type TokenType = {
   label: string;

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -20,6 +20,13 @@ export default class FlowTransformer extends Transformer {
       this.tokens.removeInitialToken();
       return true;
     }
+    if (this.tokens.currentToken().contextName === "typeParameter") {
+      this.tokens.removeInitialToken();
+      while (this.tokens.currentToken().contextName === "typeParameter") {
+        this.tokens.removeToken();
+      }
+      return true;
+    }
     return false;
   }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -153,4 +153,35 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes function type parameters", () => {
+    assertResult(
+      `
+      function f<T>(t: T): void {
+        console.log(t);
+      }
+      const o = {
+        g<T>(t: T): void {
+        }
+      }
+      class C {
+        h<T>(t: T): void {
+        }
+      }
+    `,
+      `${PREFIX}
+      function f(t) {
+        console.log(t);
+      }
+      const o = {
+        g(t) {
+        }
+      }
+      class C {
+        h(t) {
+        }
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This doesn't yet handle arrow functions due to a parsing ambiguity with JSX that
seems to affect babylon in general, but we're able to detect type parameters in
the other function cases.