### PR TITLE
Get rid of refShortHandDefaultPos

### DIFF
--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -8,23 +8,18 @@ export default abstract class LValParser extends UtilParser {
   abstract parseIdentifier(): void;
   abstract parseMaybeAssign(
     noIn?: boolean | null,
-    refShorthandDefaultPos?: Pos | null,
     afterLeftParse?: Function,
     refNeedsArrowPos?: Pos | null,
   ): void;
-  abstract parseObj(
-    isPattern: boolean,
-    isBlockScope: boolean,
-    refShorthandDefaultPos?: Pos | null,
-  ): void;
+  abstract parseObj(isPattern: boolean, isBlockScope: boolean): void;
   // Forward-declaration: defined in statement.js
   abstract parseDecorator(): void;
 
   // Parses spread element.
 
-  parseSpread(refShorthandDefaultPos: Pos | null): void {
+  parseSpread(): void {
     this.next();
-    this.parseMaybeAssign(false, refShorthandDefaultPos);
+    this.parseMaybeAssign(false);
   }
 
   parseRest(isBlockScope: boolean): void {

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -243,13 +243,10 @@ export default class StatementParser extends ExpressionParser {
       return;
     }
 
-    const refShorthandDefaultPos = {start: 0};
-    this.parseExpression(true, refShorthandDefaultPos);
+    this.parseExpression(true);
     if (this.match(tt._in) || this.isContextual("of")) {
       this.parseForIn(forAwait);
       return;
-    } else if (refShorthandDefaultPos.start) {
-      this.unexpected(refShorthandDefaultPos.start);
     }
     if (forAwait) {
       this.unexpected();

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -867,12 +867,8 @@ export default (superClass: ParserClass): ParserClass =>
 
     // parse an item inside a expression list eg. `(NODE, NODE)` where NODE represents
     // the position where this function is called
-    parseExprListItem(
-      allowEmpty: boolean | null,
-      refShorthandDefaultPos: Pos | null,
-      refNeedsArrowPos: Pos | null,
-    ): void {
-      super.parseExprListItem(allowEmpty, refShorthandDefaultPos, refNeedsArrowPos);
+    parseExprListItem(allowEmpty: boolean | null, refNeedsArrowPos: Pos | null): void {
+      super.parseExprListItem(allowEmpty, refNeedsArrowPos);
       if (this.match(tt.colon)) {
         this.flowParseTypeAnnotation();
       }
@@ -935,7 +931,6 @@ export default (superClass: ParserClass): ParserClass =>
       isGenerator: boolean,
       isPattern: boolean,
       isBlockScope: boolean,
-      refShorthandDefaultPos: Pos | null,
       objectContextId: number,
     ): void {
       // method shorthand
@@ -944,13 +939,7 @@ export default (superClass: ParserClass): ParserClass =>
         if (!this.match(tt.parenL)) this.unexpected();
       }
 
-      super.parseObjPropValue(
-        isGenerator,
-        isPattern,
-        isBlockScope,
-        refShorthandDefaultPos,
-        objectContextId,
-      );
+      super.parseObjPropValue(isGenerator, isPattern, isBlockScope, objectContextId);
     }
 
     parseAssignableListItemTypes(): void {
@@ -1059,7 +1048,6 @@ export default (superClass: ParserClass): ParserClass =>
     // 3. This is neither. Just call the super method
     parseMaybeAssign(
       noIn?: boolean | null,
-      refShorthandDefaultPos?: Pos | null,
       afterLeftParse?: Function,
       refNeedsArrowPos?: Pos | null,
     ): boolean {
@@ -1067,12 +1055,7 @@ export default (superClass: ParserClass): ParserClass =>
       if (tt.jsxTagStart && this.match(tt.jsxTagStart)) {
         const snapshot = this.state.snapshot();
         try {
-          return super.parseMaybeAssign(
-            noIn,
-            refShorthandDefaultPos,
-            afterLeftParse,
-            refNeedsArrowPos,
-          );
+          return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
         } catch (err) {
           if (err instanceof SyntaxError) {
             this.state.restoreFromSnapshot(snapshot);
@@ -1097,12 +1080,7 @@ export default (superClass: ParserClass): ParserClass =>
           this.runInTypeContext(0, () => {
             this.flowParseTypeParameterDeclaration();
           });
-          wasArrow = super.parseMaybeAssign(
-            noIn,
-            refShorthandDefaultPos,
-            afterLeftParse,
-            refNeedsArrowPos,
-          );
+          wasArrow = super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
         } catch (err) {
           throw jsxError || err;
         }
@@ -1113,7 +1091,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.unexpected();
       }
 
-      return super.parseMaybeAssign(noIn, refShorthandDefaultPos, afterLeftParse, refNeedsArrowPos);
+      return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
     }
 
     // handle return types for arrow functions

--- a/sucrase-babylon/plugins/jsx/index.ts
+++ b/sucrase-babylon/plugins/jsx/index.ts
@@ -334,7 +334,7 @@ export default (superClass: ParserClass): ParserClass =>
     // ==================================
 
     // Returns true if this was an arrow function.
-    parseExprAtom(refShortHandDefaultPos: Pos | null = null): boolean {
+    parseExprAtom(): boolean {
       if (this.match(tt.jsxText)) {
         this.parseLiteral();
         return false;
@@ -342,7 +342,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.jsxParseElement();
         return false;
       } else {
-        return super.parseExprAtom(refShortHandDefaultPos);
+        return super.parseExprAtom();
       }
     }
 

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1353,19 +1353,12 @@ export default (superClass: ParserClass): ParserClass =>
       isGenerator: boolean,
       isPattern: boolean,
       isBlockScope: boolean,
-      refShorthandDefaultPos: Pos | null,
       objectContextId: number,
     ): void {
       if (this.isRelational("<")) {
         throw new Error("TODO");
       }
-      super.parseObjPropValue(
-        isGenerator,
-        isPattern,
-        isBlockScope,
-        refShorthandDefaultPos,
-        objectContextId,
-      );
+      super.parseObjPropValue(isGenerator, isPattern, isBlockScope, objectContextId);
     }
 
     parseFunctionParams(allowModifiers?: boolean, contextId?: number): void {
@@ -1390,7 +1383,6 @@ export default (superClass: ParserClass): ParserClass =>
     // Returns true if the expression was an arrow function.
     parseMaybeAssign(
       noIn: boolean | null = null,
-      refShorthandDefaultPos?: Pos | null,
       afterLeftParse?: Function,
       refNeedsArrowPos?: Pos | null,
     ): boolean {
@@ -1407,12 +1399,7 @@ export default (superClass: ParserClass): ParserClass =>
         // Prefer to parse JSX if possible. But may be an arrow fn.
         const snapshot = this.state.snapshot();
         try {
-          return super.parseMaybeAssign(
-            noIn,
-            refShorthandDefaultPos,
-            afterLeftParse,
-            refNeedsArrowPos,
-          );
+          return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
         } catch (err) {
           if (!(err instanceof SyntaxError)) {
             // istanbul ignore next: no such error is expected
@@ -1431,12 +1418,7 @@ export default (superClass: ParserClass): ParserClass =>
       }
 
       if (jsxError === null && !this.isRelational("<")) {
-        return super.parseMaybeAssign(
-          noIn,
-          refShorthandDefaultPos,
-          afterLeftParse,
-          refNeedsArrowPos,
-        );
+        return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
       }
 
       // Either way, we're looking at a '<': tt.typeParameterStart or relational.
@@ -1448,12 +1430,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.runInTypeContext(0, () => {
           this.tsParseTypeParameters();
         });
-        wasArrow = super.parseMaybeAssign(
-          noIn,
-          refShorthandDefaultPos,
-          afterLeftParse,
-          refNeedsArrowPos,
-        );
+        wasArrow = super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
         if (!wasArrow) {
           this.unexpected(); // Go to the catch block (needs a SyntaxError).
         }
@@ -1475,23 +1452,18 @@ export default (superClass: ParserClass): ParserClass =>
         this.state.restoreFromSnapshot(snapshot);
         // This will start with a type assertion (via parseMaybeUnary).
         // But don't directly call `this.tsParseTypeAssertion` because we want to handle any binary after it.
-        return super.parseMaybeAssign(
-          noIn,
-          refShorthandDefaultPos,
-          afterLeftParse,
-          refNeedsArrowPos,
-        );
+        return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
       }
       return wasArrow;
     }
 
     // Handle type assertions
-    parseMaybeUnary(refShorthandDefaultPos?: Pos | null): boolean {
+    parseMaybeUnary(): boolean {
       if (!this.hasPlugin("jsx") && this.eatRelational("<")) {
         this.tsParseTypeAssertion();
         return false;
       } else {
-        return super.parseMaybeUnary(refShorthandDefaultPos);
+        return super.parseMaybeUnary();
       }
     }
 


### PR DESCRIPTION
This was only used for an error check when parsing an ambiguous expression, and
we can get rid of lots of plumbing by just removing the error handling.