### PR TITLE
Remove more uses of token type label names

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -1,5 +1,5 @@
 import {Token} from "../sucrase-babylon/tokenizer";
-import {TokenType} from "../sucrase-babylon/tokenizer/types";
+import {TokenType, types as tt} from "../sucrase-babylon/tokenizer/types";
 
 export type TokenProcessorSnapshot = {
   resultCode: string;
@@ -37,15 +37,15 @@ export default class TokenProcessor {
     this.tokenIndex = 0;
   }
 
-  matchesAtIndex(index: number, tagLabels: Array<string>): boolean {
+  matchesAtIndex(index: number, types: Array<TokenType>): boolean {
     if (index < 0) {
       return false;
     }
-    for (let i = 0; i < tagLabels.length; i++) {
+    for (let i = 0; i < types.length; i++) {
       if (index + i >= this.tokens.length) {
         return false;
       }
-      if (this.tokens[index + i].type.label !== tagLabels[i]) {
+      if (this.tokens[index + i].type !== types[i]) {
         return false;
       }
     }
@@ -53,7 +53,7 @@ export default class TokenProcessor {
   }
 
   matchesNameAtIndex(index: number, name: string): boolean {
-    return this.matchesAtIndex(index, ["name"]) && this.tokens[index].value === name;
+    return this.matchesAtIndex(index, [tt.name]) && this.tokens[index].value === name;
   }
 
   matches1(t1: TokenType): boolean {

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -108,7 +108,7 @@ export default class ImportTransformer extends Transformer {
     this.tokens.removeInitialToken();
     if (
       this.tokens.matchesName("type") &&
-      !this.tokens.matchesAtIndex(this.tokens.currentIndex() + 1, [","]) &&
+      !this.tokens.matchesAtIndex(this.tokens.currentIndex() + 1, [tt.comma]) &&
       !this.tokens.matchesNameAtIndex(this.tokens.currentIndex() + 1, "from")
     ) {
       // This is an "import type" statement, so exit early.
@@ -251,7 +251,7 @@ export default class ImportTransformer extends Transformer {
     if (identifierToken.type.label !== "name") {
       return false;
     }
-    if (this.tokens.matchesAtIndex(index - 2, ["."])) {
+    if (this.tokens.matchesAtIndex(index - 2, [tt.dot])) {
       return false;
     }
     if (

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -114,10 +114,10 @@ export default class JSXTransformer extends Transformer {
     // [slash, jsxTagEnd] to end the self-closing tag.
     let introEnd = this.tokens.currentIndex() + 1;
     while (
-      !this.tokens.matchesAtIndex(introEnd - 1, ["jsxName", "jsxName"]) &&
-      !this.tokens.matchesAtIndex(introEnd, ["{"]) &&
-      !this.tokens.matchesAtIndex(introEnd, ["jsxTagEnd"]) &&
-      !this.tokens.matchesAtIndex(introEnd, ["/", "jsxTagEnd"])
+      !this.tokens.matchesAtIndex(introEnd - 1, [tt.jsxName, tt.jsxName]) &&
+      !this.tokens.matchesAtIndex(introEnd, [tt.braceL]) &&
+      !this.tokens.matchesAtIndex(introEnd, [tt.jsxTagEnd]) &&
+      !this.tokens.matchesAtIndex(introEnd, [tt.slash, tt.jsxTagEnd])
     ) {
       introEnd++;
     }

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -76,8 +76,8 @@ export default class ReactDisplayNameTransformer extends Transformer {
 
   private findDisplayName(startIndex: number): string | null {
     if (
-      this.tokens.matchesAtIndex(startIndex - 2, ["name", "="]) &&
-      !this.tokens.matchesAtIndex(startIndex - 3, ["."])
+      this.tokens.matchesAtIndex(startIndex - 2, [tt.name, tt.eq]) &&
+      !this.tokens.matchesAtIndex(startIndex - 3, [tt.dot])
     ) {
       // This is an assignment (or declaration) with an identifier LHS, so use
       // that identifier name.
@@ -133,7 +133,8 @@ export default class ReactDisplayNameTransformer extends Transformer {
     // If we got this far, we know we have createClass with an object with no
     // display name, so we want to proceed as long as that was the only argument.
     return (
-      this.tokens.matchesAtIndex(index, [")"]) || this.tokens.matchesAtIndex(index, [",", ")"])
+      this.tokens.matchesAtIndex(index, [tt.parenR]) ||
+      this.tokens.matchesAtIndex(index, [tt.comma, tt.parenR])
     );
   }
 }


### PR DESCRIPTION
These should be identity checks on the tokens themselves so that token type can
turn into an enum, so this gets closer that world.