### PR TITLE
Implement basic import pruning in TypeScript

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -48,7 +48,12 @@ export default class RootTransformer {
       this.transformers.push(new FlowTransformer(this, tokens));
     }
     if (transforms.includes("typescript")) {
-      this.transformers.push(new TypeScriptTransformer(this, tokens));
+      if (!transforms.includes("imports")) {
+        throw new Error(
+          "The TypeScript transform without the import transform is not yet supported.",
+        );
+      }
+      this.transformers.push(new TypeScriptTransformer(this, tokens, importProcessor!));
     }
   }
 

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -1,10 +1,19 @@
+import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
 export default class TypeScriptTransformer extends Transformer {
-  constructor(readonly rootTransformer: RootTransformer, readonly tokens: TokenProcessor) {
+  constructor(
+    readonly rootTransformer: RootTransformer,
+    readonly tokens: TokenProcessor,
+    readonly importProcessor: ImportProcessor,
+  ) {
     super();
+  }
+
+  preprocess(): void {
+    this.importProcessor.pruneTypeOnlyImports();
   }
 
   process(): boolean {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -252,4 +252,39 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("removes non-bare import statements consisting of only types", () => {
+    assertTypeScriptResult(
+      `
+      import A from 'a';
+      import B from 'b';
+      import 'c';
+      import D from 'd';
+      import 'd';
+      import E from 'e';
+      
+      function f(a: A): boolean {
+        return a instanceof A;
+      }
+      function g(b: B): boolean {
+        return true;
+      }
+    `,
+      `${PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      
+      require('c');
+      var _d = require('d'); var _d2 = _interopRequireDefault(_d);
+      
+      
+      
+      function f(a) {
+        return a instanceof (0, _a2.default);
+      }
+      function g(b) {
+        return true;
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We need to exclude any imports that only import things used in a type context,
but still include any imports that have any bare import. This policy only
exists in TypeScript, so we only run the prune function then.