### PR TITLE
Add initial setup for typescript transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
+self-build
 dist

--- a/benchmark/profile.ts
+++ b/benchmark/profile.ts
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
-import * as fs from 'fs';
+import * as fs from "fs";
 
-import * as sucrase from '../src/index';
+import * as sucrase from "../src/index";
 
 function main(): void {
-  console.log('Profiling Sucrase on about 100,000 LOC. Make sure you have Chrome DevTools for Node open.');
-  const code = fs.readFileSync('./benchmark/sample.js').toString();
+  console.log(
+    "Profiling Sucrase on about 100,000 LOC. Make sure you have Chrome DevTools for Node open.",
+  );
+  const code = fs.readFileSync("./benchmark/sample.js").toString();
   // tslint:disable-next-line no-any
-  (console as any).profile('Sucrase');
+  (console as any).profile("Sucrase");
   for (let i = 0; i < 1000; i++) {
-    sucrase.transform(
-      code,
-      {transforms: ['jsx', 'imports', 'add-module-exports', 'react-display-name']}
-    );
+    sucrase.transform(code, {
+      transforms: ["jsx", "imports", "add-module-exports", "react-display-name"],
+    });
   }
   // tslint:disable-next-line no-any
-  (console as any).profileEnd('Sucrase');
+  (console as any).profileEnd("Sucrase");
 }
 
 if (require.main === module) {

--- a/script/self-build
+++ b/script/self-build
@@ -2,33 +2,20 @@
 
 set -e
 
-TSC="${TSC:-node_modules/.bin/tsc}"
+OUT_DIR="${OUT_DIR:-./build}"
 
 # The build dir has all build artifacts, including the benchmark. The dist dir
 # is the subset that's shipped as part of the package.
-rm -rf ./build
-mkdir -p ./build
-
-echo 'Building ES module version.'
-"${TSC}" \
-  --project . \
-  --outDir build \
-  --module ES2015 \
-  --moduleResolution node
-
-for js in $(find build -name '*.js'); do
-  mv "${js}" "$(dirname "${js}")/$(basename "${js}" .js).mjs"
-done
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
 
 echo 'Building CommonJS version.'
-"${TSC}" \
-  --project . \
-  --outDir build \
-  --module commonjs \
-  --moduleResolution node
+bin/sucrase ./src -d "${OUT_DIR}/src" --transforms imports,typescript
+bin/sucrase ./test -d "${OUT_DIR}/test" --transforms imports,typescript
+bin/sucrase ./benchmark -d build/benchmark --transforms imports,typescript
 
 echo 'Building Babylon fork.'
-bin/sucrase sucrase-babylon -d build/sucrase-babylon --transforms imports,flow
+bin/sucrase sucrase-babylon -d "${OUT_DIR}/sucrase-babylon" --transforms imports,flow
 
 rm -rf ./dist
 mkdir -p ./dist

--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -1,6 +1,6 @@
 import NameManager from "./NameManager";
 import TokenProcessor from "./TokenProcessor";
-import IdentifierReplacer from "./transformers/IdentifierReplacer";
+import {IdentifierReplacer} from "./transformers/IdentifierReplacer";
 import isMaybePropertyName from "./util/isMaybePropertyName";
 
 type NamedImport = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ async function buildDirectory(
   outDirPath: string,
   transforms: Array<Transform>,
 ): Promise<void> {
+  const extension = transforms.includes("typescript") ? ".ts" : ".js";
   if (!await exists(outDirPath)) {
     await mkdir(outDirPath);
   }
@@ -57,8 +58,9 @@ async function buildDirectory(
     const outChildPath = join(outDirPath, child);
     if ((await stat(srcChildPath)).isDirectory()) {
       await buildDirectory(srcChildPath, outChildPath, transforms);
-    } else if (srcChildPath.endsWith(".js")) {
-      await buildFile(srcChildPath, outChildPath, transforms);
+    } else if (srcChildPath.endsWith(extension)) {
+      const outPath = `${outChildPath.substr(0, outChildPath.length - 3)}.js`;
+      await buildFile(srcChildPath, outPath, transforms);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,18 @@ import TokenProcessor, {Token} from "./TokenProcessor";
 import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
 
-const DEFAULT_BABYLON_PLUGINS = ["jsx", "flow", "objectRestSpread", "classProperties"];
+const DEFAULT_BABYLON_PLUGINS = ["jsx", "objectRestSpread", "classProperties"];
 
-export type Transform = "jsx" | "imports" | "flow" | "add-module-exports" | "react-display-name";
+export type Transform =
+  | "jsx"
+  | "imports"
+  | "flow"
+  | "typescript"
+  | "add-module-exports"
+  | "react-display-name";
 
 export type Options = {
-  transforms?: Array<Transform>;
+  transforms: Array<Transform>;
   babylonPlugins?: Array<string>;
 };
 
@@ -18,24 +24,29 @@ export function getVersion(): string {
   return require("../../package.json").version;
 }
 
-export function transform(code: string, options: Options = {}): string {
-  const transforms = options.transforms || ["jsx"];
+export function transform(code: string, options: Options): string {
   const tokens = getSucraseTokens(code, options);
   const tokenProcessor = new TokenProcessor(code, tokens);
-  return new RootTransformer(tokenProcessor, transforms).transform();
+  return new RootTransformer(tokenProcessor, options.transforms).transform();
 }
 
 /**
  * Return a string representation of the sucrase tokens, mostly useful for
  * diagnostic purposes.
  */
-export function getFormattedTokens(code: string, options: Options = {}): string {
+export function getFormattedTokens(code: string, options: Options): string {
   const tokens = getSucraseTokens(code, options);
   return formatTokens(code, tokens);
 }
 
-function getSucraseTokens(code: string, options: Options = {}): Array<Token> {
+function getSucraseTokens(code: string, options: Options): Array<Token> {
   const babylonPlugins = options.babylonPlugins || DEFAULT_BABYLON_PLUGINS;
+  if (options.transforms.includes("flow")) {
+    babylonPlugins.push("flow");
+  }
+  if (options.transforms.includes("typescript")) {
+    babylonPlugins.push("typescript");
+  }
 
   let tokens = getTokens(
     code,

--- a/src/transformers/IdentifierReplacer.ts
+++ b/src/transformers/IdentifierReplacer.ts
@@ -1,3 +1,3 @@
-export default interface IdentifierReplacer {
+export interface IdentifierReplacer {
   getIdentifierReplacement(identifierName: string): string | null;
-};
+}

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -1,5 +1,5 @@
 import TokenProcessor from "../TokenProcessor";
-import IdentifierReplacer from "./IdentifierReplacer";
+import {IdentifierReplacer} from "./IdentifierReplacer";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,5 +1,5 @@
 import TokenProcessor from "../TokenProcessor";
-import IdentifierReplacer from "./IdentifierReplacer";
+import {IdentifierReplacer} from "./IdentifierReplacer";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 

--- a/sucrase-babylon/parser/statement.js
+++ b/sucrase-babylon/parser/statement.js
@@ -1328,26 +1328,7 @@ export default class StatementParser extends ExpressionParser {
       this.parseExportFrom(node, true);
     } else if (this.eat(tt._default)) {
       // export default ...
-      let expr = this.startNode();
-      let needsSemi = false;
-      if (this.eat(tt._function)) {
-        expr = this.parseFunction(expr, true, false, false, true);
-      } else if (
-        this.isContextual("async") &&
-        this.lookahead().type === tt._function
-      ) {
-        // async function declaration
-        this.eatContextual("async");
-        this.eat(tt._function);
-        expr = this.parseFunction(expr, true, false, true, true);
-      } else if (this.match(tt._class)) {
-        expr = this.parseClass(expr, true, true);
-      } else {
-        needsSemi = true;
-        expr = this.parseMaybeAssign();
-      }
-      node.declaration = expr;
-      if (needsSemi) this.semicolon();
+      node.declaration = this.parseExportDefaultExpression();
       this.checkExport(node, true, true);
       return this.finishNode(node, "ExportDefaultDeclaration");
     } else if (this.shouldParseExportDeclaration()) {
@@ -1371,6 +1352,27 @@ export default class StatementParser extends ExpressionParser {
     }
     this.checkExport(node, true);
     return this.finishNode(node, "ExportNamedDeclaration");
+  }
+
+  parseExportDefaultExpression(): N.Expression | N.Declaration {
+    const expr = this.startNode();
+    if (this.eat(tt._function)) {
+      return this.parseFunction(expr, true, false, false, true);
+    } else if (
+      this.isContextual("async") &&
+      this.lookahead().type === tt._function
+    ) {
+      // async function declaration
+      this.eatContextual("async");
+      this.eat(tt._function);
+      return this.parseFunction(expr, true, false, true, true);
+    } else if (this.match(tt._class)) {
+      return this.parseClass(expr, true, true);
+    } else {
+      const res = this.parseMaybeAssign();
+      this.semicolon();
+      return res;
+    }
   }
 
   // eslint-disable-next-line no-unused-vars

--- a/sucrase-babylon/plugins/typescript.js
+++ b/sucrase-babylon/plugins/typescript.js
@@ -1426,6 +1426,20 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       }
     }
 
+    parseExportDefaultExpression(): N.Expression | N.Declaration {
+      if (
+        this.isContextual("abstract") &&
+        this.lookahead().type === tt._class
+      ) {
+        const cls = this.startNode();
+        this.next(); // Skip "abstract"
+        this.parseClass(cls, true, true);
+        cls.abstract = true;
+        return cls;
+      }
+      return super.parseExportDefaultExpression();
+    }
+
     parseStatementContent(
       declaration: boolean,
       topLevel: ?boolean,

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -5,10 +5,13 @@ import {getFormattedTokens} from "../src";
 describe("getFormattedTokens", () => {
   it("formats a simple program", () => {
     assert.equal(
-      getFormattedTokens(`\
+      getFormattedTokens(
+        `\
 if (foo) {
   console.log('Hello world!');
-}`),
+}`,
+        {transforms: ["jsx", "imports"]},
+      ),
       `\
 Location  Label  Context   Value        beforeExpr startsExpr rightAssociative isLoop isAssign prefix postfix binop
 1:1-1:3   if     block(0)  if                                                                                      

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "https://sucrase.io",
   "dependencies": {
+    "@babel/standalone": "^7.0.0-beta.36",
     "autoprefixer": "7.1.2",
     "babel-core": "6.25.0",
     "babel-eslint": "7.2.3",
@@ -12,7 +13,6 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-react-app": "^3.0.3",
     "babel-runtime": "6.26.0",
-    "babel-standalone": "^6.26.0",
     "base64-js": "^1.2.1",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",

--- a/website/src/Constants.js
+++ b/website/src/Constants.js
@@ -19,8 +19,9 @@ export default App;
 
 export const TRANSFORMS = [
   {name: 'jsx', babelName: 'transform-react-jsx'},
-  {name: 'imports', babelName: 'transform-es2015-modules-commonjs'},
-  {name: 'flow', babelName: 'transform-flow-strip-types'},
+  {name: 'imports', babelName: 'transform-modules-commonjs'},
+  {name: 'typescript', presetName: 'typescript', isExperimental: true},
+  {name: 'flow', presetName: 'flow'},
   {name: 'react-display-name', babelName: 'transform-react-display-name'},
   {name: 'add-module-exports', babelName: 'add-module-exports'},
 ];

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import * as Babel from 'babel-standalone';
+import * as Babel from '@babel/standalone';
 import * as Sucrase from 'sucrase';
 
 import {TRANSFORMS} from './Constants';
@@ -50,7 +50,12 @@ function runSucrase() {
 function runBabel() {
   let babelPlugins = TRANSFORMS
     .filter(({name}) => config.selectedTransforms[name])
-    .map(({babelName}) => babelName);
+    .map(({babelName}) => babelName)
+    .filter(name => name);
+  const babelPresets = TRANSFORMS
+    .filter(({name}) => config.selectedTransforms[name])
+    .map(({presetName}) => presetName)
+    .filter(name => name);
   if (babelPlugins.includes('add-module-exports')) {
     babelPlugins = [
       'add-module-exports',
@@ -59,8 +64,9 @@ function runBabel() {
   }
   return runAndProfile(() =>
     Babel.transform(config.code, {
+      presets: babelPresets,
       plugins: babelPlugins,
-      parserOpts: {plugins: ['jsx', 'flow', 'classProperties']}
+      parserOpts: {plugins: ['jsx', 'classProperties']}
     }).code
   );
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@babel/standalone@^7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.0.0-beta.36.tgz#342a44f6daf1f413ab06998056357c1f7e98a1ed"
+
 "@types/mz@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/mz/-/mz-0.0.32.tgz#e8248b4e41424c052edc1725dd33650c313a3659"
@@ -978,10 +982,6 @@ babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtim
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
-
-babel-standalone@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
* Add a "self build" mode to have sucrase compile itself. The next main
  milestone is to get that completely working.
* Upgrade babel-standalone to support typescript.
* Apply a change since the fork to support `export default abstract class` in
  babylon.
* Avoid `export default interface` since babylon doesn't support it right now.