### PR TITLE
Include the file path when reporting errors from the gulp plugin

### DIFF
--- a/integrations/gulp-plugin/package.json
+++ b/integrations/gulp-plugin/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@sucrase/gulp-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Gulp plugin for Sucrase",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/master/integrations/gulp-plugin",
+  "files": [
+    "dist"
+  ],
   "peerDependencies": {
     "sucrase": "^1.8.1"
   },

--- a/integrations/gulp-plugin/src/index.ts
+++ b/integrations/gulp-plugin/src/index.ts
@@ -32,6 +32,7 @@ function gulpSucrase(options: Options): Transform {
       file.path = replaceExt(file.path, ".js");
       this.push(file);
     } catch (e) {
+      e.message = `Error when processing file ${file.path}: ${e.message}`;
       this.emit("error", new PluginError(PLUGIN_NAME, e));
     }
 


### PR DESCRIPTION
Gulp seems to sometimes report errors out of sync with the messages, so this
should make it easier to understand which file is having problems.