### PR TITLE
Handle "as" expressions in TypeScript code

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "script/build",
     "self-build": "script/self-build",
+    "self-test": "OUT_DIR=self-build yarn self-build && mocha self-build/test --opts test/mocha-self-test.opts",
     "benchmark": "node ./build/benchmark/benchmark.js",
     "lint": "eslint './src/**/*.ts' && tslint -p .",
     "profile": "node --inspect-brk ./build/benchmark/profile.js",

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -10,7 +10,9 @@ export type TokenContext =
   | "templateExpr"
   | "switchCaseCondition"
   | "type"
-  | "typeParameter";
+  | "typeParameter"
+  | "import"
+  | "namedExport";
 
 export type TokenType = {
   label: string;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1,0 +1,37 @@
+import {PREFIX} from "./prefixes";
+import {assertResult} from "./util";
+
+function assertTypeScriptResult(code: string, expectedResult: string): void {
+  assertResult(code, expectedResult, ["jsx", "imports", "typescript"]);
+}
+
+/**
+ * Tests for syntax common between flow and typescript.
+ */
+describe("type transforms", () => {
+  it("removes type assertions using `as`", () => {
+    assertTypeScriptResult(
+      `
+      const x = 0;
+      console.log(x as string);
+    `,
+      `${PREFIX}
+      const x = 0;
+      console.log(x );
+    `,
+    );
+  });
+
+  it.skip("properly handles variables named 'as'", () => {
+    assertTypeScriptResult(
+      `
+      const as = "Hello";
+      console.log(as);
+    `,
+      `${PREFIX}
+      const as = "Hello";
+      console.log(as);
+    `,
+    );
+  });
+});


### PR DESCRIPTION
This doesn't yet distinguish between the `as` keyword and identifiers named
`as`, but hopefully that is rare and can be handled later.