### PR TITLE
Get rid of some unnecessary node creation

### DIFF
--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -1575,36 +1575,7 @@ export default abstract class ExpressionParser extends LValParser {
     }
     this.state.inAsync = oldInAsync;
 
-    this.checkFunctionNameAndParams(node, allowExpression);
     this.state.inParameters = oldInParameters;
-  }
-
-  checkFunctionNameAndParams(node: N.Function, isArrowFunction: boolean | null): void {
-    // If this is a strict mode function, verify that argument names
-    // are not repeated, and it does not try to bind the words `eval`
-    // or `arguments`.
-    const isStrict = this.isStrictBody(node);
-    // Also check for arrow functions
-    const checkLVal = this.state.strict || isStrict || isArrowFunction;
-
-    const oldStrict = this.state.strict;
-    if (isStrict) this.state.strict = isStrict;
-    if (node.id) {
-      this.checkReservedWord(node.id.name, node.start, true, true);
-    }
-    if (checkLVal) {
-      const nameHash: {} = Object.create(null);
-      if (node.id) {
-        this.checkLVal(node.id, true, null, "function name");
-      }
-      for (const param of node.params) {
-        if (isStrict && param.type !== "Identifier") {
-          this.raise(param.start, "Non-simple parameter in strict mode");
-        }
-        this.checkLVal(param, true, nameHash, "function parameter list");
-      }
-    }
-    this.state.strict = oldStrict;
   }
 
   // Parses a comma-separated list of expressions, and returns them as

--- a/sucrase-babylon/parser/index.ts
+++ b/sucrase-babylon/parser/index.ts
@@ -28,10 +28,8 @@ export default class Parser extends StatementParser {
   }
 
   parse(): File {
-    const file = this.startNode<File>();
-    const program = this.startNode<Program>();
     this.nextToken();
-    return this.parseTopLevel(file, program);
+    return this.parseTopLevel();
   }
 }
 

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1399,8 +1399,6 @@ export default (superClass: ParserClass): ParserClass =>
               true,
               "arrow function parameters",
             );
-            // Use super's method to force the parameters to be checked
-            super.checkFunctionNameAndParams(innerNode as N.Function, true);
           } else {
             arrows.push(innerNode as N.ArrowFunctionExpression);
           }
@@ -2119,14 +2117,6 @@ export default (superClass: ParserClass): ParserClass =>
       } else {
         super.setArrowFunctionParameters(node, params);
       }
-    }
-
-    checkFunctionNameAndParams(node: N.Function, isArrowFunction: boolean | null): void {
-      if (isArrowFunction && this.state.noArrowParamsConversionAt.indexOf(node.start) !== -1) {
-        return;
-      }
-
-      super.checkFunctionNameAndParams(node, isArrowFunction);
     }
 
     parseParenAndDistinguishExpression(canBeArrow: boolean): N.Expression {

--- a/sucrase-babylon/types.ts
+++ b/sucrase-babylon/types.ts
@@ -92,9 +92,7 @@ export type BigIntLiteral = NodeBase & {
 
 export type BlockStatementLike = Program | BlockStatement;
 
-export type File = NodeBase & {
-  type: "File";
-  program: Program;
+export type File = {
   tokens: Array<Token>;
   scopes: Array<Scope>;
 };


### PR DESCRIPTION
Block nodes were needed to do additional strict mode checks, but we can skip
those because we assume that the code is verified externally.