### PR TITLE
Remove variance markers from typed class fields

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -173,6 +173,15 @@ class TokenPreprocessor {
         } else if (context === "class" && this.tokens.matches([":"]) && ternaryDepth === 0) {
           // Process typed class field.
           const identifierTokenIndex = this.tokens.currentIndex() - 1;
+          const previousTokenIndex = identifierTokenIndex - 1;
+
+          if (this.tokens.matchesAtIndex(previousTokenIndex, ["+/-"])) {
+            const varianceMarkerToken = this.tokens.tokens[previousTokenIndex];
+            varianceMarkerToken.contextName = "type";
+            varianceMarkerToken.contextStartIndex = previousTokenIndex;
+            varianceMarkerToken.parentContextStartIndex = this.getContextInfo().startIndex;
+          }
+
           this.advance();
           this.processTypeExpression();
           if (!this.tokens.matches(["="])) {

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -322,4 +322,21 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("properly removes class property variance markers", () => {
+    assertResult(
+      `
+      class C {
+        +foo: number;
+        -bar: number;
+      }
+    `,
+      `${PREFIX}
+      class C {
+        ;
+        ;
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This probably won't work when trying to combine with actual class fields later,
but it should work for the flow strategy of just removing field type
annotations.