### PR TITLE
Remove some of the type code from augmentTokens

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -95,11 +95,7 @@ export default class ImportProcessor {
   pruneTypeOnlyImports(): void {
     const nonTypeIdentifiers: Set<string> = new Set();
     for (const token of this.tokens.tokens) {
-      if (
-        token.type.label === "name" &&
-        token.contextName !== "type" &&
-        token.contextName !== "import"
-      ) {
+      if (token.type.label === "name" && !token.isType && token.contextName !== "import") {
         nonTypeIdentifiers.add(token.value);
       }
     }

--- a/src/augmentTokens.ts
+++ b/src/augmentTokens.ts
@@ -95,11 +95,6 @@ class TokenPreprocessor {
         this.tokens.matchesNameAtRelativeIndex(1, "type")
       ) {
         this.processTypeWildcardExport();
-      } else if (
-        this.tokens.matches(["export"]) &&
-        this.tokens.matchesNameAtRelativeIndex(1, "type")
-      ) {
-        this.processTypeAlias();
       } else if (this.startsWithKeyword(["import"])) {
         this.forceContextUntilToken("string", "import");
       } else if (this.tokens.matches(["export", "{"])) {
@@ -107,13 +102,6 @@ class TokenPreprocessor {
       } else if (this.tokens.matches(["as"])) {
         // Note that this does not yet properly handle actual variables named "as".
         this.processTypeAssertion();
-      } else if (
-        this.tokens.matchesName("type") &&
-        this.tokens.matchesAtRelativeIndex(1, ["name"]) &&
-        (this.tokens.matchesAtRelativeIndex(2, ["="]) ||
-          this.tokens.matchesAtRelativeIndex(2, ["</>"]))
-      ) {
-        this.processTypeAlias();
       } else if (
         this.tokens.matches(["export"]) &&
         this.tokens.matchesNameAtRelativeIndex(1, "interface")
@@ -362,21 +350,6 @@ class TokenPreprocessor {
     this.advance("*");
     this.advance("name");
     this.advance("string");
-    this.contextStack.pop();
-  }
-
-  private processTypeAlias(): void {
-    this.contextStack.push({context: "type", startIndex: this.tokens.currentIndex()});
-    if (this.tokens.matches(["export"])) {
-      this.advance("export");
-    }
-    this.advance("name", "type");
-    this.advance("name");
-    if (this.tokens.matches(["</>"]) && this.tokens.currentToken().value === "<") {
-      this.skipBalancedAngleBrackets();
-    }
-    this.advance("=");
-    this.skipTypeExpression();
     this.contextStack.pop();
   }
 

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -48,7 +48,7 @@ export default class ImportTransformer extends Transformer {
     if (
       this.tokens.matches(["export"]) &&
       !isMaybePropertyName(this.tokens, this.tokens.currentIndex()) &&
-      this.tokens.currentToken().contextName !== "type"
+      !this.tokens.currentToken().isType
     ) {
       this.hadExport = true;
       return this.processExport();

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -127,4 +127,15 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("handles export type for individual types", () => {
+    assertFlowResult(
+      `
+      export type {foo};
+    `,
+      `${PREFIX}
+      
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This fixes an issue with an unrecognized export syntax that's handled correctly
by the parsing code. Ideally, augmentTokens will pretty much go away completely
in the long run.