### PR TITLE
Remove readonly and abstract tokens as we see them

### DIFF
--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -34,7 +34,9 @@ export default class TypeScriptTransformer extends Transformer {
     if (
       this.tokens.matchesName("public") ||
       this.tokens.matchesName("protected") ||
-      this.tokens.matchesName("private")
+      this.tokens.matchesName("private") ||
+      this.tokens.matchesName("abstract") ||
+      this.tokens.matchesName("readonly")
     ) {
       this.tokens.removeInitialToken();
       return true;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -139,4 +139,21 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("handles readonly constructor initializers", () => {
+    assertTypeScriptResult(
+      `
+      class A {
+        constructor(readonly x: number) {
+        }
+      }
+    `,
+      `${PREFIX}
+      class A {
+        constructor( x) {;this.x = x;
+        }
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We may need to be more careful in the future to avoid confusion with
property names, but this should pretty much always work.