### PR TITLE
Properly handle keyword object keys in various cases

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -74,6 +74,20 @@ export default class TokenProcessor {
     return this.matchesNameAtIndex(this.tokenIndex, name);
   }
 
+  /**
+   * Check if this is a "real" instance of the keyword rather than an object key or property access.
+   */
+  matchesKeyword(name: string): boolean {
+    const token = this.currentToken();
+    if (this.matchesAtRelativeIndex(-1, ["."])) {
+      return false;
+    }
+    if (token.contextName === "object" && this.matchesAtRelativeIndex(1, [":"])) {
+      return false;
+    }
+    return token.type.label === name || (token.type.label === "name" && token.value === name);
+  }
+
   previousWhitespace(): string {
     return this.code.slice(
       this.tokenIndex > 0 ? this.tokens[this.tokenIndex - 1].end : 0,

--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -428,13 +428,19 @@ class TokenPreprocessor {
   }
 
   /**
-   * Keywords can be property values, so don't consider them if we're after a
-   * dot.
+   * Keywords can be property values, so don't consider them if we're after a dot or in an object
+   * key.
    */
   private startsWithKeyword(keywords: Array<string>): boolean {
-    return (
-      !this.tokens.matchesAtRelativeIndex(-1, ["."]) &&
-      keywords.some((keyword) => this.tokens.matches([keyword]))
-    );
+    if (this.tokens.matchesAtRelativeIndex(-1, ["."])) {
+      return false;
+    }
+    if (
+      this.getContextInfo().context === "object" &&
+      this.tokens.matchesAtRelativeIndex(1, [":"])
+    ) {
+      return false;
+    }
+    return keywords.some((keyword) => this.tokens.matches([keyword]));
   }
 }

--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -9,7 +9,7 @@ export default class FlowTransformer extends Transformer {
 
   process(): boolean {
     // We need to handle all classes specially in order to remove `implements`.
-    if (this.tokens.matches(["class"])) {
+    if (this.tokens.matchesKeyword("class")) {
       this.rootTransformer.processClass();
       return true;
     }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1,0 +1,94 @@
+import {ESMODULE_PREFIX, PREFIX} from "./prefixes";
+import {assertResult} from "./util";
+
+/**
+ * Test cases that aren't associated with any particular transform.
+ */
+describe("sucrase", () => {
+  it("handles keywords as object keys", () => {
+    assertResult(
+      `
+      export const keywords = {
+        break: new KeywordTokenType("break"),
+        case: new KeywordTokenType("case", { beforeExpr }),
+        catch: new KeywordTokenType("catch"),
+        continue: new KeywordTokenType("continue"),
+        debugger: new KeywordTokenType("debugger"),
+        default: new KeywordTokenType("default", { beforeExpr }),
+        do: new KeywordTokenType("do", { isLoop, beforeExpr }),
+        else: new KeywordTokenType("else", { beforeExpr }),
+        finally: new KeywordTokenType("finally"),
+        for: new KeywordTokenType("for", { isLoop }),
+        function: new KeywordTokenType("function", { startsExpr }),
+        if: new KeywordTokenType("if"),
+        return: new KeywordTokenType("return", { beforeExpr }),
+        switch: new KeywordTokenType("switch"),
+        throw: new KeywordTokenType("throw", { beforeExpr, prefix, startsExpr }),
+        try: new KeywordTokenType("try"),
+        var: new KeywordTokenType("var"),
+        let: new KeywordTokenType("let"),
+        const: new KeywordTokenType("const"),
+        while: new KeywordTokenType("while", { isLoop }),
+        with: new KeywordTokenType("with"),
+        new: new KeywordTokenType("new", { beforeExpr, startsExpr }),
+        this: new KeywordTokenType("this", { startsExpr }),
+        super: new KeywordTokenType("super", { startsExpr }),
+        class: new KeywordTokenType("class"),
+        extends: new KeywordTokenType("extends", { beforeExpr }),
+        export: new KeywordTokenType("export"),
+        import: new KeywordTokenType("import", { startsExpr }),
+        yield: new KeywordTokenType("yield", { beforeExpr, startsExpr }),
+        null: new KeywordTokenType("null", { startsExpr }),
+        true: new KeywordTokenType("true", { startsExpr }),
+        false: new KeywordTokenType("false", { startsExpr }),
+        in: new KeywordTokenType("in", { beforeExpr, binop: 7 }),
+        instanceof: new KeywordTokenType("instanceof", { beforeExpr, binop: 7 }),
+        typeof: new KeywordTokenType("typeof", { beforeExpr, prefix, startsExpr }),
+        void: new KeywordTokenType("void", { beforeExpr, prefix, startsExpr }),
+        delete: new KeywordTokenType("delete", { beforeExpr, prefix, startsExpr }),
+      };
+    `,
+      `${PREFIX}${ESMODULE_PREFIX}
+       const keywords = exports.keywords = {
+        break: new KeywordTokenType("break"),
+        case: new KeywordTokenType("case", { beforeExpr }),
+        catch: new KeywordTokenType("catch"),
+        continue: new KeywordTokenType("continue"),
+        debugger: new KeywordTokenType("debugger"),
+        default: new KeywordTokenType("default", { beforeExpr }),
+        do: new KeywordTokenType("do", { isLoop, beforeExpr }),
+        else: new KeywordTokenType("else", { beforeExpr }),
+        finally: new KeywordTokenType("finally"),
+        for: new KeywordTokenType("for", { isLoop }),
+        function: new KeywordTokenType("function", { startsExpr }),
+        if: new KeywordTokenType("if"),
+        return: new KeywordTokenType("return", { beforeExpr }),
+        switch: new KeywordTokenType("switch"),
+        throw: new KeywordTokenType("throw", { beforeExpr, prefix, startsExpr }),
+        try: new KeywordTokenType("try"),
+        var: new KeywordTokenType("var"),
+        let: new KeywordTokenType("let"),
+        const: new KeywordTokenType("const"),
+        while: new KeywordTokenType("while", { isLoop }),
+        with: new KeywordTokenType("with"),
+        new: new KeywordTokenType("new", { beforeExpr, startsExpr }),
+        this: new KeywordTokenType("this", { startsExpr }),
+        super: new KeywordTokenType("super", { startsExpr }),
+        class: new KeywordTokenType("class"),
+        extends: new KeywordTokenType("extends", { beforeExpr }),
+        export: new KeywordTokenType("export"),
+        import: new KeywordTokenType("import", { startsExpr }),
+        yield: new KeywordTokenType("yield", { beforeExpr, startsExpr }),
+        null: new KeywordTokenType("null", { startsExpr }),
+        true: new KeywordTokenType("true", { startsExpr }),
+        false: new KeywordTokenType("false", { startsExpr }),
+        in: new KeywordTokenType("in", { beforeExpr, binop: 7 }),
+        instanceof: new KeywordTokenType("instanceof", { beforeExpr, binop: 7 }),
+        typeof: new KeywordTokenType("typeof", { beforeExpr, prefix, startsExpr }),
+        void: new KeywordTokenType("void", { beforeExpr, prefix, startsExpr }),
+        delete: new KeywordTokenType("delete", { beforeExpr, prefix, startsExpr }),
+      };
+    `,
+    );
+  });
+});


### PR DESCRIPTION
There's now a general utility for distinguishing keywords from object keys and
property accesses. One possible improvement is to resolve all of this at
tokenization time, but this should work for now.