### PR TITLE
Get rid of more usages of contexts

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -1,3 +1,4 @@
+import {IdentifierRole} from "../sucrase-babylon/tokenizer";
 import NameManager from "./NameManager";
 import TokenProcessor from "./TokenProcessor";
 import isMaybePropertyName from "./util/isMaybePropertyName";
@@ -95,7 +96,11 @@ export default class ImportProcessor {
   pruneTypeOnlyImports(): void {
     const nonTypeIdentifiers: Set<string> = new Set();
     for (const token of this.tokens.tokens) {
-      if (token.type.label === "name" && !token.isType && token.contextName !== "import") {
+      if (
+        token.type.label === "name" &&
+        !token.isType &&
+        token.identifierRole === IdentifierRole.Access
+      ) {
         nonTypeIdentifiers.add(token.value);
       }
     }

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -74,6 +74,10 @@ export default class TokenProcessor {
     return this.matches([label]) && this.currentToken().contextStartIndex === contextStartIndex;
   }
 
+  matchesContextIdAndLabel(label: string, contextId: number): boolean {
+    return this.matches([label]) && this.currentToken().contextId === contextId;
+  }
+
   previousWhitespace(): string {
     return this.code.slice(
       this.tokenIndex > 0 ? this.tokens[this.tokenIndex - 1].end : 0,

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -1,6 +1,5 @@
 import {IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import ImportProcessor from "../ImportProcessor";
-import NameManager from "../NameManager";
 import TokenProcessor from "../TokenProcessor";
 import isMaybePropertyName from "../util/isMaybePropertyName";
 import RootTransformer from "./RootTransformer";
@@ -14,7 +13,6 @@ export default class ImportTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
-    readonly nameManager: NameManager,
     readonly importProcessor: ImportProcessor,
     readonly shouldAddModuleExports: boolean,
   ) {
@@ -324,9 +322,9 @@ export default class ImportTransformer extends Transformer {
     }
     const name = this.tokens.currentToken().value;
     this.tokens.copyToken();
-    if (this.tokens.currentToken().contextName === "typeParameter") {
+    if (this.tokens.currentToken().isType) {
       this.tokens.removeInitialToken();
-      while (this.tokens.currentToken().contextName === "typeParameter") {
+      while (this.tokens.currentToken().isType) {
         this.tokens.removeToken();
       }
     }

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -103,14 +103,14 @@ export default class ReactDisplayNameTransformer extends Transformer {
     // that context. We need to ignore other other contexts to avoid matching
     // nested displayName keys.
     const objectStartIndex = index + 1;
+    const objectContextId = this.tokens.tokens[objectStartIndex].contextId;
+    if (objectContextId == null) {
+      throw new Error("Expected non-null context ID on object open-brace.");
+    }
 
     for (; index < this.tokens.tokens.length; index++) {
       const token = this.tokens.tokens[index];
-      if (
-        token.type.label === "}" &&
-        token.contextName === "object" &&
-        token.contextStartIndex === objectStartIndex
-      ) {
+      if (token.type.label === "}" && token.contextId === objectContextId) {
         index++;
         break;
       }
@@ -118,8 +118,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
       if (
         this.tokens.matchesNameAtIndex(index, "displayName") &&
         this.tokens.tokens[index].identifierRole === IdentifierRole.ObjectKey &&
-        token.contextName === "object" &&
-        token.contextStartIndex === objectStartIndex
+        token.contextId === objectContextId
       ) {
         // We found a displayName key, so bail out.
         return false;

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -142,16 +142,16 @@ export default class TypeScriptTransformer extends Transformer {
       let valueCode;
 
       if (this.tokens.matches(["="])) {
-        const contextStartIndex = this.tokens.currentToken().contextStartIndex!;
+        const rhsEndIndex = this.tokens.currentToken().rhsEndIndex!;
+        if (rhsEndIndex == null) {
+          throw new Error("Expected rhsEndIndex on enum assign.");
+        }
         this.tokens.removeToken();
         if (this.tokens.matches(["string", ","]) || this.tokens.matches(["string", "}"])) {
           valueIsString = true;
         }
         const startToken = this.tokens.currentToken();
-        while (
-          !this.tokens.matchesContextEnd(",", contextStartIndex) &&
-          !this.tokens.matchesContextEnd("}", contextStartIndex)
-        ) {
+        while (this.tokens.currentIndex() < rhsEndIndex) {
           this.tokens.removeToken();
         }
         valueCode = this.tokens.code.slice(

--- a/src/util/formatTokens.ts
+++ b/src/util/formatTokens.ts
@@ -10,7 +10,7 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
     (k) => k !== "updateContext" && k !== "label" && k !== "keyword",
   );
 
-  const headings = ["Location", "Label", "Context", "Value", ...typeKeys];
+  const headings = ["Location", "Label", "Value", ...typeKeys];
 
   const lines = new LinesAndColumns(code);
   const rows = [headings, ...tokens.map(getTokenComponents)];
@@ -28,7 +28,6 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
     return [
       formatRange(token.start, token.end),
       token.type.label,
-      `${token.contextName}(${token.contextStartIndex})`,
       token.value != null ? truncate(String(token.value), 14) : "",
       ...typeKeys.map((key) => {
         const value = token.type[key];

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1726,9 +1726,10 @@ export default (superClass: ParserClass): ParserClass =>
 
     parsePropertyName(
       node: N.ObjectOrClassMember | N.ClassMember | N.TsNamedTypeElementBase,
+      classContextId: number,
     ): N.Identifier {
       const variance = this.flowParseVariance();
-      const key = super.parsePropertyName(node);
+      const key = super.parsePropertyName(node, classContextId);
       // $FlowIgnore ("variance" not defined on TsNamedTypeElementBase)
       // @ts-ignore
       node.variance = variance;
@@ -1745,6 +1746,7 @@ export default (superClass: ParserClass): ParserClass =>
       isPattern: boolean,
       isBlockScope: boolean,
       refShorthandDefaultPos: Pos | null,
+      objectContextId: number,
     ): void {
       if (prop.variance) {
         this.unexpected(prop.variance.start);
@@ -1768,6 +1770,7 @@ export default (superClass: ParserClass): ParserClass =>
         isPattern,
         isBlockScope,
         refShorthandDefaultPos,
+        objectContextId,
       );
 
       // add typeParameters if we found them

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -129,6 +129,8 @@ export class Token {
   parentContextStartIndex?: number | null;
   identifierRole?: IdentifierRole;
   shadowsGlobal?: boolean;
+  contextId?: number;
+  rhsEndIndex?: number;
 }
 
 // ## Tokenizer
@@ -153,12 +155,14 @@ export default abstract class Tokenizer extends LocationParser {
   isLookahead: boolean;
   state: State;
   input: string;
+  nextContextId: number;
 
   constructor(options: Options, input: string) {
     super();
     this.state = new State();
     this.state.init(options, input);
     this.isLookahead = false;
+    this.nextContextId = 1;
   }
 
   // Move to the next token

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -13,21 +13,21 @@ if (foo) {
         {transforms: ["jsx", "imports"]},
       ),
       `\
-Location  Label  Context   Value        beforeExpr startsExpr rightAssociative isLoop isAssign prefix postfix binop
-1:1-1:3   if     block(0)  if                                                                                      
-1:4-1:5   (      parens(1)              beforeExpr startsExpr                                                      
-1:5-1:8   name   parens(1) foo                     startsExpr                                                      
-1:8-1:9   )      parens(1)                                                                                         
-1:10-1:11 {      block(4)               beforeExpr startsExpr                                                      
-2:3-2:10  name   block(4)  console                 startsExpr                                                      
-2:10-2:11 .      block(4)                                                                                          
-2:11-2:14 name   block(4)  log                     startsExpr                                                      
-2:14-2:15 (      parens(8)              beforeExpr startsExpr                                                      
-2:15-2:29 string parens(8) Hello world!            startsExpr                                                      
-2:29-2:30 )      parens(8)                                                                                         
-2:30-2:31 ;      block(4)               beforeExpr                                                                 
-3:1-3:2   }      block(4)                                                                                          
-3:2-3:2   eof    block(0)                                                                                          `,
+Location  Label  Value        beforeExpr startsExpr rightAssociative isLoop isAssign prefix postfix binop
+1:1-1:3   if     if                                                                                      
+1:4-1:5   (                   beforeExpr startsExpr                                                      
+1:5-1:8   name   foo                     startsExpr                                                      
+1:8-1:9   )                                                                                              
+1:10-1:11 {                   beforeExpr startsExpr                                                      
+2:3-2:10  name   console                 startsExpr                                                      
+2:10-2:11 .                                                                                              
+2:11-2:14 name   log                     startsExpr                                                      
+2:14-2:15 (                   beforeExpr startsExpr                                                      
+2:15-2:29 string Hello world!            startsExpr                                                      
+2:29-2:30 )                                                                                              
+2:30-2:31 ;                   beforeExpr                                                                 
+3:1-3:2   }                                                                                              
+3:2-3:2   eof                                                                                            `,
     );
   });
 });


### PR DESCRIPTION
We now carefully put information in the tokens at parse time to handle all cases
where we previously needed contexts, except for class field detection, which
will happen next.