### PR TITLE
Remove type arguments from function calls and new invocations

### DIFF
--- a/sucrase-babylon/plugins/typescript.js
+++ b/sucrase-babylon/plugins/typescript.js
@@ -803,6 +803,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.tsTryParseAndCatch(() => {
         const res: N.TsTypeParameterInstantiation = this.startNode();
         this.expectRelational("<");
+        this.state.tokens[this.state.tokens.length - 1].type = tt.typeParameterStart;
         const typeArguments = this.tsParseDelimitedList(
           "TypeParametersOrArguments",
           this.tsParseType.bind(this),
@@ -1327,6 +1328,7 @@ export default (superClass: Class<Parser>): Class<Parser> =>
         // tsTryParseAndCatch is expensive, so avoid if not necessary.
         // 99% certain this is `new C<T>();`. But may be `new C < T;`, which is also legal.
         const typeParameters = this.tsTryParseAndCatch(() => {
+          this.state.type = tt.typeParameterStart;
           const args = this.tsParseTypeArguments();
           if (!this.match(tt.parenL)) this.unexpected();
           return args;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -326,4 +326,19 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows an explicit type parameter at function invocation time", () => {
+    assertTypeScriptResult(
+      `
+      const f = f<number>(y);
+      values.filter<Node>((node): node is Node => node !== null);
+      const c = new Cache<number>();
+    `,
+      `${PREFIX}
+      const f = f(y);
+      values.filter((node) => node !== null);
+      const c = new Cache();
+    `,
+    );
+  });
 });


### PR DESCRIPTION
For now, this takes advantage of the parser. In the future, it may be possible
to do this just from tokens.