### PR TITLE
Properly handle code starting with a shebang

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -66,7 +66,17 @@ export default class RootTransformer {
     for (const transformer of this.transformers) {
       suffix += transformer.getSuffixCode();
     }
-    return prefix + this.tokens.finish() + suffix;
+    let code = this.tokens.finish();
+    if (code.startsWith("#!")) {
+      let newlineIndex = code.indexOf("\n");
+      if (newlineIndex === -1) {
+        newlineIndex = code.length;
+        code += "\n";
+      }
+      return code.slice(0, newlineIndex + 1) + prefix + code.slice(newlineIndex + 1) + suffix;
+    } else {
+      return prefix + this.tokens.finish() + suffix;
+    }
   }
 
   processBalancedCode(): void {

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -344,4 +344,16 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("puts the prefix after a shebang if necessary", () => {
+    assertResult(
+      `#!/usr/bin/env node
+      console.log("Hello");
+    `,
+      `#!/usr/bin/env node
+"use strict";      console.log("Hello");
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });


### PR DESCRIPTION
The prefix that we add should be on the second line in that case.