### PR TITLE
Properly distinguish various names from keywords

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -182,10 +182,7 @@ class TokenPreprocessor {
           this.advance();
           this.processToToken("{", "}", "block");
         }
-      } else if (
-        this.startsWithKeyword(["declare"]) ||
-        (this.tokens.matches(["export"]) && this.tokens.matchesNameAtRelativeIndex(1, "declare"))
-      ) {
+      } else if (this.tokens.matches(["declare"]) || this.tokens.matches(["export", "declare"])) {
         this.processDeclare();
       } else if (this.tokens.matches(["name"])) {
         this.advance();

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -237,8 +237,7 @@ export default class ImportTransformer extends Transformer {
       this.processExportFunction();
     } else if (
       this.tokens.matches(["export", "class"]) ||
-      // export abstract class
-      this.tokens.matches(["export", "name", "class"])
+      this.tokens.matches(["export", "abstract", "class"])
     ) {
       this.processExportClass();
     } else if (this.tokens.matches(["export", "{"])) {
@@ -280,6 +279,7 @@ export default class ImportTransformer extends Transformer {
   private processExportDefault(): void {
     if (
       this.tokens.matches(["export", "default", "function", "name"]) ||
+      // export default aysnc function
       this.tokens.matches(["export", "default", "name", "function", "name"])
     ) {
       this.tokens.removeInitialToken();
@@ -288,9 +288,15 @@ export default class ImportTransformer extends Transformer {
       // declaration followed by exports statement.
       const name = this.processNamedFunction();
       this.tokens.appendCode(` exports.default = ${name};`);
-    } else if (this.tokens.matches(["export", "default", "class", "name"])) {
+    } else if (
+      this.tokens.matches(["export", "default", "class", "name"]) ||
+      this.tokens.matches(["export", "default", "abstract", "class", "name"])
+    ) {
       this.tokens.removeInitialToken();
       this.tokens.removeToken();
+      if (this.tokens.matches(["abstract"])) {
+        this.tokens.removeToken();
+      }
       const name = this.rootTransformer.processNamedClass();
       this.tokens.appendCode(` exports.default = ${name};`);
     } else {
@@ -371,7 +377,7 @@ export default class ImportTransformer extends Transformer {
    */
   private processExportClass(): void {
     this.tokens.removeInitialToken();
-    if (this.tokens.matchesName("abstract")) {
+    if (this.tokens.matches(["abstract"])) {
       this.tokens.removeToken();
     }
     const name = this.rootTransformer.processNamedClass();

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -42,11 +42,11 @@ export default class TypeScriptTransformer extends Transformer {
       return true;
     }
     if (
-      this.tokens.matchesName("public") ||
-      this.tokens.matchesName("protected") ||
-      this.tokens.matchesName("private") ||
-      this.tokens.matchesName("abstract") ||
-      this.tokens.matchesName("readonly")
+      this.tokens.matches(["public"]) ||
+      this.tokens.matches(["protected"]) ||
+      this.tokens.matches(["private"]) ||
+      this.tokens.matches(["abstract"]) ||
+      this.tokens.matches(["readonly"])
     ) {
       this.tokens.removeInitialToken();
       return true;

--- a/src/util/getClassInitializerInfo.ts
+++ b/src/util/getClassInitializerInfo.ts
@@ -133,11 +133,13 @@ function processConstructor(
  */
 function isAccessModifier(tokens: TokenProcessor): boolean {
   return (
-    (tokens.matches(["name"]) &&
-      ["public", "protected", "private", "readonly", "static", "async", "get", "set"].includes(
-        tokens.currentToken().value,
-      )) ||
-    tokens.matches(["+/-"])
+    (tokens.matches(["name"]) && ["async", "get", "set"].includes(tokens.currentToken().value)) ||
+    tokens.matches(["+/-"]) ||
+    tokens.matches(["readonly"]) ||
+    tokens.matches(["static"]) ||
+    tokens.matches(["public"]) ||
+    tokens.matches(["private"]) ||
+    tokens.matches(["protected"])
   );
 }
 

--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -193,6 +193,7 @@ export default abstract class LValParser extends NodeUtils {
     switch (this.state.type) {
       case tt._yield:
       case tt.name:
+        this.state.type = tt.name;
         return this.parseBindingIdentifier();
 
       case tt.bracketL: {

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -935,6 +935,7 @@ export default class StatementParser extends ExpressionParser {
         return;
       }
       // otherwise something static
+      this.state.tokens[this.state.tokens.length - 1].type = tt._static;
       isStatic = true;
     }
 

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -190,6 +190,13 @@ export const keywords = {
   typeof: new KeywordTokenType("typeof", {beforeExpr, prefix, startsExpr}),
   void: new KeywordTokenType("void", {beforeExpr, prefix, startsExpr}),
   delete: new KeywordTokenType("delete", {beforeExpr, prefix, startsExpr}),
+  declare: new KeywordTokenType("declare"),
+  readonly: new KeywordTokenType("readonly"),
+  abstract: new KeywordTokenType("abstract"),
+  static: new KeywordTokenType("static"),
+  public: new KeywordTokenType("public"),
+  private: new KeywordTokenType("private"),
+  protected: new KeywordTokenType("protected"),
 };
 
 // Map keyword names to token types.

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -478,4 +478,51 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows a parameter named declare", () => {
+    assertTypeScriptResult(
+      `
+      function foo(declare: boolean): string {
+        return "Hello!";
+      }
+    `,
+      `${PREFIX}
+      function foo(declare) {
+        return "Hello!";
+      }
+    `,
+    );
+  });
+
+  it("properly handles method parameters named readonly", () => {
+    assertTypeScriptResult(
+      `
+      class Foo {
+        bar(readonly: number) {
+          console.log(readonly);
+        }
+      }
+    `,
+      `${PREFIX}
+      class Foo {
+        bar(readonly) {
+          console.log(readonly);
+        }
+      }
+    `,
+    );
+  });
+
+  it("handles export default abstract class", () => {
+    assertTypeScriptResult(
+      `
+      export default abstract class Foo {
+      }
+    `,
+      `${PREFIX}${ESMODULE_PREFIX}
+       class Foo {
+      } exports.default = Foo;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This fixes the self build and moves a little closer to a world where the token
stream is smarter about the context of each token, so that later transforms
don't need to do as much work.