### PR TITLE
Implement TypeScript enums

### DIFF
--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -1,5 +1,6 @@
 import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
+import isIdentifier from "../util/isIdentifier";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
@@ -54,6 +55,10 @@ export default class TypeScriptTransformer extends Transformer {
       this.tokens.removeInitialToken();
       return true;
     }
+    if (this.tokens.matchesName("enum")) {
+      this.processEnum();
+      return true;
+    }
     return false;
   }
 
@@ -99,5 +104,101 @@ export default class TypeScriptTransformer extends Transformer {
       return true;
     }
     return false;
+  }
+
+  processEnum(): void {
+    this.tokens.removeInitialToken();
+    const enumName = this.tokens.currentToken().value;
+    this.tokens.removeToken();
+    this.tokens.appendCode(`var ${enumName}; (function (${enumName})`);
+    this.tokens.copyExpectedToken("{");
+    this.processEnumBody(enumName);
+    this.tokens.copyExpectedToken("}");
+    this.tokens.appendCode(`)(${enumName} || (${enumName} = {}));`);
+  }
+
+  /**
+   * Rather than try to compute the actual enum values at compile time, we just create variables for
+   * each one and let everything evaluate at runtime. There's some additional complexity due to
+   * handling string literal names, including ones that happen to be valid identifiers.
+   */
+  processEnumBody(enumName: string): void {
+    let isPreviousValidIdentifier = false;
+    let lastValueReference = null;
+    while (true) {
+      if (this.tokens.matches(["}"])) {
+        break;
+      }
+      const nameToken = this.tokens.currentToken();
+      let name;
+      let isValidIdentifier;
+      let nameStringCode;
+      if (nameToken.type.label === "name") {
+        name = nameToken.value;
+        isValidIdentifier = true;
+        nameStringCode = `"${name}"`;
+      } else if (nameToken.type.label === "string") {
+        name = nameToken.value;
+        isValidIdentifier = isIdentifier(name);
+        nameStringCode = this.tokens.code.slice(nameToken.start, nameToken.end);
+      } else {
+        throw new Error("Expected name or string at beginning of enum element.");
+      }
+      this.tokens.removeInitialToken();
+
+      let valueIsString;
+      let valueCode;
+
+      if (this.tokens.matches(["="])) {
+        const contextStartIndex = this.tokens.currentToken().contextStartIndex!;
+        this.tokens.removeToken();
+        if (this.tokens.matches(["string", ","]) || this.tokens.matches(["string", "}"])) {
+          valueIsString = true;
+        }
+        const startToken = this.tokens.currentToken();
+        while (
+          !this.tokens.matchesContextEnd(",", contextStartIndex) &&
+          !this.tokens.matchesContextEnd("}", contextStartIndex)
+        ) {
+          this.tokens.removeToken();
+        }
+        valueCode = this.tokens.code.slice(
+          startToken.start,
+          this.tokens.tokenAtRelativeIndex(-1).end,
+        );
+      } else {
+        valueIsString = false;
+        if (lastValueReference != null) {
+          if (isPreviousValidIdentifier) {
+            valueCode = `${lastValueReference} + 1`;
+          } else {
+            valueCode = `(${lastValueReference}) + 1`;
+          }
+        } else {
+          valueCode = "0";
+        }
+      }
+      if (this.tokens.matches([","])) {
+        this.tokens.removeToken();
+      }
+
+      let valueReference;
+      if (isValidIdentifier) {
+        this.tokens.appendCode(`const ${name} = ${valueCode}; `);
+        valueReference = name;
+      } else {
+        valueReference = valueCode;
+      }
+
+      if (valueIsString) {
+        this.tokens.appendCode(`${enumName}[${nameStringCode}] = ${valueReference};`);
+      } else {
+        this.tokens.appendCode(
+          `${enumName}[${enumName}[${nameStringCode}] = ${valueReference}] = ${nameStringCode};`,
+        );
+      }
+      lastValueReference = valueReference;
+      isPreviousValidIdentifier = isValidIdentifier;
+    }
   }
 }

--- a/src/util/isIdentifier.ts
+++ b/src/util/isIdentifier.ts
@@ -1,0 +1,16 @@
+import {isIdentifierChar, isIdentifierStart} from "../../sucrase-babylon/util/identifier";
+
+export default function isIdentifier(name: string): boolean {
+  if (name.length === 0) {
+    return false;
+  }
+  if (!isIdentifierStart(name.charCodeAt(0))) {
+    return false;
+  }
+  for (let i = 1; i < name.length; i++) {
+    if (!isIdentifierChar(name.charCodeAt(i))) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/sucrase-babylon/util/identifier.d.ts
+++ b/sucrase-babylon/util/identifier.d.ts
@@ -1,0 +1,2 @@
+export function isIdentifierStart(code: number): boolean;
+export function isIdentifierChar(code: number): boolean;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -360,4 +360,73 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows simple enums", () => {
+    assertTypeScriptResult(
+      `
+      enum Foo {
+        A,
+        B,
+        C
+      }
+    `,
+      `${PREFIX}
+      var Foo; (function (Foo) {
+        const A = 0; Foo[Foo["A"] = A] = "A";
+        const B = A + 1; Foo[Foo["B"] = B] = "B";
+        const C = B + 1; Foo[Foo["C"] = C] = "C";
+      })(Foo || (Foo = {}));
+    `,
+    );
+  });
+
+  it("allows simple string enums", () => {
+    assertTypeScriptResult(
+      `
+      enum Foo {
+        A = "eh",
+        B = "bee",
+        C = "sea",
+      }
+    `,
+      `${PREFIX}
+      var Foo; (function (Foo) {
+        const A = "eh"; Foo["A"] = A;
+        const B = "bee"; Foo["B"] = B;
+        const C = "sea"; Foo["C"] = C;
+      })(Foo || (Foo = {}));
+    `,
+    );
+  });
+
+  it("handles complex enum cases", () => {
+    assertTypeScriptResult(
+      `
+      enum Foo {
+        A = 15.5,
+        "Hello world" = A / 2,
+        "",
+        "D" = "foo".length,
+        E = D / D,
+        "!" = E << E,
+        "\\n",
+        ",",
+        "'",
+      }
+    `,
+      `${PREFIX}
+      var Foo; (function (Foo) {
+        const A = 15.5; Foo[Foo["A"] = A] = "A";
+        Foo[Foo["Hello world"] = A / 2] = "Hello world";
+        Foo[Foo[""] = (A / 2) + 1] = "";
+        const D = "foo".length; Foo[Foo["D"] = D] = "D";
+        const E = D / D; Foo[Foo["E"] = E] = "E";
+        Foo[Foo["!"] = E << E] = "!";
+        Foo[Foo["\\n"] = (E << E) + 1] = "\\n";
+        Foo[Foo[","] = ((E << E) + 1) + 1] = ",";
+        Foo[Foo["'"] = (((E << E) + 1) + 1) + 1] = "'";
+      })(Foo || (Foo = {}));
+    `,
+    );
+  });
 });


### PR DESCRIPTION
There ended up being some casework to handle string literal keys, including
string literals that happen to be identifiers anyway, but fortunately it could
be done with a reasonably straightforward scan through the code with
replacements.