### PR TITLE
Propagate block or function scope declaration info to tokens

### DIFF
--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -496,7 +496,7 @@ export default class StatementParser extends ExpressionParser {
       if (this.match(tt.parenL)) {
         catchBindingStartTokenIndex = this.state.tokens.length;
         this.expect(tt.parenL);
-        clause.param = this.parseBindingAtom();
+        clause.param = this.parseBindingAtom(true /* isBlockScope */);
         const clashes: {} = Object.create(null);
         this.checkLVal(clause.param, true, clashes, "catch clause");
         this.expect(tt.parenR);
@@ -741,7 +741,8 @@ export default class StatementParser extends ExpressionParser {
     node.kind = kind.keyword;
     for (;;) {
       const decl = this.startNode();
-      this.parseVarHead(decl as N.VariableDeclarator);
+      const isBlockScope = kind === tt._const || kind === tt._let;
+      this.parseVarHead(decl as N.VariableDeclarator, isBlockScope);
       if (this.eat(tt.eq)) {
         decl.init = this.parseMaybeAssign(isFor);
       } else {
@@ -767,8 +768,8 @@ export default class StatementParser extends ExpressionParser {
     return node;
   }
 
-  parseVarHead(decl: N.VariableDeclarator): void {
-    decl.id = this.parseBindingAtom();
+  parseVarHead(decl: N.VariableDeclarator, isBlockScope: boolean): void {
+    decl.id = this.parseBindingAtom(isBlockScope);
     this.checkLVal(decl.id, true, null, "variable declaration");
   }
 
@@ -840,7 +841,12 @@ export default class StatementParser extends ExpressionParser {
     this.state.inParameters = true;
 
     this.expect(tt.parenL);
-    node.params = this.parseBindingList(tt.parenR, /* allowEmpty */ false, allowModifiers);
+    node.params = this.parseBindingList(
+      tt.parenR,
+      false /* isBlockScope */,
+      false /* allowEmpty */,
+      allowModifiers,
+    );
 
     this.state.inParameters = oldInParameters;
   }

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import Parser, {ParserClass} from "../parser";
+import {ParserClass} from "../parser";
 import State from "../tokenizer/state";
 import {TokenType, types as tt} from "../tokenizer/types";
 import * as N from "../types";
@@ -1716,6 +1716,7 @@ export default (superClass: ParserClass): ParserClass =>
       isGenerator: boolean,
       isAsync: boolean,
       isPattern: boolean,
+      isBlockScope: boolean,
       refShorthandDefaultPos: Pos | null,
     ): void {
       if (prop.variance) {
@@ -1738,6 +1739,7 @@ export default (superClass: ParserClass): ParserClass =>
         isGenerator,
         isAsync,
         isPattern,
+        isBlockScope,
         refShorthandDefaultPos,
       );
 
@@ -1767,11 +1769,12 @@ export default (superClass: ParserClass): ParserClass =>
     }
 
     parseMaybeDefault(
+      isBlockScope: boolean,
       startPos?: number | null,
       startLoc?: Position | null,
       left?: N.Pattern | null,
     ): N.Pattern {
-      const node = super.parseMaybeDefault(startPos, startLoc, left);
+      const node = super.parseMaybeDefault(isBlockScope, startPos, startLoc, left);
 
       if (
         node.type === "AssignmentPattern" &&
@@ -1915,8 +1918,8 @@ export default (superClass: ParserClass): ParserClass =>
     }
 
     // parse flow type annotations on variable declarator heads - let foo: string = bar
-    parseVarHead(decl: N.VariableDeclarator): void {
-      super.parseVarHead(decl);
+    parseVarHead(decl: N.VariableDeclarator, isBlockScope: boolean): void {
+      super.parseVarHead(decl, isBlockScope);
       if (this.match(tt.colon)) {
         decl.id.typeAnnotation = this.flowParseTypeAnnotation() as N.TypeAnnotationBase;
         this.finishNode(decl.id, decl.id.type);

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -96,7 +96,8 @@ export type TokenContext =
 
 export enum IdentifierRole {
   Access,
-  Declaration,
+  FunctionScopedDeclaration,
+  BlockScopedDeclaration,
   ObjectShorthand,
   Assignment,
 }

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import {parse} from "../sucrase-babylon";
+import {IdentifierRole, Token} from "../sucrase-babylon/tokenizer";
+
+type SimpleToken = Token & {label?: string};
+type TokenExpectation = {[K in keyof SimpleToken]?: SimpleToken[K]};
+
+function assertTokens(code: string, expectedTokens: Array<TokenExpectation>): void {
+  const tokens: Array<SimpleToken> = parse(code, {tokens: true, sourceType: "module"}).tokens;
+  for (const token of tokens) {
+    token.label = token.type.label;
+  }
+  assert.equal(tokens.length, expectedTokens.length);
+  const projectedTokens = tokens.map((token, i) => {
+    const result = {};
+    for (const key of Object.keys(expectedTokens[i])) {
+      result[key] = token[key];
+    }
+    return result;
+  });
+  assert.deepEqual(projectedTokens, expectedTokens);
+}
+
+describe("tokens", () => {
+  it("properly provides identifier roles for const, let, and var", () => {
+    assertTokens(
+      `
+      const x = 1;
+      let y = 2;
+      var z = 3;
+    `,
+      [
+        {label: "const"},
+        {label: "name", identifierRole: IdentifierRole.BlockScopedDeclaration},
+        {label: "="},
+        {label: "num"},
+        {label: ";"},
+        {label: "let"},
+        {label: "name", identifierRole: IdentifierRole.BlockScopedDeclaration},
+        {label: "="},
+        {label: "num"},
+        {label: ";"},
+        {label: "var"},
+        {label: "name", identifierRole: IdentifierRole.FunctionScopedDeclaration},
+        {label: "="},
+        {label: "num"},
+        {label: ";"},
+        {label: "eof"},
+      ],
+    );
+  });
+
+  it("identifies parameters as function-scoped declarations", () => {
+    assertTokens(
+      `
+      function foo(a, b) {
+      }
+    `,
+      [
+        {label: "function"},
+        {label: "name"},
+        {label: "("},
+        {label: "name", identifierRole: IdentifierRole.FunctionScopedDeclaration},
+        {label: ","},
+        {label: "name", identifierRole: IdentifierRole.FunctionScopedDeclaration},
+        {label: ")"},
+        {label: "{"},
+        {label: "}"},
+        {label: "eof"},
+      ],
+    );
+  });
+
+  it("identifies catch assignees as block-scoped declarations", () => {
+    assertTokens(
+      `
+      try {
+      } catch (e) {
+      }
+    `,
+      [
+        {label: "try"},
+        {label: "{"},
+        {label: "}"},
+        {label: "catch"},
+        {label: "("},
+        {label: "name", identifierRole: IdentifierRole.BlockScopedDeclaration},
+        {label: ")"},
+        {label: "{"},
+        {label: "}"},
+        {label: "eof"},
+      ],
+    );
+  });
+});


### PR DESCRIPTION
We now pass around a boolean for whether the assignment context is block-scoped,
and add that information on the tokens if so. That makes it possible to
determine the appropriate scope for a given variable.

This still misses bindings like function names and class declarations, so those
will come later.