### PR TITLE
Use ContextualKeyword instead of value in most places

### DIFF
--- a/src/NameManager.ts
+++ b/src/NameManager.ts
@@ -7,9 +7,9 @@ export default class NameManager {
   constructor(readonly tokens: TokenProcessor) {}
 
   preprocessNames(): void {
-    for (const token of this.tokens.tokens) {
-      if (token.type === tt.name) {
-        this.usedNames.add(token.value);
+    for (let i = 0; i < this.tokens.tokens.length; i++) {
+      if (this.tokens.matchesAtIndex(i, [tt.name])) {
+        this.usedNames.add(this.tokens.identifierNameAtIndex(i));
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,6 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
   if (isTypeScript) {
     importProcessor.pruneTypeOnlyImports();
   }
-  identifyShadowedGlobals(tokens, scopes, importProcessor.getGlobalNames());
+  identifyShadowedGlobals(tokenProcessor, scopes, importProcessor.getGlobalNames());
   return {tokenProcessor, scopes, nameManager, importProcessor};
 }

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -68,8 +68,9 @@ export default class JSXTransformer extends Transformer {
     this.tokens.appendCode(`, {`);
     while (true) {
       if (this.tokens.matches2(tt.jsxName, tt.eq)) {
-        if (this.tokens.currentToken().value.includes("-")) {
-          this.tokens.replaceToken(`'${this.tokens.currentToken().value}'`);
+        const keyName = this.tokens.identifierName();
+        if (keyName.includes("-")) {
+          this.tokens.replaceToken(`'${keyName}'`);
         } else {
           this.tokens.copyToken();
         }
@@ -121,11 +122,11 @@ export default class JSXTransformer extends Transformer {
     ) {
       introEnd++;
     }
-    if (
-      introEnd === this.tokens.currentIndex() + 1 &&
-      startsWithLowerCase(this.tokens.currentToken().value)
-    ) {
-      this.tokens.replaceToken(`'${this.tokens.currentToken().value}'`);
+    if (introEnd === this.tokens.currentIndex() + 1) {
+      const tagName = this.tokens.identifierName();
+      if (startsWithLowerCase(tagName)) {
+        this.tokens.replaceToken(`'${tagName}'`);
+      }
     }
     while (this.tokens.currentIndex() < introEnd) {
       this.rootTransformer.processToken();

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,4 +1,4 @@
-import {IdentifierRole} from "../../sucrase-babylon/tokenizer";
+import {ContextualKeyword, IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
 import ImportProcessor from "../ImportProcessor";
 import TokenProcessor from "../TokenProcessor";
@@ -24,7 +24,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
 
   process(): boolean {
     const startIndex = this.tokens.currentIndex();
-    if (this.tokens.matchesName("createReactClass")) {
+    if (this.tokens.matchesContextual(ContextualKeyword._createReactClass)) {
       const newName = this.importProcessor.getIdentifierReplacement("createReactClass");
       if (newName) {
         this.tokens.replaceToken(`(0, ${newName})`);
@@ -36,8 +36,11 @@ export default class ReactDisplayNameTransformer extends Transformer {
     }
     if (
       this.tokens.matches3(tt.name, tt.dot, tt.name) &&
-      this.tokens.matchesName("React") &&
-      this.tokens.matchesNameAtIndex(this.tokens.currentIndex() + 2, "createClass")
+      this.tokens.matchesContextual(ContextualKeyword._React) &&
+      this.tokens.matchesContextualAtIndex(
+        this.tokens.currentIndex() + 2,
+        ContextualKeyword._createClass,
+      )
     ) {
       const newName = this.importProcessor.getIdentifierReplacement("React");
       if (newName) {
@@ -81,11 +84,11 @@ export default class ReactDisplayNameTransformer extends Transformer {
     ) {
       // This is an assignment (or declaration) with an identifier LHS, so use
       // that identifier name.
-      return this.tokens.tokens[startIndex - 2].value;
+      return this.tokens.identifierNameAtIndex(startIndex - 2);
     }
     if (this.tokens.tokens[startIndex - 2].identifierRole === IdentifierRole.ObjectKey) {
       // This is an object literal value.
-      return this.tokens.tokens[startIndex - 2].value;
+      return this.tokens.identifierNameAtIndex(startIndex - 2);
     }
     return null;
   }
@@ -117,7 +120,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
       }
 
       if (
-        this.tokens.matchesNameAtIndex(index, "displayName") &&
+        this.tokens.matchesContextualAtIndex(index, ContextualKeyword._displayName) &&
         this.tokens.tokens[index].identifierRole === IdentifierRole.ObjectKey &&
         token.contextId === objectContextId
       ) {

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -130,7 +130,7 @@ export default class RootTransformer {
     if (!this.tokens.matches2(tt._class, tt.name)) {
       throw new Error("Expected identifier for exported class name.");
     }
-    const name = this.tokens.tokens[this.tokens.currentIndex() + 1].value;
+    const name = this.tokens.identifierNameAtIndex(this.tokens.currentIndex() + 1);
     this.processClass();
     return name;
   }

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -45,7 +45,7 @@ export default class TypeScriptTransformer extends Transformer {
     while (this.tokens.matches1(tt._const) || this.tokens.matches1(tt._enum)) {
       this.tokens.removeToken();
     }
-    const enumName = this.tokens.currentToken().value;
+    const enumName = this.tokens.identifierName();
     this.tokens.removeToken();
     this.tokens.appendCode(`var ${enumName}; (function (${enumName})`);
     this.tokens.copyExpectedToken(tt.braceL);
@@ -75,11 +75,11 @@ export default class TypeScriptTransformer extends Transformer {
       let isValidIdentifier;
       let nameStringCode;
       if (nameToken.type === tt.name) {
-        name = nameToken.value;
+        name = this.tokens.identifierNameForToken(nameToken);
         isValidIdentifier = true;
         nameStringCode = `"${name}"`;
       } else if (nameToken.type === tt.string) {
-        name = nameToken.value;
+        name = this.tokens.stringValueForToken(nameToken);
         isValidIdentifier = isIdentifier(name);
         nameStringCode = this.tokens.code.slice(nameToken.start, nameToken.end);
       } else {

--- a/src/util/formatTokens.ts
+++ b/src/util/formatTokens.ts
@@ -12,7 +12,7 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
   );
   const typeKeys = Object.keys(tokens[0].type).filter((k) => k !== "label" && k !== "keyword");
 
-  const headings = ["Location", "Label", "Value", ...tokenKeys, ...typeKeys];
+  const headings = ["Location", "Label", "Raw", ...tokenKeys, ...typeKeys];
 
   const lines = new LinesAndColumns(code);
   const rows = [headings, ...tokens.map(getTokenComponents)];
@@ -27,10 +27,11 @@ export default function formatTokens(code: string, tokens: Array<Token>): string
     .join("\n");
 
   function getTokenComponents(token: Token): Array<string> {
+    const raw = code.slice(token.start, token.end);
     return [
       formatRange(token.start, token.end),
       formatTokenType(token.type),
-      token.value != null ? truncate(String(token.value), 14) : "",
+      truncate(String(raw), 14),
       ...tokenKeys.map((key) => formatValue(token[key], key)),
       ...typeKeys.map((key) => formatValue(token.type[key], key)),
     ];

--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -1,4 +1,4 @@
-import {Token} from "../../sucrase-babylon/tokenizer";
+import {ContextualKeyword, Token} from "../../sucrase-babylon/tokenizer";
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "../transformers/RootTransformer";
@@ -48,7 +48,7 @@ export default function getClassInfo(
 
   tokens.nextToken();
   while (!tokens.matchesContextIdAndLabel(tt.braceR, classContextId)) {
-    if (tokens.matchesName("constructor")) {
+    if (tokens.matchesContextual(ContextualKeyword._constructor)) {
       ({constructorInitializers, constructorInsertPos} = processConstructor(tokens));
     } else if (tokens.matches1(tt.semi)) {
       tokens.nextToken();
@@ -62,7 +62,7 @@ export default function getClassInfo(
         }
         tokens.nextToken();
       }
-      if (tokens.matchesName("constructor")) {
+      if (tokens.matchesContextual(ContextualKeyword._constructor)) {
         ({constructorInitializers, constructorInsertPos} = processConstructor(tokens));
         continue;
       }
@@ -133,7 +133,7 @@ function processClassHeader(tokens: TokenProcessor): ClassHeaderInfo {
   let hasSuperclass = false;
   tokens.nextToken();
   if (tokens.matches1(tt.name)) {
-    className = tokens.currentToken().value;
+    className = tokens.identifierName();
   }
   while (!tokens.matchesContextIdAndLabel(tt.braceL, contextId)) {
     if (tokens.matches1(tt._extends)) {
@@ -169,7 +169,7 @@ function processConstructor(
       if (token.type !== tt.name) {
         throw new Error("Expected identifier after access modifiers in constructor arg.");
       }
-      const name = token.value;
+      const name = tokens.identifierNameForToken(token);
       constructorInitializers.push(`this.${name} = ${name}`);
     }
     tokens.nextToken();
@@ -242,7 +242,7 @@ function getNameCode(tokens: TokenProcessor): string {
     if (nameToken.type === tt.string || nameToken.type === tt.num) {
       return `[${tokens.code.slice(nameToken.start, nameToken.end)}]`;
     } else {
-      return `.${nameToken.value}`;
+      return `.${tokens.identifierNameForToken(nameToken)}`;
     }
   }
 }

--- a/sucrase-babylon/parser/util.ts
+++ b/sucrase-babylon/parser/util.ts
@@ -1,4 +1,4 @@
-import Tokenizer from "../tokenizer";
+import Tokenizer, {ContextualKeyword} from "../tokenizer";
 import {formatTokenType, TokenType, TokenType as tt} from "../tokenizer/types";
 import {lineBreak} from "../util/whitespace";
 
@@ -6,23 +6,25 @@ import {lineBreak} from "../util/whitespace";
 
 export default class UtilParser extends Tokenizer {
   // Tests whether parsed token is a contextual keyword.
-  isContextual(name: string): boolean {
-    return this.match(tt.name) && this.state.value === name;
+  isContextual(contextualKeyword: ContextualKeyword): boolean {
+    return this.state.contextualKeyword === contextualKeyword;
   }
 
-  isLookaheadContextual(name: string): boolean {
-    const l = this.lookaheadTypeAndValue();
-    return l.type === tt.name && l.value === name;
+  isLookaheadContextual(contextualKeyword: ContextualKeyword): boolean {
+    const l = this.lookaheadTypeAndKeyword();
+    return l.type === tt.name && l.contextualKeyword === contextualKeyword;
   }
 
   // Consumes contextual keyword if possible.
-  eatContextual(name: string): boolean {
-    return this.state.value === name && this.eat(tt.name);
+  eatContextual(contextualKeyword: ContextualKeyword): boolean {
+    return this.state.contextualKeyword === contextualKeyword && this.eat(tt.name);
   }
 
   // Asserts that following token is given contextual keyword.
-  expectContextual(name: string, message?: string): void {
-    if (!this.eatContextual(name)) this.unexpected(null, message);
+  expectContextual(contextualKeyword: ContextualKeyword): void {
+    if (!this.eatContextual(contextualKeyword)) {
+      this.unexpected(null);
+    }
   }
 
   // Test whether a semicolon can be inserted at the current position.

--- a/sucrase-babylon/tokenizer/state.ts
+++ b/sucrase-babylon/tokenizer/state.ts
@@ -1,4 +1,4 @@
-import {Token} from "./index";
+import {ContextualKeyword, Token} from "./index";
 import {TokenType, TokenType as tt} from "./types";
 
 export type Scope = {
@@ -16,6 +16,7 @@ export type StateSnapshot = {
   type: TokenType;
   // tslint:disable-next-line: no-any
   value: any;
+  contextualKeyword: ContextualKeyword;
   start: number;
   end: number;
   isType: boolean;
@@ -63,6 +64,7 @@ export default class State {
   type: TokenType;
   // tslint:disable-next-line no-any
   value: any;
+  contextualKeyword: ContextualKeyword;
   start: number;
   end: number;
 
@@ -76,8 +78,8 @@ export default class State {
       scopesLength: this.scopes.length,
       pos: this.pos,
       type: this.type,
-      // tslint:disable-next-line: no-any
       value: this.value,
+      contextualKeyword: this.contextualKeyword,
       start: this.start,
       end: this.end,
       isType: this.isType,
@@ -92,6 +94,7 @@ export default class State {
     this.pos = snapshot.pos;
     this.type = snapshot.type;
     this.value = snapshot.value;
+    this.contextualKeyword = snapshot.contextualKeyword;
     this.start = snapshot.start;
     this.end = snapshot.end;
     this.isType = snapshot.isType;

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -13,21 +13,21 @@ if (foo) {
         {transforms: ["jsx", "imports"]},
       ),
       `\
-Location  Label  Value        isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression
-1:1-1:3   if     if                                                                                 
-1:4-1:5   (                                                                                         
-1:5-1:8   name   foo                 0                                                              
-1:8-1:9   )                                                                                         
-1:10-1:11 {                                                                                         
-2:3-2:10  name   console             0                                                              
-2:10-2:11 .                                                                                         
-2:11-2:14 name   log                                                                                
-2:14-2:15 (                                                       1                                 
-2:15-2:29 string Hello world!                                                                       
-2:29-2:30 )                                                       1                                 
-2:30-2:31 ;                                                                                         
-3:1-3:2   }                                                                                         
-3:2-3:2   eof                                                                                       `,
+Location  Label  Raw            contextualKeyword isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression
+1:1-1:3   if     if             0                                                                                       
+1:4-1:5   (      (              0                                                                                       
+1:5-1:8   name   foo            0                        0                                                              
+1:8-1:9   )      )              0                                                                                       
+1:10-1:11 {      {              0                                                                                       
+2:3-2:10  name   console        0                        0                                                              
+2:10-2:11 .      .              0                                                                                       
+2:11-2:14 name   log            0                                                                                       
+2:14-2:15 (      (              0                                                     1                                 
+2:15-2:29 string 'Hello world!' 0                                                                                       
+2:29-2:30 )      )              0                                                     1                                 
+2:30-2:31 ;      ;              0                                                                                       
+3:1-3:2   }      }              0                                                                                       
+3:2-3:2   eof                   0                                                                                       `,
     );
   });
 });


### PR DESCRIPTION
This gets closer to removing the `value` field from tokens in favor of just
using the references into the source code, and also gets rid of a bunch of
string comparisons that were necessary when detecting contextual keywords.