### PR TITLE
Change a flow-related special case to not rely on context

### DIFF
--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -407,7 +407,6 @@ export default abstract class Tokenizer extends BaseParser {
     let type = code === charCodes.asterisk ? tt.star : tt.modulo;
     let width = 1;
     let next = this.input.charCodeAt(this.state.pos + 1);
-    const exprAllowed = this.state.exprAllowed;
 
     // Exponentiation operator **
     if (code === charCodes.asterisk && next === charCodes.asterisk) {
@@ -416,7 +415,11 @@ export default abstract class Tokenizer extends BaseParser {
       type = tt.exponent;
     }
 
-    if (next === charCodes.equalsTo && !exprAllowed) {
+    // Match *= or %=, disallowing *=> which can be valid in flow.
+    if (
+      next === charCodes.equalsTo &&
+      this.input.charCodeAt(this.state.pos + 2) !== charCodes.greaterThan
+    ) {
       width++;
       type = tt.assign;
     }

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -162,4 +162,15 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("properly handles star as an arrow type param", () => {
+    assertFlowResult(
+      `
+      const x: *=>3 = null;
+    `,
+      `${PREFIX}
+      const x = null;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This should avoid the need to have expression information when parsing a type.