### PR TITLE
Remove more contextName cases

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -1,4 +1,4 @@
-import {Token} from "../sucrase-babylon/tokenizer";
+import {IdentifierRole, Token} from "../sucrase-babylon/tokenizer";
 
 export default class TokenProcessor {
   private resultCode: string = "";
@@ -64,7 +64,7 @@ export default class TokenProcessor {
     if (this.matchesAtRelativeIndex(-1, ["."])) {
       return false;
     }
-    if (token.contextName === "object" && this.matchesAtRelativeIndex(1, [":"])) {
+    if (token.identifierRole === IdentifierRole.ObjectKey) {
       return false;
     }
     return token.type.label === name || (token.type.label === "name" && token.value === name);

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,3 +1,4 @@
+import {IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
@@ -81,12 +82,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
       // that identifier name.
       return this.tokens.tokens[startIndex - 2].value;
     }
-    if (
-      this.tokens.matchesAtIndex(startIndex - 2, ["name", ":"]) &&
-      this.tokens.tokens[startIndex - 2].contextName === "object" &&
-      (this.tokens.tokens[startIndex - 3].type.label === "," ||
-        this.tokens.tokens[startIndex - 3].type.label === "{")
-    ) {
+    if (this.tokens.tokens[startIndex - 2].identifierRole === IdentifierRole.ObjectKey) {
       // This is an object literal value.
       return this.tokens.tokens[startIndex - 2].value;
     }
@@ -121,9 +117,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
 
       if (
         this.tokens.matchesNameAtIndex(index, "displayName") &&
-        this.tokens.matchesAtIndex(index + 1, [":"]) &&
-        (this.tokens.matchesAtIndex(index - 1, [","]) ||
-          this.tokens.matchesAtIndex(index - 1, ["{"])) &&
+        this.tokens.tokens[index].identifierRole === IdentifierRole.ObjectKey &&
         token.contextName === "object" &&
         token.contextStartIndex === objectStartIndex
       ) {

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -1385,6 +1385,7 @@ export default abstract class ExpressionParser extends LValParser {
           ? this.parseExprAtom()
           : this.parseMaybePrivateName();
 
+      this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.ObjectKey;
       if (prop.key.type !== "PrivateName") {
         // ClassPrivateProperty is never computed, so we don't assign in that case.
         prop.computed = false;

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -99,6 +99,7 @@ export enum IdentifierRole {
   FunctionScopedDeclaration,
   BlockScopedDeclaration,
   ObjectShorthand,
+  ObjectKey,
   Assignment,
 }
 


### PR DESCRIPTION
This offloads more work to the parse step, which should be more reliable and
avoid the need to effectively do two parsing passes.