### PR TITLE
Get rid of refNeedsArrowPos

### DIFF
--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -6,11 +6,7 @@ import UtilParser from "./util";
 export default abstract class LValParser extends UtilParser {
   // Forward-declaration: defined in expression.js
   abstract parseIdentifier(): void;
-  abstract parseMaybeAssign(
-    noIn?: boolean | null,
-    afterLeftParse?: Function,
-    refNeedsArrowPos?: Pos | null,
-  ): void;
+  abstract parseMaybeAssign(noIn?: boolean | null, afterLeftParse?: Function): void;
   abstract parseObj(isPattern: boolean, isBlockScope: boolean): void;
   // Forward-declaration: defined in statement.js
   abstract parseDecorator(): void;

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -759,10 +759,9 @@ export default (superClass: ParserClass): ParserClass =>
       return super.isExportDefaultSpecifier();
     }
 
-    parseConditional(noIn: boolean | null, startPos: number, refNeedsArrowPos?: Pos | null): void {
+    parseConditional(noIn: boolean | null, startPos: number): void {
       // only do the expensive clone if there is a question mark
-      // and if we come from inside parens
-      if (refNeedsArrowPos && this.match(tt.question)) {
+      if (this.match(tt.question)) {
         const snapshot = this.state.snapshot();
         try {
           super.parseConditional(noIn, startPos);
@@ -770,8 +769,6 @@ export default (superClass: ParserClass): ParserClass =>
         } catch (err) {
           if (err instanceof SyntaxError) {
             this.state.restoreFromSnapshot(snapshot);
-            // @ts-ignore
-            refNeedsArrowPos.start = err.pos || this.state.start;
             return;
           } else {
             // istanbul ignore next: no such error is expected
@@ -779,7 +776,7 @@ export default (superClass: ParserClass): ParserClass =>
           }
         }
       }
-      super.parseConditional(noIn, startPos, refNeedsArrowPos);
+      super.parseConditional(noIn, startPos);
     }
 
     parseParenItem(): void {
@@ -867,8 +864,8 @@ export default (superClass: ParserClass): ParserClass =>
 
     // parse an item inside a expression list eg. `(NODE, NODE)` where NODE represents
     // the position where this function is called
-    parseExprListItem(allowEmpty: boolean | null, refNeedsArrowPos: Pos | null): void {
-      super.parseExprListItem(allowEmpty, refNeedsArrowPos);
+    parseExprListItem(allowEmpty: boolean | null): void {
+      super.parseExprListItem(allowEmpty);
       if (this.match(tt.colon)) {
         this.flowParseTypeAnnotation();
       }
@@ -1046,16 +1043,12 @@ export default (superClass: ParserClass): ParserClass =>
     //    parse the rest, make sure the rest is an arrow function, and go from
     //    there
     // 3. This is neither. Just call the super method
-    parseMaybeAssign(
-      noIn?: boolean | null,
-      afterLeftParse?: Function,
-      refNeedsArrowPos?: Pos | null,
-    ): boolean {
+    parseMaybeAssign(noIn?: boolean | null, afterLeftParse?: Function): boolean {
       let jsxError = null;
       if (tt.jsxTagStart && this.match(tt.jsxTagStart)) {
         const snapshot = this.state.snapshot();
         try {
-          return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+          return super.parseMaybeAssign(noIn, afterLeftParse);
         } catch (err) {
           if (err instanceof SyntaxError) {
             this.state.restoreFromSnapshot(snapshot);
@@ -1080,7 +1073,7 @@ export default (superClass: ParserClass): ParserClass =>
           this.runInTypeContext(0, () => {
             this.flowParseTypeParameterDeclaration();
           });
-          wasArrow = super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+          wasArrow = super.parseMaybeAssign(noIn, afterLeftParse);
         } catch (err) {
           throw jsxError || err;
         }
@@ -1091,7 +1084,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.unexpected();
       }
 
-      return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+      return super.parseMaybeAssign(noIn, afterLeftParse);
     }
 
     // handle return types for arrow functions

--- a/sucrase-babylon/plugins/typescript.ts
+++ b/sucrase-babylon/plugins/typescript.ts
@@ -1254,11 +1254,11 @@ export default (superClass: ParserClass): ParserClass =>
     }
 
     // An apparent conditional expression could actually be an optional parameter in an arrow function.
-    parseConditional(noIn: boolean | null, startPos: number, refNeedsArrowPos?: Pos | null): void {
+    parseConditional(noIn: boolean | null, startPos: number): void {
       // only do the expensive clone if there is a question mark
       // and if we come from inside parens
-      if (!refNeedsArrowPos || !this.match(tt.question)) {
-        super.parseConditional(noIn, startPos, refNeedsArrowPos);
+      if (!this.match(tt.question)) {
+        super.parseConditional(noIn, startPos);
         return;
       }
 
@@ -1271,10 +1271,7 @@ export default (superClass: ParserClass): ParserClass =>
           // istanbul ignore next: no such error is expected
           throw err;
         }
-
         this.state.restoreFromSnapshot(snapshot);
-        // @ts-ignore
-        refNeedsArrowPos.start = err.pos || this.state.start;
       }
     }
 
@@ -1381,11 +1378,7 @@ export default (superClass: ParserClass): ParserClass =>
     }
 
     // Returns true if the expression was an arrow function.
-    parseMaybeAssign(
-      noIn: boolean | null = null,
-      afterLeftParse?: Function,
-      refNeedsArrowPos?: Pos | null,
-    ): boolean {
+    parseMaybeAssign(noIn: boolean | null = null, afterLeftParse?: Function): boolean {
       // Note: When the JSX plugin is on, type assertions (`<T> x`) aren't valid syntax.
 
       let jsxError: SyntaxError | null = null;
@@ -1399,7 +1392,7 @@ export default (superClass: ParserClass): ParserClass =>
         // Prefer to parse JSX if possible. But may be an arrow fn.
         const snapshot = this.state.snapshot();
         try {
-          return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+          return super.parseMaybeAssign(noIn, afterLeftParse);
         } catch (err) {
           if (!(err instanceof SyntaxError)) {
             // istanbul ignore next: no such error is expected
@@ -1418,7 +1411,7 @@ export default (superClass: ParserClass): ParserClass =>
       }
 
       if (jsxError === null && !this.isRelational("<")) {
-        return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+        return super.parseMaybeAssign(noIn, afterLeftParse);
       }
 
       // Either way, we're looking at a '<': tt.typeParameterStart or relational.
@@ -1430,7 +1423,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.runInTypeContext(0, () => {
           this.tsParseTypeParameters();
         });
-        wasArrow = super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+        wasArrow = super.parseMaybeAssign(noIn, afterLeftParse);
         if (!wasArrow) {
           this.unexpected(); // Go to the catch block (needs a SyntaxError).
         }
@@ -1452,7 +1445,7 @@ export default (superClass: ParserClass): ParserClass =>
         this.state.restoreFromSnapshot(snapshot);
         // This will start with a type assertion (via parseMaybeUnary).
         // But don't directly call `this.tsParseTypeAssertion` because we want to handle any binary after it.
-        return super.parseMaybeAssign(noIn, afterLeftParse, refNeedsArrowPos);
+        return super.parseMaybeAssign(noIn, afterLeftParse);
       }
       return wasArrow;
     }


### PR DESCRIPTION
It was only used for using the proper position in an error message, so it should
be safe to remove, and doing so gets rid of lots of plumbing.