### PR TITLE
Mark this type declarations as type tokens

### DIFF
--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -224,11 +224,21 @@ export default abstract class LValParser extends NodeUtils {
   ): ReadonlyArray<Pattern | TSParameterProperty> {
     const elts: Array<Pattern | TSParameterProperty> = [];
     let first = true;
+
+    let hasRemovedComma = false;
+    const firstItemTokenIndex = this.state.tokens.length;
+
     while (!this.eat(close)) {
       if (first) {
         first = false;
       } else {
         this.expect(tt.comma);
+        // After a "this" type in TypeScript, we need to set the following comma (if any) to also be
+        // a type token so that it will be removed.
+        if (!hasRemovedComma && this.state.tokens[firstItemTokenIndex].isType) {
+          this.state.tokens[this.state.tokens.length - 1].isType = true;
+          hasRemovedComma = true;
+        }
       }
       if (allowEmpty && this.match(tt.comma)) {
         // $FlowFixMe This method returns `ReadonlyArray<?Pattern>` if `allowEmpty` is set.

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1954,7 +1954,7 @@ export default (superClass: ParserClass): ParserClass =>
       switch (this.state.type) {
         case tt._this:
           // "this" may be the name of a parameter, so allow it.
-          return this.parseIdentifier(/* liberal */ true);
+          return this.runInTypeContext(0, () => this.parseIdentifier(/* liberal */ true));
         default:
           return super.parseBindingAtom(isBlockScope);
       }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -651,4 +651,19 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows this types in functions", () => {
+    assertTypeScriptResult(
+      `
+      function foo(this: number, x: number): number {
+        return this + x;
+      }
+    `,
+      `"use strict";
+      function foo( x) {
+        return this + x;
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This is a little tricky in that we need to also mark the following comma as a
type, but we can do this by adding some special-case code to the assignment list
code.