### PR TITLE
Handle `export * as a from 'a';` syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "script/build",
+    "clean": "rm -rf ./build ./dist",
     "self-build": "script/self-build",
     "self-test": "mocha test/**/*.ts --opts test/mocha-self-test.opts",
     "benchmark": "node ./build/benchmark/benchmark.js",

--- a/script/build
+++ b/script/build
@@ -6,9 +6,7 @@ TSC="${TSC:-node_modules/.bin/tsc}"
 
 # The build dir has all build artifacts, including the benchmark. The dist dir
 # is the subset that's shipped as part of the package.
-rm -rf ./build
 mkdir -p ./build
-rm -rf ./dist
 mkdir -p ./dist
 
 echo 'Building ES module version.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@ import TokenProcessor from "./TokenProcessor";
 import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
 
-const DEFAULT_BABYLON_PLUGINS = ["jsx", "objectRestSpread", "classProperties"];
+const DEFAULT_BABYLON_PLUGINS = [
+  "jsx",
+  "objectRestSpread",
+  "classProperties",
+  "exportNamespaceFrom",
+];
 
 export type Transform =
   | "jsx"

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -1397,6 +1397,7 @@ export default class StatementParser extends ExpressionParser {
     );
 
     this.next();
+    this.state.tokens[this.state.tokens.length - 1].type = tt._as;
 
     specifier.exported = this.parseIdentifier(true);
 

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -896,4 +896,15 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("handles export namespace as named export", () => {
+    assertResult(
+      `
+      export * as a from 'a';
+    `,
+      `${PREFIX}${ESMODULE_PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireWildcard(_a); exports.a = _a2;
+    `,
+    );
+  });
 });

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -66,7 +66,7 @@ function runBabel() {
     () =>
       Babel.transform(config.code, {
         presets: babelPresets,
-        plugins: babelPlugins,
+        plugins: [...babelPlugins, "proposal-export-namespace-from"],
         parserOpts: {plugins: ["jsx", "classProperties"]},
       }).code,
   );


### PR DESCRIPTION
This is a stage 1 proposal, so generally wouldn't make sense for this project,
but babel uses it and it's easy to implement.