### PR TITLE
Improve performance of state snapshotting

### DIFF
--- a/sucrase-babylon/parser/base.ts
+++ b/sucrase-babylon/parser/base.ts
@@ -28,7 +28,7 @@ export default class BaseParser {
       loc = {line: 0, column: 0};
     }
     message += ` (${loc.line}:${loc.column})`;
-    // tslint:disable no-any
+    // tslint:disable-next-line no-any
     const err: any = new SyntaxError(message);
     err.pos = pos;
     err.loc = loc;

--- a/sucrase-babylon/parser/util.ts
+++ b/sucrase-babylon/parser/util.ts
@@ -38,7 +38,7 @@ export default class UtilParser extends Tokenizer {
   }
 
   isLookaheadContextual(name: string): boolean {
-    const l = this.lookahead();
+    const l = this.lookaheadTypeAndValue();
     return l.type === tt.name && l.value === name;
   }
 

--- a/sucrase-babylon/plugins/jsx/index.ts
+++ b/sucrase-babylon/plugins/jsx/index.ts
@@ -307,7 +307,7 @@ export default (superClass: ParserClass): ParserClass =>
               break;
 
             case tt.braceL:
-              if (this.lookahead().type === tt.ellipsis) {
+              if (this.lookaheadType() === tt.ellipsis) {
                 this.jsxParseSpreadChild();
               } else {
                 this.jsxParseExpressionContainer();

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -211,17 +211,26 @@ export default abstract class Tokenizer extends BaseParser {
 
   // TODO
 
-  lookahead(): State {
-    const old = this.state;
-    this.state = old.clone(true);
-
+  lookaheadType(): TokenType {
+    const snapshot = this.state.snapshot();
     this.isLookahead = true;
     this.next();
+    const type = this.state.type;
     this.isLookahead = false;
+    this.state.restoreFromSnapshot(snapshot);
+    return type;
+  }
 
-    const curr = this.state;
-    this.state = old;
-    return curr;
+  // tslint:disable-next-line no-any
+  lookaheadTypeAndValue(): {type: TokenType; value: any} {
+    const snapshot = this.state.snapshot();
+    this.isLookahead = true;
+    this.next();
+    const type = this.state.type;
+    const value = this.state.value;
+    this.isLookahead = false;
+    this.state.restoreFromSnapshot(snapshot);
+    return {type, value};
   }
 
   curContext(): TokContext {

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -10,6 +10,26 @@ export type Scope = {
   endTokenIndex: number;
 };
 
+export type StateSnapshot = {
+  potentialArrowAt: number;
+  inGenerator: boolean;
+  inType: boolean;
+  noAnonFunctionType: boolean;
+  inPropertyName: boolean;
+  tokensLength: number;
+  scopesLength: number;
+  pos: number;
+  type: TokenType;
+  // tslint:disable-next-line: no-any
+  value: any;
+  start: number;
+  end: number;
+  isType: boolean;
+  lastTokEnd: number;
+  context: Array<TokContext>;
+  exprAllowed: boolean;
+};
+
 export default class State {
   init(options: Options, input: string): void {
     this.input = input;
@@ -86,19 +106,44 @@ export default class State {
   context: Array<TokContext>;
   exprAllowed: boolean;
 
-  clone(skipArrays?: boolean): State {
-    const state = new State();
-    Object.keys(this).forEach((key) => {
-      // $FlowIgnore
-      let val = this[key];
+  snapshot(): StateSnapshot {
+    return {
+      potentialArrowAt: this.potentialArrowAt,
+      inGenerator: this.inGenerator,
+      inType: this.inType,
+      noAnonFunctionType: this.noAnonFunctionType,
+      inPropertyName: this.inPropertyName,
+      tokensLength: this.tokens.length,
+      scopesLength: this.scopes.length,
+      pos: this.pos,
+      type: this.type,
+      // tslint:disable-next-line: no-any
+      value: this.value,
+      start: this.start,
+      end: this.end,
+      isType: this.isType,
+      lastTokEnd: this.lastTokEnd,
+      context: this.context.slice(),
+      exprAllowed: this.exprAllowed,
+    };
+  }
 
-      if ((!skipArrays || key === "context") && Array.isArray(val)) {
-        val = val.slice();
-      }
-
-      // $FlowIgnore
-      state[key] = val;
-    });
-    return state;
+  restoreFromSnapshot(snapshot: StateSnapshot): void {
+    this.potentialArrowAt = snapshot.potentialArrowAt;
+    this.inGenerator = snapshot.inGenerator;
+    this.inType = snapshot.inType;
+    this.noAnonFunctionType = snapshot.noAnonFunctionType;
+    this.inPropertyName = snapshot.inPropertyName;
+    this.tokens.length = snapshot.tokensLength;
+    this.scopes.length = snapshot.scopesLength;
+    this.pos = snapshot.pos;
+    this.type = snapshot.type;
+    this.value = snapshot.value;
+    this.start = snapshot.start;
+    this.end = snapshot.end;
+    this.isType = snapshot.isType;
+    this.lastTokEnd = snapshot.lastTokEnd;
+    this.context = snapshot.context;
+    this.exprAllowed = snapshot.exprAllowed;
   }
 }


### PR DESCRIPTION
Ideally we'd avoid lookahead in the first place or have a better way to
implement it, but this seems to be much faster than the dynamic property copying
from before, and improves overall perf by about 20%.