### PR TITLE
Remove non-null assertion operators

### DIFF
--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -41,6 +41,54 @@ export default class TypeScriptTransformer extends Transformer {
       this.tokens.removeInitialToken();
       return true;
     }
+    if (this.isNonNullAssertion()) {
+      this.tokens.removeInitialToken();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * This is either a negation operator or a non-null assertion operator. If it's a non-null
+   * assertion, get rid of it.
+   */
+  isNonNullAssertion(): boolean {
+    if (!this.tokens.matches(["!"])) {
+      return false;
+    }
+    let index = this.tokens.currentIndex() - 1;
+    // Walk left past all operators that might be either prefix or postfix operators.
+    while (
+      this.tokens.matchesAtIndex(index, ["!"]) ||
+      this.tokens.matchesAtIndex(index, ["++"]) ||
+      this.tokens.matchesAtIndex(index, ["--"])
+    ) {
+      index--;
+    }
+    if (index < 0) {
+      return false;
+    }
+    const prevToken = this.tokens.tokens[index];
+    // Bias toward keeping the token; if we remove it incorrectly, the code will have a subtle bug,
+    // while if we don't remove it and we need to, the code will have a syntax error.
+    if (
+      [
+        "name",
+        "num",
+        "string",
+        "false",
+        "true",
+        "null",
+        "void",
+        "this",
+        ")",
+        "]",
+        "}",
+        "`",
+      ].includes(prevToken.type.label)
+    ) {
+      return true;
+    }
     return false;
   }
 }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -156,4 +156,23 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("removes non-null assertion operator but not negation operator", () => {
+    assertTypeScriptResult(
+      `
+      const x = 1!;
+      const y = x!;
+      const z = !x; 
+      const a = (x)!(y);
+      const b = x + !y;
+    `,
+      `${PREFIX}
+      const x = 1;
+      const y = x;
+      const z = !x; 
+      const a = (x)(y);
+      const b = x + !y;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
It looks like it should be possible to always distinguish postfix `!` from
prefix `!` by looking at the prior token. For now, there's just a whitelist of
token types in which we remove the `!`.