### PR TITLE
Remove strict mode checks

### DIFF
--- a/sucrase-babylon/options.ts
+++ b/sucrase-babylon/options.ts
@@ -9,7 +9,6 @@ export type Options = {
   allowImportExportEverywhere: boolean;
   allowSuperOutsideMethod: boolean;
   plugins: ReadonlyArray<string>;
-  strictMode: boolean | null;
   ranges: boolean;
   tokens: boolean;
 };
@@ -34,8 +33,6 @@ export const defaultOptions: Options = {
   allowSuperOutsideMethod: false,
   // An array of plugins to enable
   plugins: [],
-  // TODO
-  strictMode: null,
   // Nodes have their start and end characters offsets recorded in
   // `start` and `end` properties (directly on the node, rather than
   // the `loc` object, which holds line/column data. To also add a

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -333,14 +333,6 @@ export default abstract class ExpressionParser extends LValParser {
 
       if (update) {
         this.checkLVal(node.argument, null, null, "prefix operation");
-      } else if (this.state.strict && node.operator === "delete") {
-        const arg = node.argument;
-
-        if (arg.type === "Identifier") {
-          this.raise(node.start, "Deleting local variable in strict mode");
-        } else if (arg.type === "MemberExpression" && arg.property.type === "PrivateName") {
-          this.raise(node.start, "Deleting a private field is not allowed");
-        }
       }
 
       return this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
@@ -662,8 +654,7 @@ export default abstract class ExpressionParser extends LValParser {
         const startTokenIndex = this.state.tokens.length;
         node = this.startNode();
         const allowAwait = this.state.value === "await" && this.state.inAsync;
-        const allowYield = this.shouldAllowYieldIdentifier();
-        const id = this.parseIdentifier(allowAwait || allowYield);
+        const id = this.parseIdentifier(allowAwait);
 
         if (id.name === "await") {
           if (this.state.inAsync || this.inModule) {

--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -174,12 +174,8 @@ export default abstract class LValParser extends NodeUtils {
     return this.finishNode(node as RestElement, "RestElement");
   }
 
-  shouldAllowYieldIdentifier(): boolean {
-    return this.match(tt._yield) && !this.state.strict && !this.state.inGenerator;
-  }
-
   parseBindingIdentifier(): Identifier {
-    return this.parseIdentifier(this.shouldAllowYieldIdentifier());
+    return this.parseIdentifier();
   }
 
   // Parses lvalue (assignable) atom.

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -1199,8 +1199,7 @@ export default (superClass: ParserClass): ParserClass =>
 
     // interfaces
     parseStatement(declaration: boolean, topLevel?: boolean): N.Statement {
-      // strict mode handling of `interface` since it's a reserved word
-      if (this.state.strict && this.match(tt.name) && this.state.value === "interface") {
+      if (this.match(tt.name) && this.state.value === "interface") {
         const node = this.startNode();
         return this.runInTypeContext(0, () => {
           this.next();

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -881,12 +881,7 @@ export default (superClass: ParserClass): ParserClass =>
       const node: N.TsModuleBlock = this.startNode();
       this.expect(tt.braceL);
       // Inside of a module block is considered "top-level", meaning it can have imports and exports.
-      this.parseBlockOrModuleBlockBody(
-        (node.body = []),
-        /* directives */ null,
-        /* topLevel */ true,
-        /* end */ tt.braceR,
-      );
+      this.parseBlockOrModuleBlockBody(/* topLevel */ true, /* end */ tt.braceR);
       return this.finishNode(node, "TSModuleBlock");
     }
 

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -21,8 +21,6 @@ export type Scope = {
 
 export default class State {
   init(options: Options, input: string): void {
-    this.strict = options.strictMode === false ? false : options.sourceType === "module";
-
     this.input = input;
 
     this.potentialArrowAt = -1;
@@ -76,12 +74,7 @@ export default class State {
     this.exprAllowed = true;
 
     this.containsEsc = false;
-    this.containsOctal = false;
-    this.octalPosition = null;
   }
-
-  // TODO
-  strict: boolean;
 
   // TODO
   input: string;
@@ -177,10 +170,6 @@ export default class State {
   // contained any escape sequences. This is needed because words with
   // escape sequences must not be interpreted as keywords.
   containsEsc: boolean;
-
-  // TODO
-  containsOctal: boolean;
-  octalPosition: number | null;
 
   curPosition(): Position {
     return new Position(this.curLine, this.pos - this.lineStart);


### PR DESCRIPTION
We already assumed that we were parsing in a module context, which seems
reasonable for all modern code, so assume that strict mode is enabled and
remove strict mode checks and parsing for non-strict-mode features.