### PR TITLE
Update TSLint fixture to fix build

### DIFF
--- a/example-runner/example-configs/tslint.patch
+++ b/example-runner/example-configs/tslint.patch
@@ -20,3 +20,55 @@ index 826ad87f..f4cdb8db 100644
      "test:pre": "cd ./test/config && npm install --no-save",
      "test:mocha": "mocha --reporter spec --colors \"build/test/**/*Tests.js\"",
      "test:rules": "node ./build/test/ruleTestRunner.js",
+diff --git a/test/executable/executableTests.ts b/test/executable/executableTests.ts
+index a5affd2b..c5481e45 100644
+--- a/test/executable/executableTests.ts
++++ b/test/executable/executableTests.ts
+@@ -141,6 +141,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
+                     cwd: "./test/config",
+                 },
+                 (err, stdout) => {
++                    console.log(`err is ${err}`);
+                     assert.isNotNull(err, "process should exit with error");
+                     assert.strictEqual(err.code, 2, "error code should be 2");
+                     assert.include(stdout, "hello from custom formatter", "stdout should contain output of custom formatter");
+diff --git a/test/files/custom-rules/alwaysFailRule.js b/test/files/custom-rules/alwaysFailRule.js
+index 4f1b0bf7..049d4f31 100644
+--- a/test/files/custom-rules/alwaysFailRule.js
++++ b/test/files/custom-rules/alwaysFailRule.js
+@@ -1,27 +1,12 @@
+-var __extends = (this && this.__extends) || function (d, b) {
+-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+-    function __() { this.constructor = d; }
+-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+-};
+ var Lint = require('../../../lib/index');
+-var Rule = (function (_super) {
+-    __extends(Rule, _super);
+-    function Rule() {
+-        _super.apply(this, arguments);
+-    }
+-    Rule.prototype.apply = function (sourceFile) {
++class Rule extends Lint.Rules.AbstractRule {
++    apply(sourceFile) {
+         return this.applyWithWalker(new AlwaysFailWalker(sourceFile, this.getOptions()));
+-    };
+-    return Rule;
+-})(Lint.Rules.AbstractRule);
+-exports.Rule = Rule;
+-var AlwaysFailWalker = (function (_super) {
+-    __extends(AlwaysFailWalker, _super);
+-    function AlwaysFailWalker() {
+-        _super.apply(this, arguments);
+     }
+-    AlwaysFailWalker.prototype.visitSourceFile = function (node) {
++}
++exports.Rule = Rule;
++class AlwaysFailWalker extends Lint.RuleWalker {
++    visitSourceFile(node) {
+         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "failure"));
+-    };
+-    return AlwaysFailWalker;
+-})(Lint.RuleWalker);
++    }
++}


### PR DESCRIPTION
A fixture was using old-style inheritance, which was crashing when used with
ES2015 classes.