### PR TITLE
Run transform on class field values

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -1,5 +1,10 @@
 import {IdentifierRole, Token} from "../sucrase-babylon/tokenizer";
 
+export type TokenProcessorSnapshot = {
+  resultCode: string;
+  tokenIndex: number;
+};
+
 export default class TokenProcessor {
   private resultCode: string = "";
   private tokenIndex = 0;
@@ -9,10 +14,21 @@ export default class TokenProcessor {
   /**
    * Make a new TokenProcessor for things like lookahead.
    */
-  clone(): TokenProcessor {
-    const result = new TokenProcessor(this.code, this.tokens);
-    result.tokenIndex = this.tokenIndex;
-    return result;
+  snapshot(): TokenProcessorSnapshot {
+    return {resultCode: this.resultCode, tokenIndex: this.tokenIndex};
+  }
+
+  restoreToSnapshot(snapshot: TokenProcessorSnapshot): void {
+    this.resultCode = snapshot.resultCode;
+    this.tokenIndex = snapshot.tokenIndex;
+  }
+
+  getResultCodeIndex(): number {
+    return this.resultCode.length;
+  }
+
+  getCodeInsertedSinceIndex(initialResultCodeIndex: number): string {
+    return this.resultCode.slice(initialResultCodeIndex);
   }
 
   reset(): void {

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -125,7 +125,7 @@ export default class RootTransformer {
   }
 
   processClass(): void {
-    const classInfo = getClassInfo(this.tokens);
+    const classInfo = getClassInfo(this, this.tokens);
 
     const needsCommaExpression =
       classInfo.headerInfo.isExpression && classInfo.staticInitializerSuffixes.length > 0;

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -322,4 +322,26 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("properly resolves imported names in class fields", () => {
+    assertResult(
+      `
+      import A from 'A';
+      import B from 'B';
+      class C {
+        a = A;
+        static b = B;
+      }
+    `,
+      `"use strict";
+      var _A = require('A');
+      var _B = require('B');
+      class C {constructor() { this.a = (0, _A.default); }
+        
+        
+      } C.b = (0, _B.default);
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });


### PR DESCRIPTION
Class field values might have import references, type annotations, etc, so we
need to run them through the transform step. We do this by adding code in sort
of a "dry run", and then restoring to the original code later.