### PR TITLE
Allow keywords in export syntax

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -210,6 +210,7 @@ get: () => ${primaryImportName}[key]}); });`;
 
     index++;
     if (
+      // Ideally "type" would be a token type label, but for now, it's just an identifier.
       (this.tokens.matchesNameAtIndex(index, "type") ||
         this.tokens.matchesAtIndex(index, ["typeof"])) &&
       !this.tokens.matchesAtIndex(index + 1, [","]) &&
@@ -335,7 +336,7 @@ get: () => ${primaryImportName}[key]}); });`;
       // Flow type imports should just be ignored.
       let isTypeImport = false;
       if (
-        (this.tokens.matchesNameAtIndex(index, "type") ||
+        (this.tokens.matchesAtIndex(index, ["type"]) ||
           this.tokens.matchesAtIndex(index, ["typeof"])) &&
         this.tokens.matchesAtIndex(index + 1, ["name"]) &&
         !this.tokens.matchesNameAtIndex(index + 1, "as")

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -1663,6 +1663,7 @@ export default abstract class ExpressionParser extends LValParser {
   parseIdentifier(liberal?: boolean): N.Identifier {
     const node = this.startNode();
     const name = this.parseIdentifierName(node.start, liberal);
+    this.state.tokens[this.state.tokens.length - 1].type = tt.name;
     node.name = name;
     node.loc.identifierName = name;
     return this.finishNode(node as N.Identifier, "Identifier");

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1885,9 +1885,11 @@ export default (superClass: ParserClass): ParserClass =>
 
       let specifierTypeKind = null;
       if (firstIdent.name === "type") {
+        this.state.tokens[this.state.tokens.length - 1].type = tt._type;
         specifierTypeKind = "type";
       } else if (firstIdent.name === "typeof") {
         specifierTypeKind = "typeof";
+        this.state.tokens[this.state.tokens.length - 1].type = tt._typeof;
       }
 
       let isBinding = false;

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -206,6 +206,7 @@ export const keywords = {
   protected: new KeywordTokenType("protected"),
   as: new KeywordTokenType("as"),
   enum: new KeywordTokenType("enum"),
+  type: new KeywordTokenType("type"),
 };
 
 // Map keyword names to token types.

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -262,4 +262,16 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("allows using the import keyword as an export", () => {
+    assertResult(
+      `
+      export {Import as import};
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      exports.import = Import;
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });


### PR DESCRIPTION
This changes semantic tokens to identifiers when we know that they should be
interpreted as plain identifiers, which also required changing it back in one
case when parsing flow imports.