### PR TITLE
Add an initial version of scopes emitted by the tokenizer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {getTokens} from "../sucrase-babylon";
+import {parse} from "../sucrase-babylon";
 import {Token} from "../sucrase-babylon/tokenizer/index";
 import augmentTokens from "./augmentTokens";
 import TokenProcessor from "./TokenProcessor";
@@ -48,15 +48,12 @@ function getSucraseTokens(code: string, options: Options): Array<Token> {
   if (options.transforms.includes("typescript")) {
     babylonPlugins = [...babylonPlugins, "typescript"];
   }
-
-  const tokens = getTokens(
-    code,
-    {
-      tokens: true,
-      sourceType: "module",
-      plugins: babylonPlugins,
-    } as any /* tslint:disable-line no-any */,
-  );
+  const file = parse(code, {
+    tokens: true,
+    sourceType: "module",
+    plugins: babylonPlugins,
+  });
+  const tokens = file.tokens;
   augmentTokens(code, tokens);
   return tokens;
 }

--- a/sucrase-babylon/index.ts
+++ b/sucrase-babylon/index.ts
@@ -1,40 +1,23 @@
-import {Options} from "./options";
+import {InputOptions} from "./options";
 import Parser, {ParserClass, plugins} from "./parser";
 
 import "./tokenizer/context";
-import {types as tokTypes} from "./tokenizer/types";
 
-import {Expression, File} from "./types";
+import {File} from "./types";
 
 import flowPlugin from "./plugins/flow";
 import jsxPlugin from "./plugins/jsx";
 import typescriptPlugin from "./plugins/typescript";
-import {Token} from "./tokenizer";
 
 plugins.flow = flowPlugin;
 plugins.jsx = jsxPlugin;
 plugins.typescript = typescriptPlugin;
 
-export function getTokens(input: string, options?: Options): Array<Token> {
-  options = Object.assign({}, options, {tokens: true});
-  return getParser(options, input).parse().tokens;
-}
-
-export function parse(input: string, options?: Options): File {
+export function parse(input: string, options?: InputOptions): File {
   return getParser(options, input).parse();
 }
 
-export function parseExpression(input: string, options?: Options): Expression {
-  const parser = getParser(options, input);
-  if (parser.options.strictMode) {
-    parser.state.strict = true;
-  }
-  return parser.getExpression();
-}
-
-export {tokTypes};
-
-function getParser(options: Options | null | undefined, input: string): Parser {
+function getParser(options: InputOptions | null | undefined, input: string): Parser {
   const Cls = options && options.plugins ? getParserClass(options.plugins) : Parser;
   return new Cls(options || null, input);
 }

--- a/sucrase-babylon/options.ts
+++ b/sucrase-babylon/options.ts
@@ -14,6 +14,8 @@ export type Options = {
   tokens: boolean;
 };
 
+export type InputOptions = {[O in keyof Options]?: Options[O]};
+
 export const defaultOptions: Options = {
   // Source type ("script" or "module") for different semantics
   sourceType: "script",
@@ -49,7 +51,7 @@ export const defaultOptions: Options = {
 
 // Interpret and default an options object
 
-export function getOptions(opts: Options | null): Options {
+export function getOptions(opts: InputOptions | null): Options {
   // tslint:disable-next-line no-any
   const options: any = {};
   for (const key of Object.keys(defaultOptions)) {

--- a/sucrase-babylon/parser/index.ts
+++ b/sucrase-babylon/parser/index.ts
@@ -1,9 +1,9 @@
-import {getOptions, Options} from "../options";
+import {getOptions, InputOptions} from "../options";
 import {File, Program} from "../types";
 import StatementParser from "./statement";
 
 export type ParserClass = {
-  new (options: Options | null, input: string): Parser;
+  new (inputOptions: InputOptions | null, input: string): Parser;
 };
 
 export const plugins: {
@@ -11,8 +11,8 @@ export const plugins: {
 } = {};
 
 export default class Parser extends StatementParser {
-  constructor(options: Options | null, input: string) {
-    options = getOptions(options);
+  constructor(inputOptions: InputOptions | null, input: string) {
+    const options = getOptions(inputOptions);
     super(options, input);
 
     this.options = options;

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -28,8 +28,14 @@ export default class StatementParser extends ExpressionParser {
     this.parseBlockBody(program, true, true, tt.eof);
 
     file.program = this.finishNode(program, "Program");
+    this.state.scopes.push({
+      startTokenIndex: 0,
+      endTokenIndex: this.state.tokens.length,
+      isFunctionScope: true,
+    });
 
     if (this.options.tokens) file.tokens = this.state.tokens;
+    file.scopes = this.state.scopes;
 
     return this.finishNode(file, "File");
   }
@@ -785,12 +791,15 @@ export default class StatementParser extends ExpressionParser {
     }
     if (isStatement) this.state.inGenerator = node.generator;
 
+    const startTokenIndex = this.state.tokens.length;
     this.parseFunctionParams(node);
     this.parseFunctionBodyAndFinish(
       node,
       isStatement ? "FunctionDeclaration" : "FunctionExpression",
       allowExpressionBody,
     );
+    const endTokenIndex = this.state.tokens.length;
+    this.state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: true});
 
     this.state.inFunction = oldInFunc;
     this.state.inMethod = oldInMethod;

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -13,6 +13,12 @@ export type Label = {
   statementStart?: number;
 };
 
+export type Scope = {
+  isFunctionScope: boolean;
+  startTokenIndex: number;
+  endTokenIndex: number;
+};
+
 export default class State {
   init(options: Options, input: string): void {
     this.strict = options.strictMode === false ? false : options.sourceType === "module";
@@ -44,6 +50,7 @@ export default class State {
     this.yieldInPossibleArrowParameters = null;
 
     this.tokens = [];
+    this.scopes = [];
 
     this.pos = 0;
     this.lineStart = 0;
@@ -128,6 +135,9 @@ export default class State {
 
   // Token store.
   tokens: Array<Token>;
+
+  // Array of all observed scopes, ordered by their ending position.
+  scopes: Array<Scope>;
 
   // The current position of the tokenizer in the input.
   pos: number;

--- a/sucrase-babylon/types.ts
+++ b/sucrase-babylon/types.ts
@@ -1,4 +1,5 @@
 import {Token} from "./tokenizer";
+import {Scope} from "./tokenizer/state";
 import {SourceLocation} from "./util/location";
 
 export interface NodeBase {
@@ -95,6 +96,7 @@ export type File = NodeBase & {
   type: "File";
   program: Program;
   tokens: Array<Token>;
+  scopes: Array<Scope>;
 };
 
 export type Program = NodeBase & {

--- a/test/scopes-test.ts
+++ b/test/scopes-test.ts
@@ -1,0 +1,24 @@
+import * as assert from "assert";
+import {parse} from "../sucrase-babylon";
+import {Scope} from "../sucrase-babylon/tokenizer/state";
+
+function assertScopes(code: string, expectedScopes: Array<Scope>): void {
+  assert.deepEqual(parse(code, {tokens: true, sourceType: "module"}).scopes, expectedScopes);
+}
+
+describe("scopes", () => {
+  it("properly provides function and program scopes", () => {
+    assertScopes(
+      `
+      const x = 1;
+      function foo(x) {
+        console.log(x);
+      }
+    `,
+      [
+        {startTokenIndex: 7, endTokenIndex: 19, isFunctionScope: true},
+        {startTokenIndex: 0, endTokenIndex: 20, isFunctionScope: true},
+      ],
+    );
+  });
+});


### PR DESCRIPTION
The hope here is to do minimal work at the lex/parse phase involving scopes, but
still enough that we can later identify which variables are shadowed via which
declarations. Rather than keeping a scope stack or anything like that, we just
emit a scope when we would have emitted a node, and have a flat list of scopes
that we pass into the normal Sucrase code. This can then be reconstructed in the
rare case that there actually is global shadowing in the file.

Also clean up some of the Options typings to avoid a use of `any`.