### PR TITLE
Remove move unnecessary state fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,6 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
   }
   const file = parse(code, {
     tokens: true,
-    sourceType: "module",
     plugins: babylonPlugins,
   });
   const tokens = file.tokens;

--- a/sucrase-babylon/options.ts
+++ b/sucrase-babylon/options.ts
@@ -2,7 +2,6 @@
 // the parser process. These options are recognized:
 
 export type Options = {
-  sourceType: "script" | "module";
   sourceFilename?: string;
   startLine: number;
   allowReturnOutsideFunction: boolean;
@@ -15,8 +14,7 @@ export type Options = {
 export type InputOptions = {[O in keyof Options]?: Options[O]};
 
 export const defaultOptions: Options = {
-  // Source type ("script" or "module") for different semantics
-  sourceType: "script",
+  // Note that sourceType is missing because assume we're always in a module.
   // Source filename.
   sourceFilename: undefined,
   // Line from which to start counting source. Useful for

--- a/sucrase-babylon/parser/base.ts
+++ b/sucrase-babylon/parser/base.ts
@@ -6,7 +6,6 @@ import State from "../tokenizer/state";
 export default class BaseParser {
   // Properties set by constructor in index.js
   options: Options;
-  inModule: boolean;
   plugins: {[key: string]: boolean};
   filename: string | null | undefined;
 

--- a/sucrase-babylon/parser/index.ts
+++ b/sucrase-babylon/parser/index.ts
@@ -20,7 +20,6 @@ export default class Parser extends StatementParser {
     super(options, input);
 
     this.options = options;
-    this.inModule = this.options.sourceType === "module";
     this.input = input;
     this.plugins = pluginsMap(this.options.plugins);
     this.filename = options.sourceFilename;

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -241,8 +241,7 @@ export default class StatementParser extends ExpressionParser {
     this.next();
 
     let forAwait = false;
-    if (this.state.inAsync && this.isContextual("await")) {
-      this.expectPlugin("asyncGenerators");
+    if (this.isContextual("await")) {
       forAwait = true;
       this.next();
     }
@@ -298,10 +297,6 @@ export default class StatementParser extends ExpressionParser {
   }
 
   parseReturnStatement(): void {
-    if (!this.state.inFunction && !this.options.allowReturnOutsideFunction) {
-      this.raise(this.state.start, "'return' outside of function");
-    }
-
     this.next();
 
     // In `return` (and `break`/`continue`), the keywords with
@@ -485,9 +480,7 @@ export default class StatementParser extends ExpressionParser {
     isAsync: boolean = false,
     optionalId?: boolean,
   ): void {
-    const oldInFunc = this.state.inFunction;
     const oldInGenerator = this.state.inGenerator;
-    this.state.inFunction = true;
 
     let isGenerator = false;
     if (this.match(tt.star)) {
@@ -540,14 +533,10 @@ export default class StatementParser extends ExpressionParser {
       });
     }
 
-    this.state.inFunction = oldInFunc;
     this.state.inGenerator = oldInGenerator;
   }
 
   parseFunctionParams(allowModifiers?: boolean, funcContextId?: number): void {
-    const oldInParameters = this.state.inParameters;
-    this.state.inParameters = true;
-
     this.expect(tt.parenL);
     this.state.tokens[this.state.tokens.length - 1].contextId = funcContextId;
     this.parseBindingList(
@@ -557,8 +546,6 @@ export default class StatementParser extends ExpressionParser {
       allowModifiers,
     );
     this.state.tokens[this.state.tokens.length - 1].contextId = funcContextId;
-
-    this.state.inParameters = oldInParameters;
   }
 
   // Parse a class declaration or literal (depending on the
@@ -727,7 +714,6 @@ export default class StatementParser extends ExpressionParser {
   parsePostMemberNameModifiers(): void {}
 
   parseClassProperty(): void {
-    this.state.inClassProperty = true;
     if (this.match(tt.eq)) {
       const equalsTokenIndex = this.state.tokens.length;
       this.next();
@@ -735,7 +721,6 @@ export default class StatementParser extends ExpressionParser {
       this.state.tokens[equalsTokenIndex].rhsEndIndex = this.state.tokens.length;
     }
     this.semicolon();
-    this.state.inClassProperty = false;
   }
 
   parseClassId(isStatement: boolean, optionalId: boolean = false): void {

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -474,18 +474,6 @@ export default abstract class Tokenizer extends BaseParser {
     const next = this.input.charCodeAt(this.state.pos + 1);
 
     if (next === code) {
-      if (
-        next === charCodes.dash &&
-        !this.inModule &&
-        this.input.charCodeAt(this.state.pos + 2) === charCodes.greaterThan &&
-        lineBreak.test(this.input.slice(this.state.lastTokEnd, this.state.pos))
-      ) {
-        // A `-->` line comment
-        this.skipLineComment(3);
-        this.skipSpace();
-        this.nextToken();
-        return;
-      }
       this.finishOp(tt.incDec, 2);
       return;
     }
@@ -513,20 +501,6 @@ export default abstract class Tokenizer extends BaseParser {
         return;
       }
       this.finishOp(tt.bitShift, size);
-      return;
-    }
-
-    if (
-      next === charCodes.exclamationMark &&
-      code === charCodes.lessThan &&
-      !this.inModule &&
-      this.input.charCodeAt(this.state.pos + 2) === charCodes.dash &&
-      this.input.charCodeAt(this.state.pos + 3) === charCodes.dash
-    ) {
-      // `<!--`, an XML-style comment that should be interpreted as a line comment
-      this.skipLineComment(4);
-      this.skipSpace();
-      this.nextToken();
       return;
     }
 

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -16,13 +16,9 @@ export default class State {
 
     this.potentialArrowAt = -1;
 
-    this.inFunction = false;
-    this.inParameters = false;
     this.inGenerator = false;
-    this.inAsync = false;
     this.inPropertyName = false;
     this.inType = false;
-    this.inClassProperty = false;
     this.noAnonFunctionType = false;
 
     this.tokens = [];
@@ -49,15 +45,14 @@ export default class State {
   // Used to signify the start of a potential arrow function
   potentialArrowAt: number;
 
-  // Flags to track whether we are in a function, a generator.
-  inFunction: boolean;
-  inParameters: boolean;
+  // yield is treated differently in a generator, and can be a variable name outside a generator.
   inGenerator: boolean;
-  inAsync: boolean;
+  // We need to skip JSX within a type context.
   inType: boolean;
+  // Used by Flow to handle an edge case involving funtion type parsing.
   noAnonFunctionType: boolean;
+  // Used by JSX to skip JSX parsing in property names.
   inPropertyName: boolean;
-  inClassProperty: boolean;
 
   // Token store.
   tokens: Array<Token>;

--- a/test/scopes-test.ts
+++ b/test/scopes-test.ts
@@ -3,7 +3,7 @@ import {parse} from "../sucrase-babylon";
 import {Scope} from "../sucrase-babylon/tokenizer/state";
 
 function assertScopes(code: string, expectedScopes: Array<Scope>): void {
-  assert.deepEqual(parse(code, {tokens: true, sourceType: "module"}).scopes, expectedScopes);
+  assert.deepEqual(parse(code, {tokens: true}).scopes, expectedScopes);
 }
 
 describe("scopes", () => {

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -6,7 +6,7 @@ type SimpleToken = Token & {label?: string};
 type TokenExpectation = {[K in keyof SimpleToken]?: SimpleToken[K]};
 
 function assertTokens(code: string, expectedTokens: Array<TokenExpectation>): void {
-  const tokens: Array<SimpleToken> = parse(code, {tokens: true, sourceType: "module"}).tokens;
+  const tokens: Array<SimpleToken> = parse(code, {tokens: true}).tokens;
   for (const token of tokens) {
     token.label = token.type.label;
   }


### PR DESCRIPTION
We assume we're in a module, which means we can make some simplify some
assumptions, like "await" is always reserved.