### PR TITLE
Allow export enum and const enums

### DIFF
--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -55,8 +55,7 @@ export default class ImportTransformer extends Transformer {
       this.tokens.currentToken().contextName !== "type"
     ) {
       this.hadExport = true;
-      this.processExport();
-      return true;
+      return this.processExport();
     }
     if (this.tokens.matches(["name"]) || this.tokens.matches(["jsxName"])) {
       return this.processIdentifier();
@@ -217,11 +216,18 @@ export default class ImportTransformer extends Transformer {
     return true;
   }
 
-  processExport(): void {
+  processExport(): boolean {
+    if (
+      this.tokens.matches(["export", "enum"]) ||
+      this.tokens.matches(["export", "const", "enum"])
+    ) {
+      // Let the TypeScript transform handle it.
+      return false;
+    }
     if (this.tokens.matches(["export", "default"])) {
       this.processExportDefault();
       this.hadDefaultExport = true;
-      return;
+      return true;
     }
     this.hadNamedExport = true;
     if (
@@ -230,20 +236,25 @@ export default class ImportTransformer extends Transformer {
       this.tokens.matches(["export", "const"])
     ) {
       this.processExportVar();
+      return true;
     } else if (
       this.tokens.matches(["export", "function"]) ||
       this.tokens.matches(["export", "name", "function"])
     ) {
       this.processExportFunction();
+      return true;
     } else if (
       this.tokens.matches(["export", "class"]) ||
       this.tokens.matches(["export", "abstract", "class"])
     ) {
       this.processExportClass();
+      return true;
     } else if (this.tokens.matches(["export", "{"])) {
       this.processExportBindings();
+      return true;
     } else if (this.tokens.matches(["export", "*"])) {
       this.processExportStar();
+      return true;
     } else {
       throw new Error("Unrecognized export syntax.");
     }

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1008,6 +1008,7 @@ export default (superClass: ParserClass): ParserClass =>
             // `const enum = 0;` not allowed because "enum" is a strict mode reserved word.
             this.expect(tt._const);
             this.expectContextual("enum");
+            this.state.tokens[this.state.tokens.length - 1].type = tt._enum;
             return this.tsParseEnumDeclaration(nany as N.TsEnumDeclaration, /* isConst */ true);
           }
         // falls through
@@ -1078,6 +1079,7 @@ export default (superClass: ParserClass): ParserClass =>
         case "enum":
           if (next || this.match(tt.name)) {
             if (next) this.next();
+            this.state.tokens[this.state.tokens.length - 1].type = tt._enum;
             return this.tsParseEnumDeclaration(node as N.TsEnumDeclaration, /* isConst */ false);
           }
           break;
@@ -1407,6 +1409,7 @@ export default (superClass: ParserClass): ParserClass =>
           const node: N.TsEnumDeclaration = this.startNode();
           this.expect(tt._const);
           this.expectContextual("enum");
+          this.state.tokens[this.state.tokens.length - 1].type = tt._enum;
           return this.tsParseEnumDeclaration(node, /* isConst */ true);
         }
       }

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -198,6 +198,7 @@ export const keywords = {
   private: new KeywordTokenType("private"),
   protected: new KeywordTokenType("protected"),
   as: new KeywordTokenType("as"),
+  enum: new KeywordTokenType("enum"),
 };
 
 // Map keyword names to token types.

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -538,4 +538,55 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("treats const enums as regular enums", () => {
+    assertTypeScriptResult(
+      `
+      const enum A {
+        Foo,
+        Bar,
+      }
+    `,
+      `"use strict";
+      var A; (function (A) {
+        const Foo = 0; A[A["Foo"] = Foo] = "Foo";
+        const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
+      })(A || (A = {}));
+    `,
+    );
+  });
+
+  it("allows `export enum`", () => {
+    assertTypeScriptResult(
+      `
+      export enum A {
+        Foo,
+        Bar,
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      var A; (function (A) {
+        const Foo = 0; A[A["Foo"] = Foo] = "Foo";
+        const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
+      })(A || (exports.A = A = {}));
+    `,
+    );
+  });
+
+  it("allows exported const enums", () => {
+    assertTypeScriptResult(
+      `
+      export const enum A {
+        Foo,
+        Bar,
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      var A; (function (A) {
+        const Foo = 0; A[A["Foo"] = Foo] = "Foo";
+        const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
+      })(A || (exports.A = A = {}));
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We just treat const enums as normal enums, which isn't great, but should be
correct, and is as good as we can do. It especially makes sense for the use case
of Sucrase for the fast development build and tsc for the full build.