### PR TITLE
Change `export *` implementation to skip already-declared exports

### DIFF
--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -179,8 +179,13 @@ export default class ImportProcessor {
         requireCode += ` exports.${exportStarName} = ${secondaryImportName};`;
       }
       if (hasStarExport) {
+        // Note that TypeScript and Babel do this differently; TypeScript does a simple existence
+        // check in the exports object and does a plain assignment, whereas Babel uses
+        // defineProperty and builds an object of explicitly-exported names so that star exports can
+        // always take lower precedence. For now, we do the easier TypeScript thing.a
         requireCode += ` Object.keys(${primaryImportName}).filter(key => \
 key !== 'default' && key !== '__esModule').forEach(key => { \
+if (exports.hasOwnProperty(key)) { return; } \
 Object.defineProperty(exports, key, {enumerable: true, \
 get: () => ${primaryImportName}[key]}); });`;
       }

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -730,7 +730,7 @@ module.exports = exports.default;
       export * from './MyVars';
     `,
       `${PREFIX}${ESMODULE_PREFIX}
-      var _MyVars = require('./MyVars'); Object.keys(_MyVars).filter(key => key !== 'default' && key !== '__esModule').forEach(key => { Object.defineProperty(exports, key, {enumerable: true, get: () => _MyVars[key]}); });
+      var _MyVars = require('./MyVars'); Object.keys(_MyVars).filter(key => key !== 'default' && key !== '__esModule').forEach(key => { if (exports.hasOwnProperty(key)) { return; } Object.defineProperty(exports, key, {enumerable: true, get: () => _MyVars[key]}); });
     `,
     );
   });


### PR DESCRIPTION
The behavior here is actually slightly different from Babel in that it doesn't
ensure that star exports are lower precedence than explicit exports. TypeScript
takes the same approach I took, so either seems reasonable, and a stricter Babel
mode can be added later.