### PR TITLE
Add support for static class fields

### DIFF
--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -890,6 +890,7 @@ export default class StatementParser extends ExpressionParser {
 
     this.next();
     this.state.tokens[this.state.tokens.length - 1].contextId = contextId;
+    this.state.tokens[this.state.tokens.length - 1].isExpression = !isStatement;
     this.takeDecorators(node);
     // Like with functions, we declare a special "name scope" from the start of the name to the end
     // of the class, but only with expression-style classes, to represent the fact that the name is

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1714,19 +1714,22 @@ export default (superClass: ParserClass): ParserClass =>
         node.superTypeParameters = this.flowParseTypeParameterInstantiation();
       }
       if (this.isContextual("implements")) {
-        this.next();
-        const implemented: Array<N.FlowClassImplements> = [];
-        node.implements = implemented;
-        do {
-          const innerNode = this.startNode();
-          innerNode.id = this.flowParseRestrictedIdentifier(/* liberal */ true);
-          if (this.isRelational("<")) {
-            innerNode.typeParameters = this.flowParseTypeParameterInstantiation();
-          } else {
-            innerNode.typeParameters = null;
-          }
-          implemented.push(this.finishNode(innerNode, "ClassImplements"));
-        } while (this.eat(tt.comma));
+        this.state.tokens[this.state.tokens.length - 1].type = tt._implements;
+        this.runInTypeContext(0, () => {
+          this.next();
+          const implemented: Array<N.FlowClassImplements> = [];
+          node.implements = implemented;
+          do {
+            const innerNode = this.startNode();
+            innerNode.id = this.flowParseRestrictedIdentifier(/* liberal */ true);
+            if (this.isRelational("<")) {
+              innerNode.typeParameters = this.flowParseTypeParameterInstantiation();
+            } else {
+              innerNode.typeParameters = null;
+            }
+            implemented.push(this.finishNode(innerNode, "ClassImplements"));
+          } while (this.eat(tt.comma));
+        });
       }
     }
 

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1701,7 +1701,8 @@ export default (superClass: ParserClass): ParserClass =>
         node.superTypeParameters = this.tsParseTypeArguments();
       }
       if (this.eatContextual("implements")) {
-        node.implements = this.tsParseHeritageClause();
+        this.state.tokens[this.state.tokens.length - 1].type = tt._implements;
+        node.implements = this.runInTypeContext(1, () => this.tsParseHeritageClause());
       }
     }
 

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -128,6 +128,7 @@ export class Token {
   shadowsGlobal?: boolean;
   contextId?: number;
   rhsEndIndex?: number;
+  isExpression?: boolean;
 }
 
 // ## Tokenizer

--- a/sucrase-babylon/tokenizer/types.ts
+++ b/sucrase-babylon/tokenizer/types.ts
@@ -207,6 +207,7 @@ export const keywords = {
   as: new KeywordTokenType("as"),
   enum: new KeywordTokenType("enum"),
   type: new KeywordTokenType("type"),
+  implements: new KeywordTokenType("implements"),
 };
 
 // Map keyword names to token types.

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -274,4 +274,52 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("properly converts static fields in statement classes", () => {
+    assertResult(
+      `
+      class A {
+        static x = 3;
+      }
+    `,
+      `"use strict";
+      class A {
+        
+      } A.x = 3;
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
+
+  it("properly converts static fields in expression classes", () => {
+    assertResult(
+      `
+      const A = class {
+        static x = 3;
+      }
+    `,
+      `"use strict"; var _class;
+      const A = (_class = class {
+        
+      }, _class.x = 3, _class)
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
+
+  it("properly converts exported classes with static fields", () => {
+    assertResult(
+      `
+      export default class C {
+        static x = 3;
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+       class C {
+        
+      } C.x = 3; exports.default = C;
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -17,8 +17,8 @@ describe("type transforms", () => {
       class C extends D implements E {}
     `,
       `
-      class A {}
-      class C extends D {}
+      class A  {}
+      class C extends D  {}
     `,
     );
   });


### PR DESCRIPTION
This hasn't been thoroughly tested, but seems to work. At parse time, I save
whether the class is an expression or a statement, and use that to determine
whether we need to do the comma expression trick. When using a comma expression,
we need to generate a new variable name and also declare it at the top of the
file. For statement classes, we can just add some statements immediately after
the class definition, like we do for exports.