### PR TITLE
Don't use the token context in template parsing

### DIFF
--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -236,7 +236,7 @@ export default abstract class ExpressionParser extends LValParser {
       }
     } else if (this.match(tt.backQuote)) {
       // Tagged template expression.
-      this.parseTemplate(true);
+      this.parseTemplate();
     } else {
       state.stop = true;
     }
@@ -379,7 +379,7 @@ export default abstract class ExpressionParser extends LValParser {
         return false;
 
       case tt.backQuote:
-        this.parseTemplate(false);
+        this.parseTemplate();
         return false;
 
       case tt.doubleColon: {
@@ -529,25 +529,18 @@ export default abstract class ExpressionParser extends LValParser {
     }
   }
 
-  // Parse template expression.
-  parseTemplateElement(isTagged: boolean): void {
-    if (this.state.value === null) {
-      if (!isTagged) {
-        // TODO: fix this
-        this.raise(this.state.pos, "Invalid escape sequence in template");
-      }
-    }
-    this.next();
-  }
-
-  parseTemplate(isTagged: boolean): void {
-    this.next();
-    this.parseTemplateElement(isTagged);
+  parseTemplate(): void {
+    // Finish `, read quasi
+    this.nextTemplateToken();
+    // Finish quasi, read ${
+    this.nextTemplateToken();
     while (!this.match(tt.backQuote)) {
       this.expect(tt.dollarBraceL);
       this.parseExpression();
-      this.expect(tt.braceR);
-      this.parseTemplateElement(isTagged);
+      // Finish }, read quasi
+      this.nextTemplateToken();
+      // Finish quasi, read either ${ or `
+      this.nextTemplateToken();
     }
     this.next();
   }

--- a/sucrase-babylon/tokenizer/context.ts
+++ b/sucrase-babylon/tokenizer/context.ts
@@ -2,7 +2,6 @@
 // given point in the program is loosely based on sweet.js' approach.
 // See https://github.com/mozilla/sweet.js/wiki/design
 
-import Parser from "../parser";
 import {lineBreak} from "../util/whitespace";
 import {TokenType, types as tt} from "./types";
 
@@ -16,7 +15,6 @@ export class TokContext {
     this.token = token;
     this.isExpr = !!isExpr;
     this.preserveSpace = !!preserveSpace;
-    this.override = override;
   }
 
   token: string;
@@ -33,9 +31,7 @@ export const types: {
   templateQuasi: new TokContext("${", true),
   parenStatement: new TokContext("(", false),
   parenExpression: new TokContext("(", true),
-  template: new TokContext("`", true, true, (p: Parser) => {
-    p.readTmplToken();
-  }),
+  template: new TokContext("`", true, true),
   functionExpression: new TokContext("function", true),
 };
 

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -153,6 +153,17 @@ export default abstract class Tokenizer extends BaseParser {
     this.nextToken();
   }
 
+  // Call instead of next when inside a template, since that needs to be handled differently.
+  nextTemplateToken(): void {
+    if (!this.isLookahead) {
+      this.state.tokens.push(new Token(this.state));
+    }
+
+    this.state.lastTokEnd = this.state.end;
+    this.state.start = this.state.pos;
+    this.readTmplToken();
+  }
+
   runInTypeContext<T>(existingTokensInType: number, func: () => T): T {
     for (
       let i = this.state.tokens.length - existingTokensInType;
@@ -221,7 +232,6 @@ export default abstract class Tokenizer extends BaseParser {
 
   // Read a single token, updating the parser object's token-related
   // properties.
-
   nextToken(): void {
     const curContext = this.curContext();
     if (!curContext || !curContext.preserveSpace) this.skipSpace();
@@ -242,12 +252,7 @@ export default abstract class Tokenizer extends BaseParser {
       this.finishToken(tt.eof);
       return;
     }
-
-    if (curContext.override) {
-      curContext.override(this);
-    } else {
-      this.readToken(this.fullCharCodeAtPos());
-    }
+    this.readToken(this.fullCharCodeAtPos());
   }
 
   readToken(code: number): void {

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -116,4 +116,60 @@ describe("tokens", () => {
       ],
     );
   });
+
+  it("does not get confused by a regex-like sequence of divisions", () => {
+    assertTokens(
+      `
+      5/3/1
+    `,
+      [{label: "num"}, {label: "/"}, {label: "num"}, {label: "/"}, {label: "num"}, {label: "eof"}],
+    );
+  });
+
+  it("properly recognizes regexes that look like divisions", () => {
+    assertTokens(
+      `
+      5 + /3/
+    `,
+      [{label: "num"}, {label: "+/-"}, {label: "regexp"}, {label: "eof"}],
+    );
+  });
+
+  it("properly recognizes less than and greater than that look like JSX", () => {
+    assertTokens(
+      `
+      x<Hello>2
+    `,
+      [
+        {label: "name"},
+        {label: "<"},
+        {label: "name"},
+        {label: ">"},
+        {label: "num"},
+        {label: "eof"},
+      ],
+    );
+  });
+
+  it("properly recognizes template strings", () => {
+    assertTokens(
+      `
+      \`Hello, \${name} \${surname}\`
+    `,
+      [
+        {label: "`"},
+        {label: "template"},
+        {label: "${"},
+        {label: "name"},
+        {label: "}"},
+        {label: "template"},
+        {label: "${"},
+        {label: "name"},
+        {label: "}"},
+        {label: "template"},
+        {label: "`"},
+        {label: "eof"},
+      ],
+    );
+  });
 });


### PR DESCRIPTION
This gets rid of the need for an "override" in token contexts; we instead know
when we're parsing a template and call a different function, and it gets closer
to being able to get rid of token contexts entirely.