### PR TITLE
Overhaul type detection to happen within the parser

### DIFF
--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -13,24 +13,6 @@ export default class FlowTransformer extends Transformer {
       this.rootTransformer.processClass();
       return true;
     }
-    const processedTypeAnnotation = this.rootTransformer.processPossibleTypeAnnotation();
-    if (processedTypeAnnotation) {
-      return true;
-    }
-    if (this.tokens.currentToken().contextName === "type") {
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "type") {
-        this.tokens.removeToken();
-      }
-      return true;
-    }
-    if (this.tokens.currentToken().contextName === "typeParameter") {
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "typeParameter") {
-        this.tokens.removeToken();
-      }
-      return true;
-    }
-    return false;
+    return this.rootTransformer.processPossibleTypeRange();
   }
 }

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -333,7 +333,7 @@ export default class ImportTransformer extends Transformer {
     this.tokens.copyExpectedToken("(");
     this.rootTransformer.processBalancedCode();
     this.tokens.copyExpectedToken(")");
-    this.rootTransformer.processPossibleTypeAnnotation();
+    this.rootTransformer.processPossibleTypeRange();
     this.tokens.copyExpectedToken("{");
     this.rootTransformer.processBalancedCode();
     this.tokens.copyExpectedToken("}");

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -220,21 +220,10 @@ export default class RootTransformer {
     this.tokens.copyExpectedToken("}");
   }
 
-  processPossibleTypeAnnotation(): boolean {
-    if (
-      this.tokens.matches(["?", ":"]) &&
-      this.tokens.tokenAtRelativeIndex(2).contextName === "type"
-    ) {
+  processPossibleTypeRange(): boolean {
+    if (this.tokens.currentToken().isType) {
       this.tokens.removeInitialToken();
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "type") {
-        this.tokens.removeToken();
-      }
-      return true;
-    }
-    if (this.tokens.matches([":"]) && this.tokens.tokenAtRelativeIndex(1).contextName === "type") {
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "type") {
+      while (this.tokens.currentToken().isType) {
         this.tokens.removeToken();
       }
       return true;

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -14,22 +14,8 @@ export default class TypeScriptTransformer extends Transformer {
       this.rootTransformer.processClass();
       return true;
     }
-    const processedTypeAnnotation = this.rootTransformer.processPossibleTypeAnnotation();
-    if (processedTypeAnnotation) {
-      return true;
-    }
-    if (this.tokens.currentToken().contextName === "type") {
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "type") {
-        this.tokens.removeToken();
-      }
-      return true;
-    }
-    if (this.tokens.currentToken().contextName === "typeParameter") {
-      this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "typeParameter") {
-        this.tokens.removeToken();
-      }
+    const processedType = this.rootTransformer.processPossibleTypeRange();
+    if (processedType) {
       return true;
     }
     if (

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -112,6 +112,7 @@ export class Token {
     this.value = state.value;
     this.start = state.start;
     this.end = state.end;
+    this.isType = state.isType;
     this.loc = new SourceLocation(state.startLoc, state.endLoc);
   }
 
@@ -120,6 +121,7 @@ export class Token {
   value: any;
   start: number;
   end: number;
+  isType: boolean;
   loc: SourceLocation;
   contextName?: TokenContext;
   contextStartIndex?: number;
@@ -170,6 +172,21 @@ export default abstract class Tokenizer extends LocationParser {
     this.state.lastTokEndLoc = this.state.endLoc;
     this.state.lastTokStartLoc = this.state.startLoc;
     this.nextToken();
+  }
+
+  runInTypeContext<T>(existingTokensInType: number, func: () => T): T {
+    for (
+      let i = this.state.tokens.length - existingTokensInType;
+      i < this.state.tokens.length;
+      i++
+    ) {
+      this.state.tokens[i].isType = true;
+    }
+    const oldIsType = this.state.isType;
+    this.state.isType = true;
+    const result = func();
+    this.state.isType = oldIsType;
+    return result;
   }
 
   // TODO

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -63,6 +63,8 @@ export default class State {
     this.startLoc = this.curPosition();
     this.endLoc = this.startLoc;
 
+    this.isType = false;
+
     // @ts-ignore
     this.lastTokEndLoc = null;
     // @ts-ignore
@@ -155,6 +157,8 @@ export default class State {
   // Its start and end offset
   start: number;
   end: number;
+
+  isType: boolean;
 
   // And, if locations are used, the {line, column} object
   // corresponding to those offsets

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -34,7 +34,7 @@ describe("transform flow", () => {
       const f = (): number => 3;
     `,
       `${PREFIX}
-      ;
+      
       const f = () => 3;
     `,
     );
@@ -110,7 +110,7 @@ describe("transform flow", () => {
       export type * from "a";
     `,
       `${PREFIX}
-      ;
+      
     `,
     );
   });

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -194,7 +194,7 @@ describe("type transforms", () => {
       const x: foo = 3;
     `,
       `
-      ;
+      
       const x = 3;
     `,
     );
@@ -207,7 +207,7 @@ describe("type transforms", () => {
       export const x = 1;
     `,
       `${ESMODULE_PREFIX}
-      ;
+      
        const x = exports.x = 1;
     `,
     );
@@ -340,6 +340,23 @@ describe("type transforms", () => {
       `
       function foo() {
         return -1;
+      }
+    `,
+    );
+  });
+
+  it("removes type parameters from class methods", () => {
+    assertTypeScriptAndFlowResult(
+      `
+      class A {
+        b<T>() {
+        }
+      }
+    `,
+      `
+      class A {
+        b() {
+        }
       }
     `,
     );


### PR DESCRIPTION
This gives a much more reliable definition of what is and is not a type, and
should make it possible to get rid of augmentTokenContext. This may make perf a
little worse, but hopefully that can be refined later.