### PR TITLE
Label some identifiers with their roles

### DIFF
--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -1,3 +1,4 @@
+import {IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import ImportProcessor from "../ImportProcessor";
 import NameManager from "../NameManager";
 import TokenProcessor from "../TokenProcessor";
@@ -150,51 +151,13 @@ export default class ImportTransformer extends Transformer {
 
   private processIdentifier(): boolean {
     const token = this.tokens.currentToken();
-    const lastToken = this.tokens.tokens[this.tokens.currentIndex() - 1];
-    const nextToken = this.tokens.tokens[this.tokens.currentIndex() + 1];
-    // Skip identifiers that are part of property accesses.
-    if (lastToken && lastToken.type.label === ".") {
-      return false;
-    }
 
-    // For shorthand object keys, we need to expand them and replace only the value.
-    if (
-      token.contextName === "object" &&
-      lastToken &&
-      (lastToken.type.label === "," || lastToken.type.label === "{") &&
-      nextToken &&
-      (nextToken.type.label === "," || nextToken.type.label === "}")
-    ) {
+    if (token.identifierRole === IdentifierRole.ObjectShorthand) {
       return this.processObjectShorthand();
     }
 
-    // For non-shorthand object keys, just ignore them.
-    if (
-      token.contextName === "object" &&
-      nextToken &&
-      nextToken.type.label === ":" &&
-      lastToken &&
-      (lastToken.type.label === "," || lastToken.type.label === "{")
-    ) {
-      return false;
-    }
-
-    // Object methods identifiers can be identified similarly, and they also
-    // could have the async keyword before them.
-    if (
-      token.contextName === "object" &&
-      nextToken &&
-      nextToken.type.label === "(" &&
-      lastToken &&
-      (lastToken.type.label === "," ||
-        lastToken.type.label === "{" ||
-        (lastToken.type.label === "name" && lastToken.value === "async"))
-    ) {
-      return false;
-    }
-
-    // Identifiers within class bodies must be method names.
-    if (token.contextName === "class") {
+    // JSX names should always be transformed.
+    if (token.type.label === "name" && token.identifierRole !== IdentifierRole.Access) {
       return false;
     }
     const replacement = this.importProcessor.getIdentifierReplacement(token.value);

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -18,6 +18,7 @@
 //
 // [opp]: http://en.wikipedia.org/wiki/Operator-precedence_parser
 
+import {IdentifierRole} from "../tokenizer";
 import {TokenType, types as tt} from "../tokenizer/types";
 import * as N from "../types";
 import {reservedWords} from "../util/identifier";
@@ -672,6 +673,7 @@ export default abstract class ExpressionParser extends LValParser {
           return node;
         }
 
+        this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.Access;
         return id;
       }
 
@@ -1313,6 +1315,8 @@ export default abstract class ExpressionParser extends LValParser {
       } else {
         prop.value = prop.key.__clone();
       }
+      this.state.tokens[this.state.tokens.length - 1].identifierRole =
+        IdentifierRole.ObjectShorthand;
       prop.shorthand = true;
 
       return this.finishNode(prop, "ObjectProperty");

--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -17,6 +17,7 @@ import {
 } from "../types";
 import {Pos, Position} from "../util/location";
 import {NodeUtils} from "./node";
+import { IdentifierRole } from '../tokenizer';
 
 export default abstract class LValParser extends NodeUtils {
   // Forward-declaration: defined in expression.js
@@ -192,9 +193,12 @@ export default abstract class LValParser extends NodeUtils {
   parseBindingAtom(): Pattern {
     switch (this.state.type) {
       case tt._yield:
-      case tt.name:
+      case tt.name: {
         this.state.type = tt.name;
-        return this.parseBindingIdentifier();
+        const result = this.parseBindingIdentifier();
+        this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.Declaration;
+        return result;
+      }
 
       case tt.bracketL: {
         const node = this.startNode();

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -94,6 +94,13 @@ export type TokenContext =
   | "import"
   | "namedExport";
 
+export enum IdentifierRole {
+  Access,
+  Declaration,
+  ObjectShorthand,
+  Assignment,
+}
+
 // Object type used to represent tokens. Note that normally, tokens
 // simply exist as properties on the parser object. This is only
 // used for the onToken callback and the external tokenizer.
@@ -116,6 +123,7 @@ export class Token {
   contextName?: TokenContext;
   contextStartIndex?: number;
   parentContextStartIndex?: number | null;
+  identifierRole?: IdentifierRole;
 }
 
 // ## Tokenizer


### PR DESCRIPTION
This makes it possible to distinguish an identifier access from declaration from
object shorthand, and simplifies a lot of fragile (and possibly wrong)
Sucrase-specific code. It may be best to move to a token-based analysis later,
but for now, it's cheap to attach the role as we pass over the identifier in
parsing.