### PR TITLE
Follow TypeScript import semantics with TypeScript enabled

### DIFF
--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -26,7 +26,7 @@ export default class ImportTransformer extends Transformer {
   }
 
   getPrefixCode(): string {
-    let prefix = "'use strict';";
+    let prefix = '"use strict";';
     prefix += this.importProcessor.getPrefixCode();
     if (this.hadExport) {
       prefix += 'Object.defineProperty(exports, "__esModule", {value: true});';

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -17,7 +17,7 @@ export default class RootTransformer {
   constructor(readonly tokens: TokenProcessor, transforms: Array<Transform>) {
     this.nameManager = new NameManager(tokens);
     const importProcessor = transforms.includes("imports")
-      ? new ImportProcessor(this.nameManager, tokens)
+      ? new ImportProcessor(this.nameManager, tokens, transforms.includes("typescript"))
       : null;
     const identifierReplacer = importProcessor || {getIdentifierReplacement: () => null};
 

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -231,7 +231,7 @@ exports.a = a; exports.b = b;
         return 5;
       }
     `,
-      `'use strict'; function _interopRequireWildcard2(obj) { \
+      `"use strict"; function _interopRequireWildcard2(obj) { \
 if (obj && obj.__esModule) { return obj; } else { var newObj = {}; \
 if (obj != null) { for (var key in obj) { \
 if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } \

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -1,4 +1,4 @@
-export const PREFIX = `'use strict'; function _interopRequireWildcard(obj) { \
+export const PREFIX = `"use strict"; function _interopRequireWildcard(obj) { \
 if (obj && obj.__esModule) { return obj; } else { var newObj = {}; \
 if (obj != null) { for (var key in obj) { \
 if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } \

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -115,7 +115,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {
         [b]() {
         }
@@ -136,7 +136,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {
         get foo() {
           return 3;
@@ -155,7 +155,7 @@ describe("sucrase", () => {
       if (foo.case === 3) {
       }
     `,
-      `${PREFIX}
+      `"use strict";
       if (foo.case === 3) {
       }
     `,
@@ -173,7 +173,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       function foo() {
         outer: switch (a) {
           default:

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -2,8 +2,8 @@ import {ESMODULE_PREFIX, PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
 function assertTypeScriptAndFlowResult(code: string, expectedResult: string): void {
-  assertResult(code, expectedResult, ["jsx", "imports", "typescript"]);
-  assertResult(code, expectedResult, ["jsx", "imports", "flow"]);
+  assertResult(code, `"use strict";${expectedResult}`, ["jsx", "imports", "typescript"]);
+  assertResult(code, PREFIX + expectedResult, ["jsx", "imports", "flow"]);
 }
 
 /**
@@ -16,7 +16,7 @@ describe("type transforms", () => {
       class A implements B {}
       class C extends D implements E {}
     `,
-      `${PREFIX}
+      `
       class A {}
       class C extends D {}
     `,
@@ -42,7 +42,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `${PREFIX}
+      `
       function f() {
         return 3;
       }
@@ -70,7 +70,7 @@ describe("type transforms", () => {
         const b = (a: number);
       }
     `,
-      `${PREFIX}
+      `
       function foo(x, y) {
         const a = "Hello";
         const b = (a);
@@ -86,7 +86,7 @@ describe("type transforms", () => {
         return [];
       }
     `,
-      `${PREFIX}
+      `
       function foo() {
         return [];
       }
@@ -101,7 +101,7 @@ describe("type transforms", () => {
         return [];
       }
     `,
-      `${PREFIX}
+      `
       function foo() {
         return [];
       }
@@ -117,7 +117,7 @@ describe("type transforms", () => {
         y: {} = {};
       }
     `,
-      `${PREFIX}
+      `
       class A {constructor() { this.x = 2;this.y = {}; }
         
         
@@ -133,7 +133,7 @@ describe("type transforms", () => {
         x: number;
       }
     `,
-      `${PREFIX}
+      `
       class A {
         
       }
@@ -156,7 +156,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `${PREFIX}
+      `
       function f(t) {
         console.log(t);
       }
@@ -179,7 +179,7 @@ describe("type transforms", () => {
         return x + 1;
       }
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `${ESMODULE_PREFIX}
        function foo(x) {
         return x + 1;
       } exports.foo = foo;
@@ -193,7 +193,7 @@ describe("type transforms", () => {
       type foo = number;
       const x: foo = 3;
     `,
-      `${PREFIX}
+      `
       ;
       const x = 3;
     `,
@@ -206,7 +206,7 @@ describe("type transforms", () => {
       export type foo = number | string;
       export const x = 1;
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `${ESMODULE_PREFIX}
       ;
        const x = exports.x = 1;
     `,
@@ -220,7 +220,7 @@ describe("type transforms", () => {
         return x;
       }
     `,
-      `${PREFIX}
+      `
       function foo(x) {
         return x;
       }
@@ -233,7 +233,7 @@ describe("type transforms", () => {
       `
       const x: | number | string = "Hello";
     `,
-      `${PREFIX}
+      `
       const x = "Hello";
     `,
     );
@@ -246,7 +246,7 @@ describe("type transforms", () => {
       const arr2: Array<Array<number>> = [[2]];
       const arr3: Array<Array<Array<number>>> = [[[3]]];
     `,
-      `${PREFIX}
+      `
       const arr1 = [[1]];
       const arr2 = [[2]];
       const arr3 = [[[3]]];
@@ -260,7 +260,7 @@ describe("type transforms", () => {
       interface Cartesian { x: number; y: number; }
       export interface Polar { r: number; theta: number; }
     `,
-      `${PREFIX}
+      `
       
 
     `,
@@ -274,7 +274,7 @@ describe("type transforms", () => {
         interface: true,
       };
     `,
-      `${PREFIX}
+      `
       const o = {
         interface: true,
       };
@@ -289,7 +289,7 @@ describe("type transforms", () => {
         return 'Hi!';
       }
     `,
-      `${PREFIX}
+      `
       function foo(x) {
         return 'Hi!';
       }
@@ -302,7 +302,7 @@ describe("type transforms", () => {
       `
       const f = <T>(t: T): number => 3;
     `,
-      `${PREFIX}
+      `
       const f = (t) => 3;
     `,
     );
@@ -313,7 +313,7 @@ describe("type transforms", () => {
       `
       const f: <T>(t: T) => number = () => 3;
     `,
-      `${PREFIX}
+      `
       const f = () => 3;
     `,
     );
@@ -324,7 +324,7 @@ describe("type transforms", () => {
       `
       class Foo<T> {}
     `,
-      `${PREFIX}
+      `
       class Foo {}
     `,
     );
@@ -337,7 +337,7 @@ describe("type transforms", () => {
         return -1;
       }
     `,
-      `${PREFIX}
+      `
       function foo() {
         return -1;
       }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -12,7 +12,7 @@ describe("typescript transform", () => {
       const x = 0;
       console.log(x as string);
     `,
-      `${PREFIX}
+      `"use strict";
       const x = 0;
       console.log(x );
     `,
@@ -25,7 +25,7 @@ describe("typescript transform", () => {
       const as = "Hello";
       console.log(as);
     `,
-      `${PREFIX}
+      `"use strict";
       const as = "Hello";
       console.log(as);
     `,
@@ -42,7 +42,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {
         
          c() {
@@ -63,7 +63,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {
         
         constructor() {;this.x = 1;
@@ -84,7 +84,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A extends B {
         
         constructor(a) {
@@ -102,7 +102,7 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {constructor() { this.x = 1; }
         
       }
@@ -117,7 +117,7 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A extends B {constructor(...args) { super(...args); this.x = 1; }
         
       }
@@ -132,7 +132,7 @@ describe("typescript transform", () => {
         args = 1;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A extends B {constructor(...args2) { super(...args2); this.args = 1; }
         
       }
@@ -148,7 +148,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {
         constructor( x) {;this.x = x;
         }
@@ -166,7 +166,7 @@ describe("typescript transform", () => {
       const a = (x)!(y);
       const b = x + !y;
     `,
-      `${PREFIX}
+      `"use strict";
       const x = 1;
       const y = x;
       const z = !x; 
@@ -184,7 +184,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}
        class Foo {
         static run() {
         }
@@ -201,7 +201,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}
        class Foo {
         async run() {
         }
@@ -217,7 +217,7 @@ describe("typescript transform", () => {
         return x === 0;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       function foo(x) {
         return x === 0;
       }
@@ -232,7 +232,7 @@ describe("typescript transform", () => {
         return list.reduce((memo, item) => memo.concat(map(item)), [] as Array<U>);
       }
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}
        function flatMap(list, map) {
         return list.reduce((memo, item) => memo.concat(map(item)), [] );
       } exports.default = flatMap;
@@ -246,7 +246,7 @@ describe("typescript transform", () => {
       export interface A extends B {
       }
     `,
-      `${PREFIX}
+      `"use strict";
       
 
     `,
@@ -270,16 +270,16 @@ describe("typescript transform", () => {
         return true;
       }
     `,
-      `${PREFIX}
-      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      `"use strict";
+      var _a = require('a');
       
       require('c');
-      var _d = require('d'); var _d2 = _interopRequireDefault(_d);
+      var _d = require('d');
       
       
       
       function f(a) {
-        return a instanceof (0, _a2.default);
+        return a instanceof (0, _a.default);
       }
       function g(b) {
         return true;
@@ -296,7 +296,7 @@ describe("typescript transform", () => {
         f: any = function() {};
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {constructor() { this.f = function() {}; }
         
         
@@ -310,7 +310,7 @@ describe("typescript transform", () => {
       `
       export abstract class A {}
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}
        class A {} exports.A = A;
     `,
     );
@@ -321,7 +321,7 @@ describe("typescript transform", () => {
       `
       values.filter((node): node is Node => node !== null);
     `,
-      `${PREFIX}
+      `"use strict";
       values.filter((node) => node !== null);
     `,
     );
@@ -334,7 +334,7 @@ describe("typescript transform", () => {
       values.filter<Node>((node): node is Node => node !== null);
       const c = new Cache<number>();
     `,
-      `${PREFIX}
+      `"use strict";
       const f = f(y);
       values.filter((node) => node !== null);
       const c = new Cache();
@@ -351,7 +351,7 @@ describe("typescript transform", () => {
         "Hello, world" = 2;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class A {constructor() { this[a + b] = 3;this[0] = 1;this["Hello, world"] = 2; }
         
         
@@ -370,7 +370,7 @@ describe("typescript transform", () => {
         C
       }
     `,
-      `${PREFIX}
+      `"use strict";
       var Foo; (function (Foo) {
         const A = 0; Foo[Foo["A"] = A] = "A";
         const B = A + 1; Foo[Foo["B"] = B] = "B";
@@ -389,7 +389,7 @@ describe("typescript transform", () => {
         C = "sea",
       }
     `,
-      `${PREFIX}
+      `"use strict";
       var Foo; (function (Foo) {
         const A = "eh"; Foo["A"] = A;
         const B = "bee"; Foo["B"] = B;
@@ -414,7 +414,7 @@ describe("typescript transform", () => {
         "'",
       }
     `,
-      `${PREFIX}
+      `"use strict";
       var Foo; (function (Foo) {
         const A = 15.5; Foo[Foo["A"] = A] = "A";
         Foo[Foo["Hello world"] = A / 2] = "Hello world";
@@ -439,7 +439,7 @@ describe("typescript transform", () => {
         console.log(x);
       }
     `,
-      `${PREFIX}
+      `"use strict";
       
 
       function foo(x) {
@@ -457,7 +457,7 @@ describe("typescript transform", () => {
         export = result;
       }
     `,
-      `${PREFIX}
+      `"use strict";
       
 
 
@@ -472,7 +472,7 @@ describe("typescript transform", () => {
       export declare class Foo {
       }
     `,
-      `${PREFIX}
+      `"use strict";
       
 
     `,
@@ -486,7 +486,7 @@ describe("typescript transform", () => {
         return "Hello!";
       }
     `,
-      `${PREFIX}
+      `"use strict";
       function foo(declare) {
         return "Hello!";
       }
@@ -503,7 +503,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `${PREFIX}
+      `"use strict";
       class Foo {
         bar(readonly) {
           console.log(readonly);
@@ -519,9 +519,22 @@ describe("typescript transform", () => {
       export default abstract class Foo {
       }
     `,
-      `${PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}
        class Foo {
       } exports.default = Foo;
+    `,
+    );
+  });
+
+  it("allows calling a function imported via `import *` with TypeScript enabled", () => {
+    assertTypeScriptResult(
+      `
+      import * as f from './myFunc';
+      console.log(f());
+    `,
+      `"use strict";
+      var _myFunc = require('./myFunc'); var f = _myFunc;
+      console.log(f());
     `,
     );
   });

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -81,6 +81,7 @@ class App extends Component {
       this.state.code !== prevState.code ||
       this.state.selectedTransforms !== prevState.selectedTransforms ||
       this.state.compareWithBabel !== prevState.compareWithBabel ||
+      this.state.compareWithTypeScript !== prevState.compareWithTypeScript ||
       this.state.showTokens !== prevState.showTokens
     ) {
       this.postConfigToWorker();


### PR DESCRIPTION
This should fix an issue from decaffeinate-parser where the code was using
`import *` on a function, which works in TypeScript but not babel.