### PR TITLE
Add initial support for `declare` syntax

### DIFF
--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -448,4 +448,34 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("handles and removes `declare module` syntax", () => {
+    assertTypeScriptResult(
+      `
+      declare module "builtin-modules" {
+        let result: string[];
+        export = result;
+      }
+    `,
+      `${PREFIX}
+      
+
+
+
+    `,
+    );
+  });
+
+  it("handles and removes `export declare class` syntax", () => {
+    assertTypeScriptResult(
+      `
+      export declare class Foo {
+      }
+    `,
+      `${PREFIX}
+      
+
+    `,
+    );
+  });
 });


### PR DESCRIPTION
For now, we just support `declare module`, and `declare class` but hopefully
this should be easy to extend in a disciplined way to all of the other declare
syntaxes.