### PR TITLE
Remove lots of node-handling code within expression parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,7 @@ import TokenProcessor from "./TokenProcessor";
 import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
 
-const DEFAULT_BABYLON_PLUGINS = [
-  "objectRestSpread",
-  "classProperties",
-  "numericSeparator",
-  "dynamicImport",
-];
+const DEFAULT_BABYLON_PLUGINS = ["objectRestSpread", "classProperties", "numericSeparator"];
 
 export type Transform =
   | "jsx"

--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -24,7 +24,7 @@ export default abstract class LValParser extends NodeUtils {
     refShorthandDefaultPos?: Pos | null,
     afterLeftParse?: Function,
     refNeedsArrowPos?: Pos | null,
-  ): Expression;
+  ): void;
   abstract parseObj<T extends ObjectPattern | ObjectExpression>(
     isPattern: boolean,
     isBlockScope: boolean,
@@ -38,7 +38,7 @@ export default abstract class LValParser extends NodeUtils {
   parseSpread<T extends RestElement | SpreadElement>(refShorthandDefaultPos: Pos | null): T {
     const node = this.startNode();
     this.next();
-    node.argument = this.parseMaybeAssign(false, refShorthandDefaultPos);
+    this.parseMaybeAssign(false, refShorthandDefaultPos);
     return this.finishNode(node as T, "SpreadElement");
   }
 

--- a/sucrase-babylon/plugins/jsx/index.ts
+++ b/sucrase-babylon/plugins/jsx/index.ts
@@ -260,14 +260,16 @@ export default (superClass: ParserClass): ParserClass =>
 
     // Parses any type of JSX attribute value.
 
-    jsxParseAttributeValue(): N.Expression {
+    jsxParseAttributeValue(): void {
       switch (this.state.type) {
         case tt.braceL:
-          return this.jsxParseExpressionContainer();
+          this.jsxParseExpressionContainer();
+          return;
 
         case tt.jsxTagStart:
         case tt.string:
-          return this.parseExprAtom();
+          this.parseExprAtom();
+          return;
 
         default:
           throw this.raise(
@@ -323,7 +325,9 @@ export default (superClass: ParserClass): ParserClass =>
         return this.finishNode(node, "JSXSpreadAttribute");
       }
       node.name = this.jsxParseNamespacedName();
-      node.value = this.eat(tt.eq) ? this.jsxParseAttributeValue() : null;
+      if (this.eat(tt.eq)) {
+        this.jsxParseAttributeValue();
+      }
       return this.finishNode(node, "JSXAttribute");
     }
 
@@ -460,11 +464,14 @@ export default (superClass: ParserClass): ParserClass =>
     // Overrides
     // ==================================
 
-    parseExprAtom(refShortHandDefaultPos: Pos | null = null): N.Expression {
+    // Returns true if this was an arrow function.
+    parseExprAtom(refShortHandDefaultPos: Pos | null = null): boolean {
       if (this.match(tt.jsxText)) {
-        return this.parseLiteral(this.state.value, "JSXText");
+        this.parseLiteral(this.state.value, "JSXText");
+        return false;
       } else if (this.match(tt.jsxTagStart)) {
-        return this.jsxParseElement();
+        this.jsxParseElement();
+        return false;
       } else {
         return super.parseExprAtom(refShortHandDefaultPos);
       }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -390,4 +390,16 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  it("handles prefix operators with a parenthesized operand", () => {
+    assertResult(
+      `
+      const x = +(y);
+    `,
+      `"use strict";
+      const x = +(y);
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });


### PR DESCRIPTION
We need to propagate whether or not the parsed value is an arrow function, and
there were a few hopefully-safe shortcuts to avoid the need to pass nodes
around, but it all seems to work.