### PR TITLE
Properly determine type parsing strategy for type annotations

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -85,8 +85,9 @@ class TokenPreprocessor {
           ternaryDepth--;
           this.advance();
         } else {
+          const mayBeArrowReturnType = this.tokens.matchesAtRelativeIndex(-1, [")"]);
           this.advance();
-          this.processTypeExpression({disallowArrow: true});
+          this.processTypeExpression({disallowArrow: mayBeArrowReturnType});
         }
       } else if (
         this.tokens.matches(["export"]) &&

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -339,4 +339,36 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("recognizes arrow function types within parameters", () => {
+    assertResult(
+      `
+      function partition<T>(
+        list: T[],
+        test: (T, number, T[]) => ?boolean,
+      ): [T[], T[]] {
+        return [];
+      }
+    `,
+      `${PREFIX}
+      function partition(
+        list,
+        test,
+      ) {
+        return [];
+      }
+    `,
+    );
+  });
+
+  it("recognizes arrow function types in variable declarations", () => {
+    assertResult(
+      `
+      const x: a => b = 2;
+    `,
+      `${PREFIX}
+      const x = 2;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Previously, we were avoiding arrow functions on all types instead of just
function return types. As far as I know, we can distinguish the two by seeing if
there is a close-paren before the type annotation.