### PR TITLE
Handle some cases of complex export binding assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ focuses on compiling non-standard language extensions: JSX, TypeScript, and
 Flow. Because of this smaller scope, Sucrase can get away with an architecture
 that is much more performant but less extensible and maintainable.
 
-**Current state:** The project is in active development. It is about 13x faster
-than Babel and about 5x faster than TypeScript, and it has been tested on
-hundreds of thousands of lines of code. You may still find bugs when running on
-your code, though. You probably shouldn't use it in production, but you may find
-it useful in development. Feel free to file issues!
+**Current state:** The project is in active development. It is about 15x faster
+than Babel and about 6x faster than TypeScript, and it has been tested on
+hundreds of thousands of lines of code. Still, you may find correctness issues
+when running on a large codebase. Feel free to file issues!
 
 Sucrase can convert the following codebases with all tests passing:
 * Sucrase itself (6K lines of code excluding Babylon fork, typescript, imports).
 * The [Benchling](https://benchling.com/) frontend codebase
   (500K lines of code, JSX, imports).
 * [Babel](https://github.com/babel/babel) (63K lines of code, flow, imports).
+* [React](https://github.com/facebook/react) (86K lines of code, JSX, flow,
+  imports).
 * [TSLint](https://github.com/palantir/tslint) (20K lines of code, typescript,
   imports).
 * [Apollo client](https://github.com/apollographql/apollo-client) (34K lines of
@@ -138,15 +139,15 @@ case, it is much faster than Babel.
 
 ## Performance
 
-Currently, Sucrase runs about 13x faster than Babel (even when Babel only runs
-the relevant transforms) and 5x faster than TypeScript. Here's the output of
+Currently, Sucrase runs about 15x faster than Babel (even when Babel only runs
+the relevant transforms) and 6x faster than TypeScript. Here's the output of
 one run of `npm run benchmark`:
 
 ```
 Simulating transpilation of 100,000 lines of code:
-Sucrase: 777.638ms
-TypeScript: 3820.914ms
-Babel: 10041.368ms
+Sucrase: 670.313ms
+TypeScript: 3988.560ms
+Babel: 10060.157ms
 ```
 
 ## Project vision and future work
@@ -161,7 +162,7 @@ Babel: 10041.368ms
 
 ### New features
 
-* Implement more integrations, like for Webpack and Rollup.
+* Implement more integrations, like a Rollup plugin.
 * Emit proper source maps. (The line numbers already match up, but this would
   help with debuggers and other tools.)
 * Rethink configuration and try to simplify it as much as possible, and allow
@@ -181,9 +182,8 @@ Babel: 10041.368ms
 * Add integrity checks to compare intermediate Sucrase results (like tokens and
   the role of each identifier and pair of curly braces) with the equivalent
   information from Babel.
-* Fix some known correctness loose ends, like import hoisting, export assignment
-  detection for complex assignments, and fully replicating the small differences
-  between Babel and the TypeScript compiler.
+* Fix some known correctness loose ends, like import hoisting and fully
+  replicating the small differences between Babel and the TypeScript compiler.
 
 ## License and attribution
 

--- a/example-runner/example-configs/react.patch
+++ b/example-runner/example-configs/react.patch
@@ -11,25 +11,6 @@ index e12b9ccd9..60ab40224 100644
      "test-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.source.js",
      "test-prod-build": "yarn test-build-prod",
      "test-build": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.build.js",
-diff --git a/packages/events/EventPluginUtils.js b/packages/events/EventPluginUtils.js
-index d5e5a5e84..df250cf47 100644
---- a/packages/events/EventPluginUtils.js
-+++ b/packages/events/EventPluginUtils.js
-@@ -15,11 +15,9 @@ export let getNodeFromInstance = null;
- 
- export const injection = {
-   injectComponentTree: function(Injected) {
--    ({
--      getFiberCurrentPropsFromNode,
--      getInstanceFromNode,
--      getNodeFromInstance,
--    } = Injected);
-+    getFiberCurrentPropsFromNode = Injected.getFiberCurrentPropsFromNode;
-+    getInstanceFromNode = Injected.getInstanceFromNode;
-+    getNodeFromInstance = Injected.getNodeFromInstance;
-     if (__DEV__) {
-       warning(
-         getNodeFromInstance && getInstanceFromNode,
 diff --git a/scripts/babel/__tests__/transform-prevent-infinite-loops-test.js b/scripts/babel/__tests__/transform-prevent-infinite-loops-test.js
 index bcc508ad1..41900fa55 100644
 --- a/scripts/babel/__tests__/transform-prevent-infinite-loops-test.js

--- a/integrations/gulp-plugin/yarn.lock
+++ b/integrations/gulp-plugin/yarn.lock
@@ -65,10 +65,6 @@ array-slice@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
 
-charcodes@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/charcodes/-/charcodes-0.0.10.tgz#98d67a7a1e17ce154d1faafd01e72e9a6cff54f5"
-
 commander@^2.12.2:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -161,12 +157,11 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-sucrase@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.8.1.tgz#9caa8cc08832c44e225ac2affcea9468038886bd"
+sucrase@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.12.1.tgz#97a92597432d2af03887bfab11614da5efef0998"
   dependencies:
     "@types/mz" "^0.0.32"
-    charcodes "0.0.10"
     commander "^2.12.2"
     lines-and-columns "^1.1.6"
     mz "^2.7.0"

--- a/integrations/jest-plugin/yarn.lock
+++ b/integrations/jest-plugin/yarn.lock
@@ -46,9 +46,9 @@ pirates@^3.0.2:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-sucrase@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.9.0.tgz#5078661ebc4a9fed2a8fda055745b9fcdc074c38"
+sucrase@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.12.1.tgz#97a92597432d2af03887bfab11614da5efef0998"
   dependencies:
     "@types/mz" "^0.0.32"
     commander "^2.12.2"

--- a/integrations/webpack-loader/yarn.lock
+++ b/integrations/webpack-loader/yarn.lock
@@ -95,9 +95,9 @@ source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-sucrase@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.10.0.tgz#7cd0926f5804a15569279ca59ae905403f10acec"
+sucrase@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-1.12.1.tgz#97a92597432d2af03887bfab11614da5efef0998"
   dependencies:
     "@types/mz" "^0.0.32"
     commander "^2.12.2"

--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -277,7 +277,11 @@ get: () => ${primaryImportName}[key]}); });`;
     if (
       this.tokens.matchesAtIndex(index, ["export", "var"]) ||
       this.tokens.matchesAtIndex(index, ["export", "let"]) ||
-      this.tokens.matchesAtIndex(index, ["export", "const"]) ||
+      this.tokens.matchesAtIndex(index, ["export", "const"])
+    ) {
+      const exportName = this.tokens.tokens[index + 2].value;
+      this.identifierReplacements.set(exportName, `exports.${exportName}`);
+    } else if (
       this.tokens.matchesAtIndex(index, ["export", "function"]) ||
       this.tokens.matchesAtIndex(index, ["export", "class"])
     ) {

--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -57,7 +57,7 @@ function markShadowedGlobals(
     }
 
     const token = tokens[i];
-    if (token.type.label === "name" && globalNames.has(token.value)) {
+    if (scopeStack.length > 1 && token.type.label === "name" && globalNames.has(token.value)) {
       if (token.identifierRole === IdentifierRole.BlockScopedDeclaration) {
         markShadowedForScope(scopeStack[scopeStack.length - 1], tokens, token.value);
       } else if (token.identifierRole === IdentifierRole.FunctionScopedDeclaration) {

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -73,9 +73,9 @@ describe("transform imports", () => {
       export const z = 3;
     `,
       `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
-       var x = exports.x = 1;
-       let y = exports.y = 2;
-       const z = exports.z = 3;
+       exports.x = 1;
+       exports.y = 2;
+       exports.z = 3;
     `,
     );
   });
@@ -319,7 +319,7 @@ return obj && obj.__esModule ? obj : { default: obj }; }
 
 
 var _moduleName = require('moduleName');
-      console.log((0, _moduleName.a) + (0, _moduleName.b));
+      console.log(_moduleName.a + _moduleName.b);
     `,
     );
   });
@@ -363,7 +363,7 @@ var _moduleName = require('moduleName');
       `"use strict";${IMPORT_PREFIX}
       var _mymodule = require('my-module'); var _mymodule2 = _interopRequireDefault(_mymodule);
       
-      (0, _mymodule2.default).test();
+      _mymodule2.default.test();
       test.foo();
     `,
     );
@@ -394,7 +394,7 @@ var _moduleName = require('moduleName');
       `"use strict";${IMPORT_PREFIX}
       var _mymodule = require('my-module'); var wildcardName = _interopRequireWildcard(_mymodule);
       
-      (0, wildcardName.default).methodName();
+      wildcardName.default.methodName();
     `,
     );
   });
@@ -472,7 +472,7 @@ var _moduleName = require('moduleName');
       };
       
       function f() {
-        return true ? (0, _foo2.default) : 3;
+        return true ? _foo2.default : 3;
       }
     `,
     );
@@ -500,12 +500,12 @@ var _moduleName = require('moduleName');
       const o = {
         foo: _foo2.default,
         bar,
-        baz: (0, _foo2.default),
+        baz: _foo2.default,
         for: 4,
       };
       
       function f() {
-        (0, _foo2.default)
+        _foo2.default
       }
     `,
     );
@@ -522,7 +522,7 @@ var _moduleName = require('moduleName');
       `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       var _superclass = require('./superclass'); var _superclass2 = _interopRequireDefault(_superclass);
       
-       class Subclass extends (0, _superclass2.default) {
+       class Subclass extends _superclass2.default {
       } exports.Subclass = Subclass;
     `,
     );
@@ -540,7 +540,7 @@ var _moduleName = require('moduleName');
       var _react = require('react'); var _react2 = _interopRequireDefault(_react);
       var _Foo = require('./Foo'); var _Foo2 = _interopRequireDefault(_Foo);
       
-      const elem = _react2.default.createElement((0, _Foo2.default), {${devProps(5)}} );
+      const elem = _react2.default.createElement(_Foo2.default, {${devProps(5)}} );
     `,
     );
   });
@@ -557,7 +557,7 @@ var _moduleName = require('moduleName');
       var _react = require('react'); var _react2 = _interopRequireDefault(_react);
       var _value = require('./value'); var _value2 = _interopRequireDefault(_value);
       
-      _react2.default.createElement('div', { a: (0, _value2.default), ${devProps(5)}} );
+      _react2.default.createElement('div', { a: _value2.default, ${devProps(5)}} );
     `,
     );
   });
@@ -585,7 +585,7 @@ var _moduleName = require('moduleName');
         _react2.default.createElement('div', {${devProps(6)}}
           , _react2.default.createElement('span', {${devProps(7)}}
             , _react2.default.createElement('span', {${devProps(8)}} )
-            , (0, _value2.default)
+            , _value2.default
           )
         )
       );
@@ -614,7 +614,7 @@ module.exports = exports.default;
       export default 4;
     `,
       `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
-       const x = exports.x = 1;
+       exports.x = 1;
       exports. default = 4;
     `,
       ["imports", "add-module-exports"],
@@ -870,7 +870,7 @@ module.exports = exports.default;
     `,
       `"use strict";${IMPORT_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireDefault(_a);
-      console.log((0, _a2.default));
+      console.log(_a2.default);
       function f() {
         let a = 3;
         a = 7;
@@ -935,7 +935,7 @@ module.exports = exports.default;
     `,
       `"use strict";${IMPORT_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireDefault(_a);
-      const {b = (0, _a2.default)} = {};
+      const {b = _a2.default} = {};
       if (true) {
         const {a} = {};
         console.log(a);
@@ -955,10 +955,27 @@ module.exports = exports.default;
     `,
       `"use strict";${IMPORT_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireDefault(_a);
-      const f = ((0, _a2.default), b);
+      const f = (_a2.default, b);
       const g = (a, b) => c;
       const h = a => c;
       const f2 = async (a) => c;
+    `,
+    );
+  });
+
+  it("properly handles complex assignments to exported values", () => {
+    assertResult(
+      `
+      export let a = 1;
+      ({a} = 2);
+      a = 3;
+      console.log(a);
+    `,
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
+       exports.a = 1;
+      ({a: exports.a} = 2);
+      exports.a = 3;
+      console.log(exports.a);
     `,
     );
   });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -49,7 +49,7 @@ describe("sucrase", () => {
       };
     `,
       `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
-       const keywords = exports.keywords = {
+       exports.keywords = {
         break: new KeywordTokenType("break"),
         case: new KeywordTokenType("case", { beforeExpr }),
         catch: new KeywordTokenType("catch"),
@@ -336,10 +336,10 @@ describe("sucrase", () => {
       `"use strict";
       var _A = require('A');
       var _B = require('B');
-      class C {constructor() { this.a = (0, _A.default); }
+      class C {constructor() { this.a = _A.default; }
         
         
-      } C.b = (0, _B.default);
+      } C.b = _B.default;
     `,
       ["jsx", "imports", "typescript"],
     );

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -208,7 +208,7 @@ describe("type transforms", () => {
     `,
       `${ESMODULE_PREFIX}
       
-       const x = exports.x = 1;
+       exports.x = 1;
     `,
     );
   });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -279,7 +279,7 @@ describe("typescript transform", () => {
       
       
       function f(a) {
-        return a instanceof (0, _a.default);
+        return a instanceof _a.default;
       }
       function g(b) {
         return true;


### PR DESCRIPTION
This follows the TypeScript strategy of replacing all variable usages with
`exports.foo`, which also ends up replacing assignments (including destructuring
assignments) as well. I tried to get the Babel strategy working, but properly
detecting assignees within destructure operations seems to be very difficult
with the current way that it's parsed. This change fixes the behavior for React,
and I believe the behavior now mimics TypeScript, so hopefully this should be a
good long-term solution.