### PR TITLE
Fix import replacement for arrow function params

### DIFF
--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -3,7 +3,6 @@ import {TokenType, types as tt} from "../tokenizer/types";
 import {
   ArrayPattern,
   AssignmentPattern,
-  Decorator,
   Expression,
   Identifier,
   Node,

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -943,4 +943,23 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("properly handles arrow functions with parameters shadowing imported names", () => {
+    assertResult(
+      `
+      import a from 'a';
+      const f = (a, b);
+      const g = (a, b) => c;
+      const h = a => c;
+      const f2 = async (a) => c;
+    `,
+      `${PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      const f = ((0, _a2.default), b);
+      const g = (a, b) => c;
+      const h = a => c;
+      const f2 = async (a) => c;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Arrow functions are parsed in a special way in Babylon where they are parsed as
comma expressions, then changed to a parameter list if it sees an arrow. The AST
is properly corrected, but the tokens aren't, so tokens weren't being marked as
declarations. This changes the strategy to backtrack if we see an arrow. This
requires another state.clone, but hopefully I can make that more efficient (or
unnecessary), and it should make it easier to get rid of node creation.