### PR TITLE
Change website to hide most options by default

### DIFF
--- a/website/src/App.test.js
+++ b/website/src/App.test.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
+it("renders without crashing", () => {
+  const div = document.createElement("div");
   ReactDOM.render(<App />, div);
 });

--- a/website/src/Constants.js
+++ b/website/src/Constants.js
@@ -29,14 +29,14 @@ export default App;
 `;
 
 export const TRANSFORMS = [
-  {name: 'jsx', babelName: 'transform-react-jsx'},
-  {name: 'typescript', presetName: 'typescript'},
-  {name: 'flow', presetName: 'flow'},
-  {name: 'imports', babelName: 'transform-modules-commonjs'},
-  {name: 'react-display-name', babelName: 'transform-react-display-name'},
-  {name: 'add-module-exports', babelName: 'add-module-exports'},
+  {name: "jsx", babelName: "transform-react-jsx"},
+  {name: "typescript", presetName: "typescript"},
+  {name: "flow", presetName: "flow"},
+  {name: "imports", babelName: "transform-modules-commonjs"},
+  {name: "react-display-name", babelName: "transform-react-display-name", hideByDefault: true},
+  {name: "add-module-exports", babelName: "add-module-exports", hideByDefault: true},
 ];
 
-export const DEFAULT_TRANSFORMS = ['jsx', 'typescript', 'imports'];
+export const DEFAULT_TRANSFORMS = ["jsx", "typescript", "imports"];
 export const DEFAULT_COMPARE_WITH_BABEL = true;
 export const DEFAULT_SHOW_TOKENS = false;

--- a/website/src/Editor.js
+++ b/website/src/Editor.js
@@ -1,13 +1,13 @@
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import MonacoEditor from 'react-monaco-editor';
-import {AutoSizer} from 'react-virtualized';
+import PropTypes from "prop-types";
+import React, {Component} from "react";
+import MonacoEditor from "react-monaco-editor";
+import {AutoSizer} from "react-virtualized";
 
 export default class Editor extends Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
     code: PropTypes.string.isRequired,
-    timeMs: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['LOADING'])]),
+    timeMs: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["LOADING"])]),
     onChange: PropTypes.func,
     isReadOnly: PropTypes.bool,
     isPlaintext: PropTypes.bool,
@@ -36,9 +36,9 @@ export default class Editor extends Component {
   _formatTime() {
     const {timeMs} = this.props;
     if (timeMs == null) {
-      return '';
-    } else if (timeMs === 'LOADING') {
-      return ' (...)'
+      return "";
+    } else if (timeMs === "LOADING") {
+      return " (...)";
     } else {
       return ` (${Math.round(timeMs * 100) / 100}ms)`;
     }
@@ -47,18 +47,14 @@ export default class Editor extends Component {
   render() {
     const {label, code, onChange, isReadOnly, isPlaintext, options} = this.props;
     return (
-      <div className='Editor'>
-        <span className='Editor-label'>
+      <div className="Editor">
+        <span className="Editor-label">
           {label}
           {this._formatTime()}
         </span>
-        <span className='Editor-container'>
-          <AutoSizer
-            onResize={this.invalidate}
-            defaultWidth={300}
-            defaultHeight={300}
-          >
-            {({width, height}) =>
+        <span className="Editor-container">
+          <AutoSizer onResize={this.invalidate} defaultWidth={300} defaultHeight={300}>
+            {({width, height}) => (
               <MonacoEditor
                 editorDidMount={this._editorDidMount}
                 width={width}
@@ -74,7 +70,7 @@ export default class Editor extends Component {
                   ...options,
                 }}
               />
-            }
+            )}
           </AutoSizer>
         </span>
       </div>

--- a/website/src/OptionBox.js
+++ b/website/src/OptionBox.js
@@ -1,33 +1,35 @@
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 export default class OptionBox extends Component {
   static propTypes = {
-    options: PropTypes.arrayOf(PropTypes.shape({
-      text: PropTypes.string.isRequired,
-      checked: PropTypes.bool.isRequired,
-      onToggle: PropTypes.func.isRequired,
-    })).isRequired,
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        text: PropTypes.string.isRequired,
+        checked: PropTypes.bool.isRequired,
+        onToggle: PropTypes.func.isRequired,
+      }),
+    ).isRequired,
     title: PropTypes.string.isRequired,
   };
 
   render() {
     const {options, title} = this.props;
     return (
-      <div className='OptionBox'>
-        <span className='OptionBox-title'>{title}</span>
-        {options.map(({text, checked, onToggle}) =>
-          <label key={text} className='OptionBox-label'>
+      <div className="OptionBox">
+        <span className="OptionBox-title">{title}</span>
+        {options.map(({text, checked, onToggle}) => (
+          <label key={text} className="OptionBox-label">
             <input
-              className='OptionBox-checkbox'
-              type='checkbox'
+              className="OptionBox-checkbox"
+              type="checkbox"
               checked={checked}
               onChange={onToggle}
             />
             {text}
           </label>
-        )}
+        ))}
       </div>
-    )
+    );
   }
 }

--- a/website/src/URLHashState.js
+++ b/website/src/URLHashState.js
@@ -1,5 +1,5 @@
-import GZip from 'gzip-js';
-import * as Base64 from 'base64-js';
+import GZip from "gzip-js";
+import * as Base64 from "base64-js";
 
 import {
   DEFAULT_COMPARE_WITH_BABEL,
@@ -7,18 +7,22 @@ import {
   DEFAULT_TRANSFORMS,
   INITIAL_CODE,
   TRANSFORMS,
-} from './Constants';
+} from "./Constants";
 
-export function saveHashState({code, compressedCode, selectedTransforms, compareWithBabel, showTokens}) {
+export function saveHashState({
+  code,
+  compressedCode,
+  selectedTransforms,
+  compareWithBabel,
+  showTokens,
+}) {
   const components = [];
 
-  const transformsValue = TRANSFORMS
-    .filter(({name}) => selectedTransforms[name])
+  const transformsValue = TRANSFORMS.filter(({name}) => selectedTransforms[name])
     .map(({name}) => name)
-    .join(',');
+    .join(",");
 
-
-  if (transformsValue !== DEFAULT_TRANSFORMS.join(',')) {
+  if (transformsValue !== DEFAULT_TRANSFORMS.join(",")) {
     components.push(`selectedTransforms=${transformsValue}`);
   }
   if (compareWithBabel !== DEFAULT_COMPARE_WITH_BABEL) {
@@ -37,33 +41,37 @@ export function saveHashState({code, compressedCode, selectedTransforms, compare
   }
 
   if (components.length > 0) {
-    window.location.hash = components.join('&');
+    window.location.hash = components.join("&");
   } else {
-    window.history.replaceState("", document.title, window.location.pathname + window.location.search);
+    window.history.replaceState(
+      "",
+      document.title,
+      window.location.pathname + window.location.search,
+    );
   }
 }
 
 export function loadHashState() {
   try {
     let hashContents = window.location.hash;
-    if (!hashContents.startsWith('#')) {
+    if (!hashContents.startsWith("#")) {
       return null;
     }
-    const components = hashContents.substr(1).split('&');
+    const components = hashContents.substr(1).split("&");
     const result = {};
     for (const component of components) {
-      let [key, value] = component.split('=');
-      if (key === 'selectedTransforms') {
+      let [key, value] = component.split("=");
+      if (key === "selectedTransforms") {
         result.selectedTransforms = {};
-        for (const transformName of value.split(',')) {
+        for (const transformName of value.split(",")) {
           result.selectedTransforms[transformName] = true;
         }
-      } else if (key === 'code') {
+      } else if (key === "code") {
         result.code = window.decodeURIComponent(value);
-      } else if (key === 'compressedCode') {
+      } else if (key === "compressedCode") {
         result.code = decompressCode(window.decodeURIComponent(value));
-      } else if (['compareWithBabel', 'showTokens'].includes(key)) {
-        result[key] = value === 'true';
+      } else if (["compareWithBabel", "showTokens"].includes(key)) {
+        result[key] = value === "true";
       }
     }
     // Deleting code and refreshing should give the default state again.

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -1,12 +1,11 @@
 /* eslint-disable no-restricted-globals */
-import * as Babel from '@babel/standalone';
-import * as Sucrase from 'sucrase';
+import * as Babel from "@babel/standalone";
+import * as Sucrase from "sucrase";
 
-import {TRANSFORMS} from './Constants';
-import {compressCode} from './URLHashState';
-import getTokens from './getTokens';
-Babel.registerPlugin('add-module-exports', require('babel-plugin-add-module-exports'));
-
+import {TRANSFORMS} from "./Constants";
+import {compressCode} from "./URLHashState";
+import getTokens from "./getTokens";
+Babel.registerPlugin("add-module-exports", require("babel-plugin-add-module-exports"));
 
 let config = null;
 
@@ -14,62 +13,57 @@ let config = null;
  * The worker architecture intentionally bypasses the browser event loop in
  * favor of.
  */
-self.addEventListener('message', ({data}) => {
+self.addEventListener("message", ({data}) => {
   self.postMessage(processEvent(data));
 });
 
 function processEvent(data) {
-  if (data.type === 'SET_CONFIG') {
+  if (data.type === "SET_CONFIG") {
     config = data.config;
     return null;
-  } else if (data.type === 'RUN_SUCRASE') {
+  } else if (data.type === "RUN_SUCRASE") {
     return runSucrase().code;
-  } else if (data.type === 'RUN_BABEL') {
+  } else if (data.type === "RUN_BABEL") {
     return runBabel().code;
-  } else if (data.type === 'COMPRESS_CODE') {
+  } else if (data.type === "COMPRESS_CODE") {
     return compressCode(config.code);
-  } else if (data.type === 'GET_TOKENS') {
+  } else if (data.type === "GET_TOKENS") {
     return getTokens(config.code, getSelectedTransforms());
-  } else if (data.type === 'PROFILE_SUCRASE') {
+  } else if (data.type === "PROFILE_SUCRASE") {
     return runSucrase().time;
-  } else if (data.type === 'PROFILE_BABEL') {
+  } else if (data.type === "PROFILE_BABEL") {
     return runBabel().time;
   }
 }
 
 function getSelectedTransforms() {
-  return TRANSFORMS
-    .map(({name}) => name)
-    .filter(name => config.selectedTransforms[name]);
+  return TRANSFORMS.map(({name}) => name).filter((name) => config.selectedTransforms[name]);
 }
 
 function runSucrase() {
-  return runAndProfile(() =>
-    Sucrase.transform(config.code, {transforms: getSelectedTransforms()})
-  );
+  return runAndProfile(() => Sucrase.transform(config.code, {transforms: getSelectedTransforms()}));
 }
 
 function runBabel() {
-  let babelPlugins = TRANSFORMS
-    .filter(({name}) => config.selectedTransforms[name])
+  let babelPlugins = TRANSFORMS.filter(({name}) => config.selectedTransforms[name])
     .map(({babelName}) => babelName)
-    .filter(name => name);
-  const babelPresets = TRANSFORMS
-    .filter(({name}) => config.selectedTransforms[name])
+    .filter((name) => name);
+  const babelPresets = TRANSFORMS.filter(({name}) => config.selectedTransforms[name])
     .map(({presetName}) => presetName)
-    .filter(name => name);
-  if (babelPlugins.includes('add-module-exports')) {
+    .filter((name) => name);
+  if (babelPlugins.includes("add-module-exports")) {
     babelPlugins = [
-      'add-module-exports',
-      ...babelPlugins.filter(p => p !== 'add-module-exports')
+      "add-module-exports",
+      ...babelPlugins.filter((p) => p !== "add-module-exports"),
     ];
   }
-  return runAndProfile(() =>
-    Babel.transform(config.code, {
-      presets: babelPresets,
-      plugins: babelPlugins,
-      parserOpts: {plugins: ['jsx', 'classProperties']}
-    }).code
+  return runAndProfile(
+    () =>
+      Babel.transform(config.code, {
+        presets: babelPresets,
+        plugins: babelPlugins,
+        parserOpts: {plugins: ["jsx", "classProperties"]},
+      }).code,
   );
 }
 

--- a/website/src/WorkerClient.js
+++ b/website/src/WorkerClient.js
@@ -1,8 +1,8 @@
-import Worker from './Worker.worker.js';
+import Worker from "./Worker.worker.js";
 
 const worker = new Worker();
 
-const CANCELLED_MESSAGE = 'SUCRASE JOB CANCELLED';
+const CANCELLED_MESSAGE = "SUCRASE JOB CANCELLED";
 
 // Used to coordinate communication with the worker. This is non-null any time
 // there is an active call, and it is nulled out on completion. Only one request
@@ -21,7 +21,7 @@ let updateStateFn = null;
 // slow enough that it's useful to do in a web worker.
 let handleCompressedCodeFn = null;
 
-worker.addEventListener('message', ({data}) => {
+worker.addEventListener("message", ({data}) => {
   nextResolve(data);
   nextResolve = null;
 });
@@ -32,39 +32,39 @@ function sendMessage(message) {
   }
   worker.postMessage(message);
   if (nextResolve) {
-    throw new Error('Cannot send message when a message is already in progress!');
+    throw new Error("Cannot send message when a message is already in progress!");
   }
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     nextResolve = resolve;
-  })
+  });
 }
 
 async function setConfig(config) {
-  await sendMessage({type: 'SET_CONFIG', config});
+  await sendMessage({type: "SET_CONFIG", config});
 }
 
 async function runSucrase() {
-  return await sendMessage({type: 'RUN_SUCRASE'});
+  return await sendMessage({type: "RUN_SUCRASE"});
 }
 
 async function runBabel() {
-  return await sendMessage({type: 'RUN_BABEL'});
+  return await sendMessage({type: "RUN_BABEL"});
 }
 
 async function compressCode() {
-  return await sendMessage({type: 'COMPRESS_CODE'});
+  return await sendMessage({type: "COMPRESS_CODE"});
 }
 
 async function getTokens() {
-  return await sendMessage({type: 'GET_TOKENS'});
+  return await sendMessage({type: "GET_TOKENS"});
 }
 
 async function profileSucrase() {
-  return await sendMessage({type: 'PROFILE_SUCRASE'});
+  return await sendMessage({type: "PROFILE_SUCRASE"});
 }
 
 async function profileBabel() {
-  return await sendMessage({type: 'PROFILE_BABEL'});
+  return await sendMessage({type: "PROFILE_BABEL"});
 }
 
 /**
@@ -76,14 +76,14 @@ async function waitForConfig() {
     nextConfig = null;
     return config;
   } else {
-    const waitPromise = new Promise(resolve => {
+    const waitPromise = new Promise((resolve) => {
       notifyConfig = resolve;
     });
     await waitPromise;
     notifyConfig = null;
     const config = nextConfig;
     if (config == null) {
-      throw new Error('Unexpected missing config after notify.');
+      throw new Error("Unexpected missing config after notify.");
     }
     nextConfig = null;
     return config;
@@ -117,8 +117,8 @@ async function workerLoop() {
     try {
       await setConfig(config);
       const sucraseCode = await runSucrase();
-      const babelCode = config.compareWithBabel ? await runBabel() : '';
-      const tokensStr = config.showTokens ? await getTokens() : '';
+      const babelCode = config.compareWithBabel ? await runBabel() : "";
+      const tokensStr = config.showTokens ? await getTokens() : "";
       updateStateFn({sucraseCode, babelCode, tokensStr});
 
       const compressedCode = await compressCode();

--- a/website/src/getTokens.js
+++ b/website/src/getTokens.js
@@ -1,8 +1,8 @@
-import {getFormattedTokens} from 'sucrase';
+import {getFormattedTokens} from "sucrase";
 
 export default function getTokens(code, transforms) {
   try {
-    return getFormattedTokens(code, {transforms})
+    return getFormattedTokens(code, {transforms});
   } catch (e) {
     console.error(e);
     return e.message;

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import registerServiceWorker from './registerServiceWorker';
-import './WorkerClient';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import registerServiceWorker from "./registerServiceWorker";
+import "./WorkerClient";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));
 registerServiceWorker();

--- a/website/src/registerServiceWorker.js
+++ b/website/src/registerServiceWorker.js
@@ -9,17 +9,15 @@
 // This link also includes instructions on opting out of this behavior.
 
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
+  window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
+    window.location.hostname === "[::1]" ||
     // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/),
 );
 
 export default function register() {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
     if (publicUrl.origin !== window.location.origin) {
@@ -29,7 +27,7 @@ export default function register() {
       return;
     }
 
-    window.addEventListener('load', () => {
+    window.addEventListener("load", () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
       if (!isLocalhost) {
@@ -46,43 +44,43 @@ export default function register() {
 function registerValidSW(swUrl) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
+          if (installingWorker.state === "installed") {
             if (navigator.serviceWorker.controller) {
               // At this point, the old content will have been purged and
               // the fresh content will have been added to the cache.
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
-              console.log('New content is available; please refresh.');
+              console.log("New content is available; please refresh.");
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.log("Content is cached for offline use.");
             }
           }
         };
       };
     })
-    .catch(error => {
-      console.error('Error during service worker registration:', error);
+    .catch((error) => {
+      console.error("Error during service worker registration:", error);
     });
 }
 
 function checkValidServiceWorker(swUrl) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       if (
         response.status === 404 ||
-        response.headers.get('content-type').indexOf('javascript') === -1
+        response.headers.get("content-type").indexOf("javascript") === -1
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -93,15 +91,13 @@ function checkValidServiceWorker(swUrl) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
+      console.log("No internet connection found. App is running in offline mode.");
     });
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.ready.then((registration) => {
       registration.unregister();
     });
   }


### PR DESCRIPTION
This should hopefully make it slightly less intimidating and make it clear that
the other options are for relatively obscure legacy use cases and for
development.

Also run Prettier on all website code.