### PR TITLE
Allow class fields with names like "function"

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -4,6 +4,7 @@ export type TokenContext =
   | "brackets"
   | "object"
   | "class"
+  | "classFieldExpression"
   | "jsxTag"
   | "jsxChild"
   | "jsxExpression"

--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -118,6 +118,9 @@ class TokenPreprocessor {
         this.tokens.matchesAtRelativeIndex(1, ["name"])
       ) {
         this.processInterfaceDeclaration();
+      } else if (this.tokens.matches(["="]) && context === "class") {
+        this.advance();
+        this.processRegion([], [], "classFieldExpression", {followingLabels: [";"]});
       } else if (this.startsWithKeyword(["if", "for", "while", "catch"])) {
         // Code of the form TOKEN (...) BLOCK
         if (this.tokens.matches(["("])) {
@@ -130,7 +133,7 @@ class TokenPreprocessor {
         } else {
           this.advance();
         }
-      } else if (this.startsWithKeyword(["function"])) {
+      } else if (this.startsWithKeyword(["function"]) && context !== "class") {
         this.advance();
         if (this.tokens.matches(["name"])) {
           this.advance();

--- a/src/util/getClassInitializerInfo.ts
+++ b/src/util/getClassInitializerInfo.ts
@@ -34,10 +34,9 @@ export default function getClassInitializerInfo(tokens: TokenProcessor): ClassIn
       while (isAccessModifier(tokens)) {
         tokens.nextToken();
       }
+      // The name might be a keyword like "function", so for now don't make any assertions about it
+      // being a name token; the value will still be correct.
       const nameToken = tokens.currentToken();
-      if (nameToken.type.label !== "name") {
-        throw new Error("Expected name for class method/field.");
-      }
       tokens.nextToken();
       if (tokens.matches(["</>"]) || tokens.matches(["("])) {
         // This is a method, so just skip to the close-brace at the end.

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -91,4 +91,19 @@ describe("sucrase", () => {
     `,
     );
   });
+
+  it("allows keywords as object keys", () => {
+    assertResult(
+      `
+      const o = {
+        function: 3,
+      };
+    `,
+      `${PREFIX}
+      const o = {
+        function: 3,
+      };
+    `,
+    );
+  });
 });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -287,4 +287,21 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows class fields with keyword names", () => {
+    assertTypeScriptResult(
+      `
+      class A {
+        readonly function: number;
+        f: any = function() {};
+      }
+    `,
+      `${PREFIX}
+      class A {constructor() { this.f = function() {}; }
+        
+        
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We now isolate class field values as their own context, so if you're in a class
context you know that you won't be in a normal expression, and can treat
keywords like "function" as normal names. I also got rid of an assert that the
token is a name token, since in this case it isn't always one.