### PR TITLE
Remove all remaining usages of token contexts

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -152,6 +152,10 @@ export default class TokenProcessor {
     this.tokenIndex++;
   }
 
+  previousToken(): void {
+    this.tokenIndex--;
+  }
+
   expectToken(label: string): void {
     if (this.tokens[this.tokenIndex].type.label !== label) {
       throw new Error(`Expected token ${label}`);

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1171,6 +1171,7 @@ export default (superClass: ParserClass): ParserClass =>
       node: N.BodilessFunctionOrMethodBase,
       type: string,
       allowExpressionBody?: boolean,
+      funcContextId?: number,
     ): void {
       // For arrow functions, `parseArrow` handles the return type itself.
       if (!allowExpressionBody && this.match(tt.colon)) {
@@ -1189,7 +1190,7 @@ export default (superClass: ParserClass): ParserClass =>
           : null;
       }
 
-      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody);
+      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody, funcContextId);
     }
 
     // interfaces
@@ -1939,7 +1940,7 @@ export default (superClass: ParserClass): ParserClass =>
     }
 
     // parse function type parameters - function foo<T>() {}
-    parseFunctionParams(node: N.Function): void {
+    parseFunctionParams(node: N.Function, allowModifiers?: boolean, contextId?: number): void {
       // $FlowFixMe
       // @ts-ignore
       const kind = node.kind;
@@ -1948,7 +1949,7 @@ export default (superClass: ParserClass): ParserClass =>
           node.typeParameters = this.flowParseTypeParameterDeclaration();
         });
       }
-      super.parseFunctionParams(node);
+      super.parseFunctionParams(node, allowModifiers, contextId);
     }
 
     // parse flow type annotations on variable declarator heads - let foo: string = bar

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1271,6 +1271,7 @@ export default (superClass: ParserClass): ParserClass =>
       node: N.BodilessFunctionOrMethodBase,
       type: string,
       allowExpressionBody?: boolean,
+      funcContextId?: number,
     ): void {
       // For arrow functions, `parseArrow` handles the return type itself.
       if (!allowExpressionBody && this.match(tt.colon)) {
@@ -1299,7 +1300,7 @@ export default (superClass: ParserClass): ParserClass =>
         return;
       }
 
-      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody);
+      super.parseFunctionBodyAndFinish(node, type, allowExpressionBody, funcContextId);
     }
 
     parseSubscript(
@@ -1731,10 +1732,10 @@ export default (superClass: ParserClass): ParserClass =>
       );
     }
 
-    parseFunctionParams(node: N.Function, allowModifiers?: boolean): void {
+    parseFunctionParams(node: N.Function, allowModifiers?: boolean, contextId?: number): void {
       const typeParameters = this.tsTryParseTypeParameters();
       if (typeParameters) node.typeParameters = typeParameters;
-      super.parseFunctionParams(node, allowModifiers);
+      super.parseFunctionParams(node, allowModifiers, contextId);
     }
 
     // `let x: number;`


### PR DESCRIPTION
This is now entirely replaced with similar targed information computed at the
parse step.