### PR TITLE
Properly identify and ignore shadowed globals

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -1,6 +1,5 @@
 import NameManager from "./NameManager";
 import TokenProcessor from "./TokenProcessor";
-import {IdentifierReplacer} from "./transformers/IdentifierReplacer";
 import isMaybePropertyName from "./util/isMaybePropertyName";
 
 type NamedImport = {
@@ -24,7 +23,7 @@ type ImportInfo = {
  * TypeScript uses a simpler mechanism that does not use functions like interopRequireDefault and
  * interopRequireWildcard, so we also allow that mode for compatibility.
  */
-export default class ImportProcessor implements IdentifierReplacer {
+export default class ImportProcessor {
   private importInfoByPath: Map<string, ImportInfo> = new Map();
   private importsToReplace: Map<string, string> = new Map();
   private identifierReplacements: Map<string, string> = new Map();
@@ -376,5 +375,16 @@ get: () => ${primaryImportName}[key]}); });`;
 
   resolveExportBinding(assignedName: string): string | null {
     return this.exportBindingsByLocalName.get(assignedName) || null;
+  }
+
+  /**
+   * Return all imported/exported names where we might be interested in whether usages of those
+   * names are shadowed.
+   */
+  getGlobalNames(): Set<string> {
+    return new Set([
+      ...this.identifierReplacements.keys(),
+      ...this.exportBindingsByLocalName.keys(),
+    ]);
   }
 }

--- a/src/NameManager.ts
+++ b/src/NameManager.ts
@@ -6,7 +6,7 @@ export default class NameManager {
 
   constructor(readonly tokens: TokenProcessor) {}
 
-  preprocessNames(tokens: Array<Token>): void {
+  preprocessNames(): void {
     for (const token of this.tokens.tokens) {
       if (token.type.label === "name") {
         this.usedNames.add(token.value);

--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -1,0 +1,87 @@
+import {IdentifierRole, Token} from "../sucrase-babylon/tokenizer";
+import {Scope} from "../sucrase-babylon/tokenizer/state";
+
+/**
+ * Traverse the given tokens and modify them if necessary to indicate that some names shadow global
+ * variables.
+ */
+export default function identifyShadowedGlobals(
+  tokens: Array<Token>,
+  scopes: Array<Scope>,
+  globalNames: Set<string>,
+): void {
+  if (!hasShadowedGlobals(tokens, globalNames)) {
+    return;
+  }
+  markShadowedGlobals(tokens, scopes, globalNames);
+}
+
+/**
+ * We can do a fast up-front check to see if there are any declarations to global names. If not,
+ * then there's no point in computing scope assignments.
+ */
+function hasShadowedGlobals(tokens: Array<Token>, globalNames: Set<string>): boolean {
+  for (const token of tokens) {
+    if (
+      token.type.label === "name" &&
+      (token.identifierRole === IdentifierRole.FunctionScopedDeclaration ||
+        token.identifierRole === IdentifierRole.BlockScopedDeclaration) &&
+      globalNames.has(token.value)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function markShadowedGlobals(
+  tokens: Array<Token>,
+  scopes: Array<Scope>,
+  globalNames: Set<string>,
+): void {
+  const scopeStack = [];
+  let scopeIndex = scopes.length - 1;
+  // Scopes were generated at completion time, so they're sorted by end index, so we can maintain a
+  // good stack by going backwards through them.
+  for (let i = tokens.length - 1; ; i--) {
+    while (scopeStack.length > 0 && scopeStack[scopeStack.length - 1].startTokenIndex === i + 1) {
+      scopeStack.pop();
+    }
+    while (scopeIndex >= 0 && scopes[scopeIndex].endTokenIndex === i + 1) {
+      scopeStack.push(scopes[scopeIndex]);
+      scopeIndex--;
+    }
+    // Process scopes after the last iteration so we can make sure we pop all of them.
+    if (i < 0) {
+      break;
+    }
+
+    const token = tokens[i];
+    if (token.type.label === "name" && globalNames.has(token.value)) {
+      if (token.identifierRole === IdentifierRole.BlockScopedDeclaration) {
+        markShadowedForScope(scopeStack[scopeStack.length - 1], tokens, token.value);
+      } else if (token.identifierRole === IdentifierRole.FunctionScopedDeclaration) {
+        let stackIndex = scopeStack.length - 1;
+        while (stackIndex > 0 && !scopeStack[stackIndex].isFunctionScope) {
+          stackIndex--;
+        }
+        if (stackIndex < 0) {
+          throw new Error("Did not find parent function scope.");
+        }
+        markShadowedForScope(scopeStack[stackIndex], tokens, token.value);
+      }
+    }
+  }
+  if (scopeStack.length > 0) {
+    throw new Error("Expected empty scope stack after processing file.");
+  }
+}
+
+function markShadowedForScope(scope: Scope, tokens: Array<Token>, name: string): void {
+  for (let i = scope.startTokenIndex; i < scope.endTokenIndex; i++) {
+    const token = tokens[i];
+    if (token.type.label === "name" && token.value === name) {
+      token.shadowsGlobal = true;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import {parse} from "../sucrase-babylon";
-import {Token} from "../sucrase-babylon/tokenizer/index";
+import {Scope} from "../sucrase-babylon/tokenizer/state";
 import augmentTokens from "./augmentTokens";
+import identifyShadowedGlobals from "./identifyShadowedGlobals";
+import ImportProcessor from "./ImportProcessor";
+import NameManager from "./NameManager";
 import TokenProcessor from "./TokenProcessor";
 import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
@@ -20,15 +23,21 @@ export type Options = {
   babylonPlugins?: Array<string>;
 };
 
+export type SucraseContext = {
+  tokenProcessor: TokenProcessor;
+  scopes: Array<Scope>;
+  nameManager: NameManager;
+  importProcessor: ImportProcessor;
+};
+
 export function getVersion(): string {
   // eslint-disable-next-line
   return require("../../package.json").version;
 }
 
 export function transform(code: string, options: Options): string {
-  const tokens = getSucraseTokens(code, options);
-  const tokenProcessor = new TokenProcessor(code, tokens);
-  return new RootTransformer(tokenProcessor, options.transforms).transform();
+  const sucraseContext = getSucraseContext(code, options);
+  return new RootTransformer(sucraseContext, options.transforms).transform();
 }
 
 /**
@@ -36,11 +45,20 @@ export function transform(code: string, options: Options): string {
  * diagnostic purposes.
  */
 export function getFormattedTokens(code: string, options: Options): string {
-  const tokens = getSucraseTokens(code, options);
+  const tokens = getSucraseContext(code, options).tokenProcessor.tokens;
   return formatTokens(code, tokens);
 }
 
-function getSucraseTokens(code: string, options: Options): Array<Token> {
+/**
+ * Call into the parser/tokenizer and do some further preprocessing:
+ * - Come up with a set of used names so that we can assign new names.
+ * - Preprocess all import/export statements so we know which globals we are interested in.
+ * - Compute situations where any of those globals are shadowed.
+ *
+ * In the future, some of these preprocessing steps can be skipped based on what actual work is
+ * being done.
+ */
+function getSucraseContext(code: string, options: Options): SucraseContext {
   let babylonPlugins = options.babylonPlugins || DEFAULT_BABYLON_PLUGINS;
   if (options.transforms.includes("flow")) {
     babylonPlugins = [...babylonPlugins, "flow"];
@@ -54,6 +72,18 @@ function getSucraseTokens(code: string, options: Options): Array<Token> {
     plugins: babylonPlugins,
   });
   const tokens = file.tokens;
+  const scopes = file.scopes;
   augmentTokens(code, tokens);
-  return tokens;
+
+  const tokenProcessor = new TokenProcessor(code, tokens);
+  const nameManager = new NameManager(tokenProcessor);
+  nameManager.preprocessNames();
+  const isTypeScript = options.transforms.includes("typescript");
+  const importProcessor = new ImportProcessor(nameManager, tokenProcessor, isTypeScript);
+  importProcessor.preprocessTokens();
+  if (isTypeScript) {
+    importProcessor.pruneTypeOnlyImports();
+  }
+  identifyShadowedGlobals(tokens, scopes, importProcessor.getGlobalNames());
+  return {tokenProcessor, scopes, nameManager, importProcessor};
 }

--- a/src/transformers/IdentifierReplacer.ts
+++ b/src/transformers/IdentifierReplacer.ts
@@ -1,3 +1,0 @@
-export interface IdentifierReplacer {
-  getIdentifierReplacement(identifierName: string): string | null;
-}

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -21,11 +21,6 @@ export default class ImportTransformer extends Transformer {
     super();
   }
 
-  preprocess(): void {
-    this.nameManager.preprocessNames(this.tokens.tokens);
-    this.importProcessor.preprocessTokens();
-  }
-
   getPrefixCode(): string {
     let prefix = '"use strict";';
     prefix += this.importProcessor.getPrefixCode();
@@ -150,6 +145,9 @@ export default class ImportTransformer extends Transformer {
 
   private processIdentifier(): boolean {
     const token = this.tokens.currentToken();
+    if (token.shadowsGlobal) {
+      return false;
+    }
 
     if (token.identifierRole === IdentifierRole.ObjectShorthand) {
       return this.processObjectShorthand();

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -1,5 +1,5 @@
+import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
-import {IdentifierReplacer} from "./IdentifierReplacer";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
@@ -7,7 +7,7 @@ export default class JSXTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
-    readonly identifierReplacer: IdentifierReplacer,
+    readonly importProcessor: ImportProcessor,
   ) {
     super();
   }
@@ -138,7 +138,7 @@ export default class JSXTransformer extends Transformer {
   }
 
   processJSXTag(): void {
-    const resolvedReactName = this.identifierReplacer.getIdentifierReplacement("React") || "React";
+    const resolvedReactName = this.importProcessor.getIdentifierReplacement("React") || "React";
     // First tag is always jsxTagStart.
     this.tokens.replaceToken(`${resolvedReactName}.createElement(`);
     this.processTagIntro();

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,5 +1,5 @@
+import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
-import {IdentifierReplacer} from "./IdentifierReplacer";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
@@ -15,7 +15,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
-    readonly identifierReplacer: IdentifierReplacer,
+    readonly importProcessor: ImportProcessor,
   ) {
     super();
   }
@@ -23,7 +23,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
   process(): boolean {
     const startIndex = this.tokens.currentIndex();
     if (this.tokens.matchesName("createReactClass")) {
-      const newName = this.identifierReplacer.getIdentifierReplacement("createReactClass");
+      const newName = this.importProcessor.getIdentifierReplacement("createReactClass");
       if (newName) {
         this.tokens.replaceToken(`(0, ${newName})`);
       } else {
@@ -37,7 +37,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
       this.tokens.matchesName("React") &&
       this.tokens.matchesNameAtIndex(this.tokens.currentIndex() + 2, "createClass")
     ) {
-      const newName = this.identifierReplacer.getIdentifierReplacement("React");
+      const newName = this.importProcessor.getIdentifierReplacement("React");
       if (newName) {
         this.tokens.replaceToken(newName);
         this.tokens.copyToken();

--- a/src/transformers/Transformer.ts
+++ b/src/transformers/Transformer.ts
@@ -1,6 +1,4 @@
 export default abstract class Transformer {
-  preprocess(): void {}
-
   // Return true if anything was processed, false otherwise.
   abstract process(): boolean;
 

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -1,20 +1,11 @@
-import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
 import isIdentifier from "../util/isIdentifier";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
 export default class TypeScriptTransformer extends Transformer {
-  constructor(
-    readonly rootTransformer: RootTransformer,
-    readonly tokens: TokenProcessor,
-    readonly importProcessor: ImportProcessor,
-  ) {
+  constructor(readonly rootTransformer: RootTransformer, readonly tokens: TokenProcessor) {
     super();
-  }
-
-  preprocess(): void {
-    this.importProcessor.pruneTypeOnlyImports();
   }
 
   process(): boolean {

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -125,6 +125,7 @@ export class Token {
   contextStartIndex?: number;
   parentContextStartIndex?: number | null;
   identifierRole?: IdentifierRole;
+  shadowsGlobal?: boolean;
 }
 
 // ## Tokenizer

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -856,4 +856,27 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("does not transform shadowed identifiers", () => {
+    assertResult(
+      `
+      import a from 'a';
+      console.log(a);
+      function f() {
+        let a = 3;
+        a = 7;
+        console.log(a);
+      }
+    `,
+      `${PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      console.log((0, _a2.default));
+      function f() {
+        let a = 3;
+        a = 7;
+        console.log(a);
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This seems to work at least for simple cases. We check all declarations of
global names (really just imports/exports), find their scope, and walk the
scope, marking all appropriate name tokens as shadowing globals. That ensures
that we don't replace them as import references.

This makes tests completely work for decaffeinate, decaffeinate-parser, and
coffee-lex.