### PR TITLE
Properly detect import usages for TypeScript import pruning

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -99,7 +99,9 @@ export default class ImportProcessor {
       if (
         token.type.label === "name" &&
         !token.isType &&
-        token.identifierRole === IdentifierRole.Access
+        (token.identifierRole === IdentifierRole.Access ||
+          token.identifierRole === IdentifierRole.ObjectShorthand ||
+          token.identifierRole === IdentifierRole.ExportAccess)
       ) {
         nonTypeIdentifiers.add(token.value);
       }

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -1561,6 +1561,7 @@ export default class StatementParser extends ExpressionParser {
 
       const node = this.startNode<N.ExportSpecifier>();
       node.local = this.parseIdentifier(isDefault);
+      this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.ExportAccess;
       node.exported = this.eatContextual("as") ? this.parseIdentifier(true) : node.local.__clone();
       nodes.push(this.finishNode(node, "ExportSpecifier"));
     }

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -96,11 +96,11 @@ export type TokenContext =
 
 export enum IdentifierRole {
   Access,
+  ExportAccess,
   FunctionScopedDeclaration,
   BlockScopedDeclaration,
   ObjectShorthand,
   ObjectKey,
-  Assignment,
 }
 
 // Object type used to represent tokens. Note that normally, tokens

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -623,4 +623,17 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("does not prune imports that are then exported", () => {
+    assertTypeScriptResult(
+      `
+      import A from 'a';
+      export {A};
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      var _a = require('a');
+      exports.A = _a.default;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We previously weren't detecting object shorthand or exported values.