### PR TITLE
Change JSX transform to handle entities and newlines

### DIFF
--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -276,4 +276,17 @@ describe("transform JSX", () => {
     `,
     );
   });
+
+  it("preserves/allows windows newlines in string literals but not tag bodies", () => {
+    assertResult(
+      `
+      const e = <div a="foo\r\nbar">a\r\nb</div>;
+    `,
+      `${JSX_PREFIX}
+      const e = React.createElement('div', { a: "foo\\r\\nbar"
+, __self: this, __source: {fileName: _jsxFileName, lineNumber: 2}}, "a b"
+);
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This avoids the need for the parser to produce the JSX string, handling
entities. Instead, the same code handles both. This gets rid of one of the last
uses of the value field in tokens/state.