### PR TITLE
Properly handle JSX property accesses with the same names as imports

### DIFF
--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -153,8 +153,7 @@ export default class ImportTransformer extends Transformer {
       return this.processObjectShorthand();
     }
 
-    // JSX names should always be transformed.
-    if (token.type.label === "name" && token.identifierRole !== IdentifierRole.Access) {
+    if (token.identifierRole !== IdentifierRole.Access) {
       return false;
     }
     const replacement = this.importProcessor.getIdentifierReplacement(token.value);

--- a/sucrase-babylon/plugins/jsx/index.ts
+++ b/sucrase-babylon/plugins/jsx/index.ts
@@ -1,6 +1,5 @@
-// @ts-ignore
-
 import Parser, {ParserClass} from "../../parser";
+import {IdentifierRole} from "../../tokenizer";
 import {TokContext, types as tc} from "../../tokenizer/context";
 import {TokenType, types as tt} from "../../tokenizer/types";
 import * as N from "../../types";
@@ -231,7 +230,11 @@ export default (superClass: ParserClass): ParserClass =>
       const startPos = this.state.start;
       const startLoc = this.state.startLoc;
       const name = this.jsxParseIdentifier();
-      if (!this.eat(tt.colon)) return name;
+      if (!this.eat(tt.colon)) {
+        // Plain identifier, so this is an access.
+        this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.Access;
+        return name;
+      }
 
       const node = this.startNodeAt(startPos, startLoc);
       node.namespace = name;

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -879,4 +879,21 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("does not transform property accesses in JSX", () => {
+    assertResult(
+      `
+      import React from 'react';
+      import Row from 'row';
+      
+      const e = <foo.Row />;
+    `,
+      `${PREFIX}
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
+      var _row = require('row'); var _row2 = _interopRequireDefault(_row);
+      
+      const e = _react2.default.createElement(foo.Row, null );
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Previously, we were transforming all jsxIdentifier tokens, but really we want to
only transform ones at the start, so we mark the token at the parse step like we
do with regular identifiers.