### PR TITLE
Fix token marking in object shorthand case

### DIFF
--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -922,4 +922,25 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("properly handles object destructuring with imported names", () => {
+    assertResult(
+      `
+      import a from 'a';
+      const {b = a} = {};
+      if (true) {
+        const {a} = {};
+        console.log(a);
+      }
+    `,
+      `${PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      const {b = (0, _a2.default)} = {};
+      if (true) {
+        const {a} = {};
+        console.log(a);
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
We want to mark the key, not the default value, and if it's a pattern, we want
to mark whether it's block scoped or not rather than calling it an object
shorthand.