### PR TITLE
Get rid of the inGenerator state flag

### DIFF
--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -452,8 +452,6 @@ export default class StatementParser extends ExpressionParser {
     allowExpressionBody?: boolean,
     optionalId?: boolean,
   ): void {
-    const oldInGenerator = this.state.inGenerator;
-
     let isGenerator = false;
     if (this.match(tt.star)) {
       isGenerator = true;
@@ -466,16 +464,7 @@ export default class StatementParser extends ExpressionParser {
 
     let nameScopeStartTokenIndex = null;
 
-    // When parsing function expression, the binding identifier is parsed
-    // according to the rules inside the function.
-    // e.g. (function* yield() {}) is invalid because "yield" is disallowed in
-    // generators.
-    // This isn't the case with function declarations: function* yield() {} is
-    // valid because yield is parsed as if it was outside the generator.
-    // Therefore, this.state.inGenerator is set before or after parsing the
-    // function id according to the "isStatement" parameter.
-    if (!isStatement) this.state.inGenerator = isGenerator;
-    if (this.match(tt.name) || this.match(tt._yield)) {
+    if (this.match(tt.name)) {
       // Expression-style functions should limit their name's scope to the function body, so we make
       // a new function scope to enforce that.
       if (!isStatement) {
@@ -485,7 +474,6 @@ export default class StatementParser extends ExpressionParser {
       this.state.tokens[this.state.tokens.length - 1].identifierRole =
         IdentifierRole.FunctionScopedDeclaration;
     }
-    if (isStatement) this.state.inGenerator = isGenerator;
 
     const startTokenIndex = this.state.tokens.length;
     this.parseFunctionParams();
@@ -501,8 +489,6 @@ export default class StatementParser extends ExpressionParser {
         isFunctionScope: true,
       });
     }
-
-    this.state.inGenerator = oldInGenerator;
   }
 
   parseFunctionParams(allowModifiers?: boolean, funcContextId?: number): void {

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -9,7 +9,6 @@ export type Scope = {
 
 export type StateSnapshot = {
   potentialArrowAt: number;
-  inGenerator: boolean;
   noAnonFunctionType: boolean;
   tokensLength: number;
   scopesLength: number;
@@ -28,7 +27,6 @@ export default class State {
 
     this.potentialArrowAt = -1;
 
-    this.inGenerator = false;
     this.noAnonFunctionType = false;
 
     this.tokens = [];
@@ -49,8 +47,6 @@ export default class State {
   // Used to signify the start of a potential arrow function
   potentialArrowAt: number;
 
-  // yield is treated differently in a generator, and can be a variable name outside a generator.
-  inGenerator: boolean;
   // Used by Flow to handle an edge case involving function type parsing.
   noAnonFunctionType: boolean;
 
@@ -75,7 +71,6 @@ export default class State {
   snapshot(): StateSnapshot {
     return {
       potentialArrowAt: this.potentialArrowAt,
-      inGenerator: this.inGenerator,
       noAnonFunctionType: this.noAnonFunctionType,
       tokensLength: this.tokens.length,
       scopesLength: this.scopes.length,
@@ -91,7 +86,6 @@ export default class State {
 
   restoreFromSnapshot(snapshot: StateSnapshot): void {
     this.potentialArrowAt = snapshot.potentialArrowAt;
-    this.inGenerator = snapshot.inGenerator;
     this.noAnonFunctionType = snapshot.noAnonFunctionType;
     this.tokens.length = snapshot.tokensLength;
     this.scopes.length = snapshot.scopesLength;


### PR DESCRIPTION
The details around `yield` being a variable name outside of generators are
irrelevant in strict mode (which we assume), which treats `yield` as a reserved
word, so we don't actually need that state.