### PR TITLE
Change back to Babylon parser to handle JSX vs type parameter distinction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import TokenProcessor, {Token} from "./TokenProcessor";
 import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
 
-const DEFAULT_BABYLON_PLUGINS = ["jsx", "flow", "objectRestSpread"];
+const DEFAULT_BABYLON_PLUGINS = ["jsx", "flow", "objectRestSpread", "classProperties"];
 
 export type Transform = "jsx" | "imports" | "flow" | "add-module-exports" | "react-display-name";
 

--- a/sucrase-babylon/index.js
+++ b/sucrase-babylon/index.js
@@ -19,13 +19,8 @@ plugins.jsx = jsxPlugin;
 plugins.typescript = typescriptPlugin;
 
 export function getTokens(input: string, options?: Options): $ReadOnlyArray<Token | Comment> {
-  const parser = getParser(options, input);
-  parser.nextToken();
-  while (parser.state.type.label !== 'eof') {
-    parser.next();
-  }
-  parser.next();
-  return parser.state.tokens;
+  options = Object.assign({}, options, {tokens: true});
+  return getParser(options, input).parse().tokens;
 }
 
 export function parse(input: string, options?: Options): File {

--- a/sucrase-babylon/plugins/flow.js
+++ b/sucrase-babylon/plugins/flow.js
@@ -3,7 +3,7 @@
 // @flow
 
 import type Parser from "../parser";
-import { types as tt, type TokenType } from "../tokenizer/types";
+import { types as tt, TokenType } from "../tokenizer/types";
 import * as N from "../types";
 import type { Pos, Position } from "../util/location";
 import type State from "../tokenizer/state";
@@ -23,6 +23,8 @@ const primitiveTypes = [
   "typeof",
   "void",
 ];
+
+tt.typeParameterStart = new TokenType("typeParameterStart");
 
 function isEsModuleType(bodyElement: N.Node): boolean {
   return (
@@ -522,7 +524,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       this.state.inType = true;
 
       // istanbul ignore else: this condition is already checked at all call sites
-      if (this.isRelational("<") || this.match(tt.jsxTagStart)) {
+      if (this.isRelational("<") || this.match(tt.typeParameterStart)) {
         this.next();
       } else {
         this.unexpected();
@@ -2096,6 +2098,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
             // by parsing `jsxTagStart` to stop the JSX plugin from
             // messing with the tokens
             this.state.context.length -= 2;
+            this.state.type = tt.typeParameterStart;
 
             jsxError = err;
           } else {

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -371,4 +371,26 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("does not confuse type parameters with JSX", () => {
+    assertResult(
+      `
+      const f = <T>(t: T): number => 3;
+    `,
+      `${PREFIX}
+      const f = (t) => 3;
+    `,
+    );
+  });
+
+  it("does not confuse type parameters with JSX", () => {
+    assertResult(
+      `
+      const f: <T>(t: T) => number = () => 3;
+    `,
+      `${PREFIX}
+      const f = () => 3;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This slows things down, unfortunately, but it may still be reasonable to trim
down the babylon parser to make it faster and unify it with augmentTokens.