### PR TITLE
Implement optional catch binding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const DEFAULT_BABYLON_PLUGINS = [
   "classProperties",
   "exportNamespaceFrom",
   "numericSeparator",
+  "optionalCatchBinding",
 ];
 
 export type Transform =

--- a/src/transformers/OptionalCatchBindingTransformer.ts
+++ b/src/transformers/OptionalCatchBindingTransformer.ts
@@ -1,0 +1,17 @@
+import NameManager from "../NameManager";
+import TokenProcessor from "../TokenProcessor";
+import Transformer from "./Transformer";
+
+export default class OptionalCatchBindingTransformer extends Transformer {
+  constructor(readonly tokens: TokenProcessor, readonly nameManager: NameManager) {
+    super();
+  }
+
+  process(): boolean {
+    if (this.tokens.matches(["catch", "{"])) {
+      this.tokens.copyToken();
+      this.tokens.appendCode(` (${this.nameManager.claimFreeName("e")})`);
+    }
+    return false;
+  }
+}

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -6,6 +6,7 @@ import FlowTransformer from "./FlowTransformer";
 import ImportTransformer from "./ImportTransformer";
 import JSXTransformer from "./JSXTransformer";
 import NumericSeparatorTransformer from "./NumericSeparatorTransformer";
+import OptionalCatchBindingTransformer from "./OptionalCatchBindingTransformer";
 import ReactDisplayNameTransformer from "./ReactDisplayNameTransformer";
 import Transformer from "./Transformer";
 import TypeScriptTransformer from "./TypeScriptTransformer";
@@ -22,6 +23,7 @@ export default class RootTransformer {
     this.tokens = tokenProcessor;
 
     this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
+    this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
     if (transforms.includes("jsx")) {
       this.transformers.push(new JSXTransformer(this, tokenProcessor, importProcessor));
     }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -356,4 +356,26 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("handles optional catch binding", () => {
+    assertResult(
+      `
+      const e = 3;
+      try {
+        console.log(e);
+      } catch {
+        console.log("Failed!");
+      }
+    `,
+      `"use strict";
+      const e = 3;
+      try {
+        console.log(e);
+      } catch (e2) {
+        console.log("Failed!");
+      }
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -7,7 +7,10 @@ import {TRANSFORMS} from "./Constants";
 import {compressCode} from "./URLHashState";
 import getTokens from "./getTokens";
 Babel.registerPlugin("add-module-exports", require("babel-plugin-add-module-exports"));
-Babel.registerPlugin("proposal-numeric-separator", require("@babel/plugin-proposal-numeric-separator"));
+Babel.registerPlugin(
+  "proposal-numeric-separator",
+  require("@babel/plugin-proposal-numeric-separator"),
+);
 
 let config = null;
 
@@ -67,7 +70,12 @@ function runBabel() {
     () =>
       Babel.transform(config.code, {
         presets: babelPresets,
-        plugins: [...babelPlugins, "proposal-export-namespace-from", "proposal-numeric-separator"],
+        plugins: [
+          ...babelPlugins,
+          "proposal-export-namespace-from",
+          "proposal-numeric-separator",
+          "proposal-optional-catch-binding",
+        ],
         parserOpts: {plugins: ["jsx", "classProperties", "numericSeparator"]},
       }).code,
   );


### PR DESCRIPTION
This is allowed by TypeScript and is easy to implement, so it seems reasonable
to just always include it.