### PR TITLE
Properly handle variables named "as"

### DIFF
--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -98,7 +98,7 @@ class TokenPreprocessor {
         this.forceContextUntilToken("string", "import");
       } else if (this.tokens.matches(["export", "{"])) {
         this.forceContextUntilToken("}", "namedExport");
-      } else if (this.startsWithKeyword(["as"])) {
+      } else if (this.tokens.matches(["as"])) {
         // Note that this does not yet properly handle actual variables named "as".
         this.processTypeAssertion();
       } else if (

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1320,6 +1320,7 @@ export default (superClass: ParserClass): ParserClass =>
         !this.hasPrecedingLineBreak() &&
         this.eatContextual("as")
       ) {
+        this.state.tokens[this.state.tokens.length - 1].type = tt._as;
         const node: N.TsAsExpression = this.startNodeAt(leftStartPos, leftStartLoc);
         node.expression = left;
         node.typeAnnotation = this.tsParseType();

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -197,6 +197,7 @@ export const keywords = {
   public: new KeywordTokenType("public"),
   private: new KeywordTokenType("private"),
   protected: new KeywordTokenType("protected"),
+  as: new KeywordTokenType("as"),
 };
 
 // Map keyword names to token types.

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -19,7 +19,7 @@ describe("typescript transform", () => {
     );
   });
 
-  it.skip("properly handles variables named 'as'", () => {
+  it("properly handles variables named 'as'", () => {
     assertTypeScriptResult(
       `
       const as = "Hello";


### PR DESCRIPTION
We now have a special token type for it, which avoids the need to distinguish
from an identifier.