### PR TITLE
Remove service worker from website

### DIFF
--- a/website/src/index.js
+++ b/website/src/index.js
@@ -2,8 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
-import registerServiceWorker from "./registerServiceWorker";
+import {unregister as unregisterServiceWorker} from "./registerServiceWorker";
 import "./WorkerClient";
 
 ReactDOM.render(<App />, document.getElementById("root"));
-registerServiceWorker();
+unregisterServiceWorker();


### PR DESCRIPTION
It seems to be causing caching issues that aren't fixed on refresh, so seems
best to disable it for now and then re-enable later maybe.