### PR TITLE
Properly distinguish "async", "get", and "set" keywords from names

### DIFF
--- a/src/util/getClassInitializerInfo.ts
+++ b/src/util/getClassInitializerInfo.ts
@@ -133,7 +133,9 @@ function processConstructor(
  */
 function isAccessModifier(tokens: TokenProcessor): boolean {
   return (
-    (tokens.matches(["name"]) && ["async", "get", "set"].includes(tokens.currentToken().value)) ||
+    tokens.matches(["async"]) ||
+    tokens.matches(["get"]) ||
+    tokens.matches(["set"]) ||
     tokens.matches(["+/-"]) ||
     tokens.matches(["readonly"]) ||
     tokens.matches(["static"]) ||

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -1091,6 +1091,7 @@ export default class StatementParser extends ExpressionParser {
         this.pushClassProperty(classBody, publicProp);
       }
     } else if (isSimple && (key as N.Identifier).name === "async" && !this.isLineTerminator()) {
+      this.state.tokens[this.state.tokens.length - 1].type = tt._async;
       // an async method
       const isGenerator = this.match(tt.star);
       if (isGenerator) {
@@ -1117,6 +1118,11 @@ export default class StatementParser extends ExpressionParser {
       ((key as N.Identifier).name === "get" || (key as N.Identifier).name === "set") &&
       !(this.isLineTerminator() && this.match(tt.star))
     ) {
+      if ((key as N.Identifier).name === "get") {
+        this.state.tokens[this.state.tokens.length - 1].type = tt._get;
+      } else {
+        this.state.tokens[this.state.tokens.length - 1].type = tt._set;
+      }
       // `get\n*` is an uninitialized property named 'get' followed by a generator.
       // a getter or setter
       // @ts-ignore

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -190,6 +190,13 @@ export const keywords = {
   typeof: new KeywordTokenType("typeof", {beforeExpr, prefix, startsExpr}),
   void: new KeywordTokenType("void", {beforeExpr, prefix, startsExpr}),
   delete: new KeywordTokenType("delete", {beforeExpr, prefix, startsExpr}),
+
+  // Other keywords
+  async: new KeywordTokenType("async"),
+  get: new KeywordTokenType("get"),
+  set: new KeywordTokenType("set"),
+
+  // TypeScript keywords
   declare: new KeywordTokenType("declare"),
   readonly: new KeywordTokenType("readonly"),
   abstract: new KeywordTokenType("abstract"),

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -208,4 +208,44 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("handles methods called `get` and `set` in a class", () => {
+    assertResult(
+      `
+      class A {
+        get() {
+        }
+        set() {
+        }
+      }
+    `,
+      `"use strict";
+      class A {
+        get() {
+        }
+        set() {
+        }
+      }
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
+
+  it("handles async class methods", () => {
+    assertResult(
+      `
+      class A {
+        async foo() {
+        }
+      }
+    `,
+      `"use strict";
+      class A {
+        async foo() {
+        }
+      }
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });


### PR DESCRIPTION
This fixes a number of cases in Babel where there were methods with the name
"get".