### PR TITLE
Handle interfaces using `extends`

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -348,8 +348,9 @@ class TokenPreprocessor {
     }
     this.advance("name", "interface");
     this.advance("name");
-    if (this.tokens.matches(["</>"]) && this.tokens.currentToken().value === "<") {
-      this.skipBalancedAngleBrackets();
+    // Skip past any type parameter name or extends declaration.
+    while (!this.tokens.matches(["{"])) {
+      this.advance();
     }
     this.skipBalancedCode("{", "}");
     this.contextStack.pop();

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -239,4 +239,17 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("handles interfaces using `extends`", () => {
+    assertTypeScriptResult(
+      `
+      export interface A extends B {
+      }
+    `,
+      `${PREFIX}
+      
+
+    `,
+    );
+  });
 });


### PR DESCRIPTION
It looks like neither the type parameter nor the extended type are allowed to
have complex code like curly braces, so we can just skip to the curly brace.