### PR TITLE
Implement numeric separators

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -124,6 +124,11 @@ export default class TokenProcessor {
     return this.tokens[this.tokenIndex];
   }
 
+  currentTokenCode(): string {
+    const token = this.currentToken();
+    return this.code.slice(token.start, token.end);
+  }
+
   tokenAtRelativeIndex(relativeIndex: number): Token {
     return this.tokens[this.tokenIndex + relativeIndex];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const DEFAULT_BABYLON_PLUGINS = [
   "objectRestSpread",
   "classProperties",
   "exportNamespaceFrom",
+  "numericSeparator",
 ];
 
 export type Transform =

--- a/src/transformers/NumericSeparatorTransformer.ts
+++ b/src/transformers/NumericSeparatorTransformer.ts
@@ -1,0 +1,19 @@
+import TokenProcessor from "../TokenProcessor";
+import Transformer from "./Transformer";
+
+export default class NumericSeparatorTransformer extends Transformer {
+  constructor(readonly tokens: TokenProcessor) {
+    super();
+  }
+
+  process(): boolean {
+    if (this.tokens.matches(["num"])) {
+      const code = this.tokens.currentTokenCode();
+      if (code.includes("_")) {
+        this.tokens.replaceToken(code.replace(/_/g, ""));
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -5,6 +5,7 @@ import getClassInitializerInfo from "../util/getClassInitializerInfo";
 import FlowTransformer from "./FlowTransformer";
 import ImportTransformer from "./ImportTransformer";
 import JSXTransformer from "./JSXTransformer";
+import NumericSeparatorTransformer from "./NumericSeparatorTransformer";
 import ReactDisplayNameTransformer from "./ReactDisplayNameTransformer";
 import Transformer from "./Transformer";
 import TypeScriptTransformer from "./TypeScriptTransformer";
@@ -19,6 +20,7 @@ export default class RootTransformer {
     const {tokenProcessor, importProcessor} = sucraseContext;
     this.tokens = tokenProcessor;
 
+    this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
     if (transforms.includes("jsx")) {
       this.transformers.push(new JSXTransformer(this, tokenProcessor, importProcessor));
     }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -248,4 +248,18 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("removes numeric separators from number literals", () => {
+    assertResult(
+      `
+      const n = 1_000_000;
+      const x = 12_34.56_78;
+    `,
+      `"use strict";
+      const n = 1000000;
+      const x = 1234.5678;
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "https://sucrase.io",
   "dependencies": {
+    "@babel/plugin-proposal-numeric-separator": "^7.0.0-beta.37",
     "@babel/standalone": "^7.0.0-beta.36",
     "autoprefixer": "7.1.2",
     "babel-core": "6.25.0",

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -7,6 +7,7 @@ import {TRANSFORMS} from "./Constants";
 import {compressCode} from "./URLHashState";
 import getTokens from "./getTokens";
 Babel.registerPlugin("add-module-exports", require("babel-plugin-add-module-exports"));
+Babel.registerPlugin("proposal-numeric-separator", require("@babel/plugin-proposal-numeric-separator"));
 
 let config = null;
 
@@ -66,8 +67,8 @@ function runBabel() {
     () =>
       Babel.transform(config.code, {
         presets: babelPresets,
-        plugins: [...babelPlugins, "proposal-export-namespace-from"],
-        parserOpts: {plugins: ["jsx", "classProperties"]},
+        plugins: [...babelPlugins, "proposal-export-namespace-from", "proposal-numeric-separator"],
+        parserOpts: {plugins: ["jsx", "classProperties", "numericSeparator"]},
       }).code,
   );
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@babel/plugin-proposal-numeric-separator@^7.0.0-beta.37":
+  version "7.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.37.tgz#53cadbbdf34bac5b2920920b22168098fcdc05b8"
+  dependencies:
+    "@babel/plugin-syntax-numeric-separator" "7.0.0-beta.37"
+
+"@babel/plugin-syntax-numeric-separator@7.0.0-beta.37":
+  version "7.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.37.tgz#45cf626436e0938a087ca7931ef32ad8a49b1815"
+
 "@babel/standalone@^7.0.0-beta.36":
   version "7.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.0.0-beta.36.tgz#342a44f6daf1f413ab06998056357c1f7e98a1ed"


### PR DESCRIPTION
Babel uses them, and they're easy to implement, so this gets them out of the
way.