### PR TITLE
Properly handle optional parameters in arrow functions

### DIFF
--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1452,6 +1452,7 @@ export default (superClass: ParserClass): ParserClass =>
     parseParenItem(node: N.Expression, startPos: number, startLoc: Position): N.Expression {
       node = super.parseParenItem(node, startPos, startLoc);
       if (this.eat(tt.question)) {
+        this.state.tokens[this.state.tokens.length - 1].isType = true;
         node.optional = true;
       }
 

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1611,6 +1611,7 @@ export default (superClass: ParserClass): ParserClass =>
     parseParenItem(node: N.Expression, startPos: number, startLoc: Position): N.Expression {
       node = super.parseParenItem(node, startPos, startLoc);
       if (this.eat(tt.question)) {
+        this.state.tokens[this.state.tokens.length - 1].isType = true;
         node.optional = true;
       }
 

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -393,4 +393,15 @@ describe("type transforms", () => {
     `,
     );
   });
+
+  it("handles arrow functions with optional parameters", () => {
+    assertTypeScriptAndFlowResult(
+      `
+      const f = (x?: number) => x + 1;
+    `,
+      `
+      const f = (x) => x + 1;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Previously, these weren't being included in the type range due to the fragile
nature of distinguishing arrow params from a parenthsized expression, but now I
just set the token as a type in that case.