### PR TITLE
Switch from classes to plain function calls across the parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     "class-methods-use-this": "off",
     "func-names": "off",
     "import/extensions": "off",
+    "import/no-mutable-exports": "off",
     "import/prefer-default-export": "off",
     "no-await-in-loop": "off",
     "no-bitwise": "off",

--- a/sucrase-babylon/index.ts
+++ b/sucrase-babylon/index.ts
@@ -1,7 +1,5 @@
-import Parser from "./parser";
-import FlowParser from "./plugins/flow";
-import JSXParser from "./plugins/jsx";
-import TypeScriptParser from "./plugins/typescript";
+import {parseFile} from "./parser";
+import {initParser} from "./parser/base";
 import {Token} from "./tokenizer";
 import {Scope} from "./tokenizer/state";
 
@@ -11,21 +9,9 @@ export type File = {
 };
 
 export function parse(input: string, plugins: Array<string>): File {
-  return getParser(plugins, input).parse();
-}
-
-function getParser(plugins: Array<string>, input: string): Parser {
   if (plugins.includes("flow") && plugins.includes("typescript")) {
     throw new Error("Cannot combine flow and typescript plugins.");
   }
-
-  if (plugins.includes("typescript")) {
-    return new TypeScriptParser(input, plugins);
-  } else if (plugins.includes("flow")) {
-    return new FlowParser(input, plugins);
-  } else if (plugins.includes("jsx")) {
-    return new JSXParser(input, plugins);
-  } else {
-    return new Parser(input, plugins);
-  }
+  initParser(input, plugins);
+  return parseFile();
 }

--- a/sucrase-babylon/parser/base.ts
+++ b/sucrase-babylon/parser/base.ts
@@ -2,36 +2,41 @@ import LinesAndColumns from "lines-and-columns";
 
 import State from "../tokenizer/state";
 
-export default class BaseParser {
-  plugins: {[key: string]: boolean};
+export let plugins: {[key: string]: boolean};
+export let state: State;
+export let input: string;
+export let nextContextId: number;
 
-  // Initialized by Tokenizer
-  state: State;
-  input: string;
+export function getNextContextId(): number {
+  return nextContextId++;
+}
 
-  hasPlugin(name: string): boolean {
-    return Boolean(this.plugins[name]);
+export function hasPlugin(name: string): boolean {
+  return Boolean(plugins[name]);
+}
+
+// This function is used to raise exceptions on parse errors. It
+// takes an offset integer (into the current `input`) to indicate
+// the location of the error, attaches the position to the end
+// of the error message, and then raises a `SyntaxError` with that
+// message.
+export function raise(pos: number, message: string): never {
+  let loc = new LinesAndColumns(input).locationForIndex(pos);
+  if (!loc) {
+    loc = {line: 0, column: 0};
   }
+  message += ` (${loc.line}:${loc.column})`;
+  // tslint:disable-next-line no-any
+  const err: any = new SyntaxError(message);
+  err.pos = pos;
+  err.loc = loc;
+  throw err;
+}
 
-  // This function is used to raise exceptions on parse errors. It
-  // takes an offset integer (into the current `input`) to indicate
-  // the location of the error, attaches the position to the end
-  // of the error message, and then raises a `SyntaxError` with that
-  // message.
-  raise(pos: number, message: string, missingPluginNames?: Array<string>): never {
-    let loc = new LinesAndColumns(this.input).locationForIndex(pos);
-    if (!loc) {
-      loc = {line: 0, column: 0};
-    }
-    message += ` (${loc.line}:${loc.column})`;
-    // tslint:disable-next-line no-any
-    const err: any = new SyntaxError(message);
-    err.pos = pos;
-    err.loc = loc;
-    if (missingPluginNames) {
-      // @ts-ignore
-      err.missingPlugin = missingPluginNames;
-    }
-    throw err;
-  }
+export function initParser(inputCode: string, pluginList: Array<string>): void {
+  input = inputCode;
+  state = new State();
+  state.init(input);
+  nextContextId = 1;
+  plugins = pluginList.reduce((obj, p) => ({...obj, [p]: true}), {});
 }

--- a/sucrase-babylon/parser/index.ts
+++ b/sucrase-babylon/parser/index.ts
@@ -1,25 +1,13 @@
 import {File} from "../index";
-import StatementParser from "./statement";
+import {nextToken, skipLineComment} from "../tokenizer";
+import {input, state} from "./base";
+import {parseTopLevel} from "./statement";
 
-export type Pos = {
-  start: number;
-};
-
-export default class Parser extends StatementParser {
-  constructor(input: string, plugins: Array<string>) {
-    super(input);
-
-    this.input = input;
-    this.plugins = plugins.reduce((obj, p) => ({...obj, [p]: true}), {});
-
-    // If enabled, skip leading hashbang line.
-    if (this.state.pos === 0 && this.input[0] === "#" && this.input[1] === "!") {
-      this.skipLineComment(2);
-    }
+export function parseFile(): File {
+  // If enabled, skip leading hashbang line.
+  if (state.pos === 0 && input[0] === "#" && input[1] === "!") {
+    skipLineComment(2);
   }
-
-  parse(): File {
-    this.nextToken();
-    return this.parseTopLevel();
-  }
+  nextToken();
+  return parseTopLevel();
 }

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -1,902 +1,1080 @@
 /* eslint max-len: 0 */
 
 import {File} from "../index";
-import {ContextualKeyword, IdentifierRole} from "../tokenizer";
+import {
+  flowAfterParseClassSuper,
+  flowAfterParseVarHead,
+  flowParseExportDeclaration,
+  flowParseExportStar,
+  flowParseIdentifierStatement,
+  flowParseImportSpecifier,
+  flowParseTypeAnnotation,
+  flowParseTypeParameterDeclaration,
+  flowShouldDisallowExportDefaultSpecifier,
+  flowShouldParseExportDeclaration,
+  flowShouldParseExportStar,
+  flowStartParseFunctionParams,
+  flowStartParseImportSpecifiers,
+  flowTryParseStatement,
+} from "../plugins/flow";
+import {
+  tsAfterParseClassSuper,
+  tsAfterParseVarHead,
+  tsIsDeclarationStart,
+  tsParseAccessModifier,
+  tsParseExportDeclaration,
+  tsParseIdentifierStatement,
+  tsParseImportEqualsDeclaration,
+  tsStartParseFunctionParams,
+  tsTryParseClassMemberWithIsStatic,
+  tsTryParseExport,
+  tsTryParseExportDefaultExpression,
+  tsTryParseStatementContent,
+  tsTryParseTypeAnnotation,
+  tsTryParseTypeParameters,
+} from "../plugins/typescript";
+import {
+  ContextualKeyword,
+  eat,
+  IdentifierRole,
+  lookaheadType,
+  lookaheadTypeAndKeyword,
+  match,
+  next,
+} from "../tokenizer";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
-import ExpressionParser from "./expression";
+import {getNextContextId, hasPlugin, state} from "./base";
+import {
+  parseCallExpressionArguments,
+  parseExprAtom,
+  parseExpression,
+  parseExprSubscripts,
+  parseFunctionBodyAndFinish,
+  parseIdentifier,
+  parseMaybeAssign,
+  parseMethod,
+  parseParenExpression,
+  parsePropertyName,
+} from "./expression";
+import {parseBindingAtom, parseBindingIdentifier, parseBindingList} from "./lval";
+import {
+  canInsertSemicolon,
+  eatContextual,
+  expect,
+  expectContextual,
+  isContextual,
+  isLineTerminator,
+  semicolon,
+  unexpected,
+} from "./util";
 
-export default class StatementParser extends ExpressionParser {
-  // ### Statement parsing
+export function parseTopLevel(): File {
+  parseBlockBody(true, tt.eof);
 
-  parseTopLevel(): File {
-    this.parseBlockBody(true, tt.eof);
+  state.scopes.push({
+    startTokenIndex: 0,
+    endTokenIndex: state.tokens.length,
+    isFunctionScope: true,
+  });
 
-    this.state.scopes.push({
-      startTokenIndex: 0,
-      endTokenIndex: this.state.tokens.length,
-      isFunctionScope: true,
-    });
+  return {
+    tokens: state.tokens,
+    scopes: state.scopes,
+  };
+}
 
-    return {
-      tokens: this.state.tokens,
-      scopes: this.state.scopes,
-    };
-  }
+// Parse a single statement.
+//
+// If expecting a statement and finding a slash operator, parse a
+// regular expression literal. This is to handle cases like
+// `if (foo) /blah/.exec(foo)`, where looking at the previous token
+// does not help.
 
-  // Parse a single statement.
-  //
-  // If expecting a statement and finding a slash operator, parse a
-  // regular expression literal. This is to handle cases like
-  // `if (foo) /blah/.exec(foo)`, where looking at the previous token
-  // does not help.
-
-  parseStatement(declaration: boolean, topLevel: boolean = false): void {
-    if (this.match(tt.at)) {
-      this.parseDecorators();
+export function parseStatement(declaration: boolean, topLevel: boolean = false): void {
+  if (hasPlugin("flow")) {
+    if (flowTryParseStatement()) {
+      return;
     }
-    this.parseStatementContent(declaration, topLevel);
+  }
+  if (match(tt.at)) {
+    parseDecorators();
+  }
+  parseStatementContent(declaration, topLevel);
+}
+
+function parseStatementContent(declaration: boolean, topLevel: boolean): void {
+  if (hasPlugin("typescript")) {
+    if (tsTryParseStatementContent()) {
+      return;
+    }
   }
 
-  parseStatementContent(declaration: boolean, topLevel: boolean): void {
-    const starttype = this.state.type;
+  const starttype = state.type;
 
-    // Most types of statements are recognized by the keyword they
-    // start with. Many are trivial to parse, some require a bit of
-    // complexity.
+  // Most types of statements are recognized by the keyword they
+  // start with. Many are trivial to parse, some require a bit of
+  // complexity.
 
-    switch (starttype) {
-      case tt._break:
-      case tt._continue:
-        this.parseBreakContinueStatement();
-        return;
-      case tt._debugger:
-        this.parseDebuggerStatement();
-        return;
-      case tt._do:
-        this.parseDoStatement();
-        return;
-      case tt._for:
-        this.parseForStatement();
-        return;
-      case tt._function:
-        if (this.lookaheadType() === tt.dot) break;
-        if (!declaration) this.unexpected();
-        this.parseFunctionStatement();
-        return;
+  switch (starttype) {
+    case tt._break:
+    case tt._continue:
+      parseBreakContinueStatement();
+      return;
+    case tt._debugger:
+      parseDebuggerStatement();
+      return;
+    case tt._do:
+      parseDoStatement();
+      return;
+    case tt._for:
+      parseForStatement();
+      return;
+    case tt._function:
+      if (lookaheadType() === tt.dot) break;
+      if (!declaration) unexpected();
+      parseFunctionStatement();
+      return;
 
-      case tt._class:
-        if (!declaration) this.unexpected();
-        this.parseClass(true);
-        return;
+    case tt._class:
+      if (!declaration) unexpected();
+      parseClass(true);
+      return;
 
-      case tt._if:
-        this.parseIfStatement();
-        return;
-      case tt._return:
-        this.parseReturnStatement();
-        return;
-      case tt._switch:
-        this.parseSwitchStatement();
-        return;
-      case tt._throw:
-        this.parseThrowStatement();
-        return;
-      case tt._try:
-        this.parseTryStatement();
-        return;
+    case tt._if:
+      parseIfStatement();
+      return;
+    case tt._return:
+      parseReturnStatement();
+      return;
+    case tt._switch:
+      parseSwitchStatement();
+      return;
+    case tt._throw:
+      parseThrowStatement();
+      return;
+    case tt._try:
+      parseTryStatement();
+      return;
 
-      case tt._let:
-      case tt._const:
-        if (!declaration) this.unexpected(); // NOTE: falls through to _var
+    case tt._let:
+    case tt._const:
+      if (!declaration) unexpected(); // NOTE: falls through to _var
 
-      case tt._var:
-        this.parseVarStatement(starttype);
-        return;
+    case tt._var:
+      parseVarStatement(starttype);
+      return;
 
-      case tt._while:
-        this.parseWhileStatement();
-        return;
-      case tt.braceL:
-        this.parseBlock();
-        return;
-      case tt.semi:
-        this.parseEmptyStatement();
-        return;
-      case tt._export:
-      case tt._import: {
-        const nextType = this.lookaheadType();
-        if (nextType === tt.parenL || nextType === tt.dot) {
-          break;
-        }
-        this.next();
-        if (starttype === tt._import) {
-          this.parseImport();
-        } else {
-          this.parseExport();
-        }
-        return;
-      }
-      case tt.name:
-        if (this.state.contextualKeyword === ContextualKeyword._async) {
-          const functionStart = this.state.start;
-          // peek ahead and see if next token is a function
-          const snapshot = this.state.snapshot();
-          this.next();
-          if (this.match(tt._function) && !this.canInsertSemicolon()) {
-            this.expect(tt._function);
-            this.parseFunction(functionStart, true, false);
-            return;
-          } else {
-            this.state.restoreFromSnapshot(snapshot);
-          }
-        }
-      default:
-        // Do nothing.
+    case tt._while:
+      parseWhileStatement();
+      return;
+    case tt.braceL:
+      parseBlock();
+      return;
+    case tt.semi:
+      parseEmptyStatement();
+      return;
+    case tt._export:
+    case tt._import: {
+      const nextType = lookaheadType();
+      if (nextType === tt.parenL || nextType === tt.dot) {
         break;
-    }
-
-    // If the statement does not start with a statement keyword or a
-    // brace, it's an ExpressionStatement or LabeledStatement. We
-    // simply start parsing an expression, and afterwards, if the
-    // next token is a colon and the expression was a simple
-    // Identifier node, we switch to interpreting it as a label.
-    const initialTokensLength = this.state.tokens.length;
-    this.parseExpression();
-    let simpleName = null;
-    if (this.state.tokens.length === initialTokensLength + 1) {
-      const token = this.state.tokens[this.state.tokens.length - 1];
-      if (token.type === tt.name) {
-        simpleName = token.contextualKeyword;
       }
-    }
-    if (simpleName == null) {
-      this.semicolon();
-      return;
-    }
-    if (this.eat(tt.colon)) {
-      this.parseLabeledStatement();
-    } else {
-      // This was an identifier, so we might want to handle flow/typescript-specific cases.
-      this.parseIdentifierStatement(simpleName);
-    }
-  }
-
-  parseDecorators(): void {
-    while (this.match(tt.at)) {
-      this.parseDecorator();
-    }
-  }
-
-  parseDecorator(): void {
-    this.next();
-    this.parseIdentifier();
-    while (this.eat(tt.dot)) {
-      this.parseIdentifier();
-    }
-    if (this.eat(tt.parenL)) {
-      this.parseCallExpressionArguments(tt.parenR);
-    }
-  }
-
-  parseBreakContinueStatement(): void {
-    this.next();
-    if (!this.isLineTerminator()) {
-      this.parseIdentifier();
-      this.semicolon();
-    }
-  }
-
-  parseDebuggerStatement(): void {
-    this.next();
-    this.semicolon();
-  }
-
-  parseDoStatement(): void {
-    this.next();
-    this.parseStatement(false);
-    this.expect(tt._while);
-    this.parseParenExpression();
-    this.eat(tt.semi);
-  }
-
-  parseForStatement(): void {
-    const startTokenIndex = this.state.tokens.length;
-    this.parseAmbiguousForStatement();
-    const endTokenIndex = this.state.tokens.length;
-    this.state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: false});
-  }
-
-  // Disambiguating between a `for` and a `for`/`in` or `for`/`of`
-  // loop is non-trivial. Basically, we have to parse the init `var`
-  // statement or expression, disallowing the `in` operator (see
-  // the second parameter to `parseExpression`), and then check
-  // whether the next token is `in` or `of`. When there is no init
-  // part (semicolon immediately after the opening parenthesis), it
-  // is a regular `for` loop.
-  parseAmbiguousForStatement(): void {
-    this.next();
-
-    let forAwait = false;
-    if (this.isContextual(ContextualKeyword._await)) {
-      forAwait = true;
-      this.next();
-    }
-    this.expect(tt.parenL);
-
-    if (this.match(tt.semi)) {
-      if (forAwait) {
-        this.unexpected();
-      }
-      this.parseFor();
-      return;
-    }
-
-    if (this.match(tt._var) || this.match(tt._let) || this.match(tt._const)) {
-      const varKind = this.state.type;
-      this.next();
-      this.parseVar(true, varKind);
-      if (this.match(tt._in) || this.isContextual(ContextualKeyword._of)) {
-        this.parseForIn(forAwait);
-        return;
-      }
-      this.parseFor();
-      return;
-    }
-
-    this.parseExpression(true);
-    if (this.match(tt._in) || this.isContextual(ContextualKeyword._of)) {
-      this.parseForIn(forAwait);
-      return;
-    }
-    if (forAwait) {
-      this.unexpected();
-    }
-    this.parseFor();
-  }
-
-  parseFunctionStatement(): void {
-    const functionStart = this.state.start;
-    this.next();
-    this.parseFunction(functionStart, true);
-  }
-
-  parseIfStatement(): void {
-    this.next();
-    this.parseParenExpression();
-    this.parseStatement(false);
-    if (this.eat(tt._else)) {
-      this.parseStatement(false);
-    }
-  }
-
-  parseReturnStatement(): void {
-    this.next();
-
-    // In `return` (and `break`/`continue`), the keywords with
-    // optional arguments, we eagerly look for a semicolon or the
-    // possibility to insert one.
-
-    if (!this.isLineTerminator()) {
-      this.parseExpression();
-      this.semicolon();
-    }
-  }
-
-  parseSwitchStatement(): void {
-    this.next();
-    this.parseParenExpression();
-    const startTokenIndex = this.state.tokens.length;
-    this.expect(tt.braceL);
-
-    // Don't bother validation; just go through any sequence of cases, defaults, and statements.
-    while (!this.match(tt.braceR)) {
-      if (this.match(tt._case) || this.match(tt._default)) {
-        const isCase = this.match(tt._case);
-        this.next();
-        if (isCase) {
-          this.parseExpression();
-        }
-        this.expect(tt.colon);
+      next();
+      if (starttype === tt._import) {
+        parseImport();
       } else {
-        this.parseStatement(true);
+        parseExport();
       }
+      return;
     }
-    this.next(); // Closing brace
-    const endTokenIndex = this.state.tokens.length;
-    this.state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: false});
-  }
-
-  parseThrowStatement(): void {
-    this.next();
-    this.parseExpression();
-    this.semicolon();
-  }
-
-  parseTryStatement(): void {
-    this.next();
-
-    this.parseBlock();
-
-    if (this.match(tt._catch)) {
-      this.next();
-      let catchBindingStartTokenIndex = null;
-      if (this.match(tt.parenL)) {
-        catchBindingStartTokenIndex = this.state.tokens.length;
-        this.expect(tt.parenL);
-        this.parseBindingAtom(true /* isBlockScope */);
-        this.expect(tt.parenR);
+    case tt.name:
+      if (state.contextualKeyword === ContextualKeyword._async) {
+        const functionStart = state.start;
+        // peek ahead and see if next token is a function
+        const snapshot = state.snapshot();
+        next();
+        if (match(tt._function) && !canInsertSemicolon()) {
+          expect(tt._function);
+          parseFunction(functionStart, true, false);
+          return;
+        } else {
+          state.restoreFromSnapshot(snapshot);
+        }
       }
-      this.parseBlock();
-      if (catchBindingStartTokenIndex != null) {
-        // We need a special scope for the catch binding which includes the binding itself and the
-        // catch block.
-        const endTokenIndex = this.state.tokens.length;
-        this.state.scopes.push({
-          startTokenIndex: catchBindingStartTokenIndex,
-          endTokenIndex,
-          isFunctionScope: false,
-        });
-      }
-    }
-    if (this.eat(tt._finally)) {
-      this.parseBlock();
-    }
+    default:
+      // Do nothing.
+      break;
   }
 
-  parseVarStatement(kind: TokenType): void {
-    this.next();
-    this.parseVar(false, kind);
-    this.semicolon();
-  }
-
-  parseWhileStatement(): void {
-    this.next();
-    this.parseParenExpression();
-    this.parseStatement(false);
-  }
-
-  parseEmptyStatement(): void {
-    this.next();
-  }
-
-  parseLabeledStatement(): void {
-    this.parseStatement(true);
-  }
-
-  /**
-   * Parse a statement starting with an identifier of the given name. Subclasses match on the name
-   * to handle statements like "declare".
-   */
-  parseIdentifierStatement(contextualKeyword: ContextualKeyword): void {
-    this.semicolon();
-  }
-
-  // Parse a semicolon-enclosed block of statements, handling `"use
-  // strict"` declarations when `allowStrict` is true (used for
-  // function bodies).
-
-  parseBlock(
-    allowDirectives: boolean = false,
-    isFunctionScope: boolean = false,
-    contextId?: number,
-  ): void {
-    const startTokenIndex = this.state.tokens.length;
-    this.expect(tt.braceL);
-    if (contextId) {
-      this.state.tokens[this.state.tokens.length - 1].contextId = contextId;
-    }
-    this.parseBlockBody(false, tt.braceR);
-    if (contextId) {
-      this.state.tokens[this.state.tokens.length - 1].contextId = contextId;
-    }
-    const endTokenIndex = this.state.tokens.length;
-    this.state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope});
-  }
-
-  parseBlockBody(topLevel: boolean, end: TokenType): void {
-    while (!this.eat(end)) {
-      this.parseStatement(true, topLevel);
+  // If the statement does not start with a statement keyword or a
+  // brace, it's an ExpressionStatement or LabeledStatement. We
+  // simply start parsing an expression, and afterwards, if the
+  // next token is a colon and the expression was a simple
+  // Identifier node, we switch to interpreting it as a label.
+  const initialTokensLength = state.tokens.length;
+  parseExpression();
+  let simpleName = null;
+  if (state.tokens.length === initialTokensLength + 1) {
+    const token = state.tokens[state.tokens.length - 1];
+    if (token.type === tt.name) {
+      simpleName = token.contextualKeyword;
     }
   }
-
-  // Parse a regular `for` loop. The disambiguation code in
-  // `parseStatement` will already have parsed the init statement or
-  // expression.
-
-  parseFor(): void {
-    this.expect(tt.semi);
-    if (!this.match(tt.semi)) {
-      this.parseExpression();
-    }
-    this.expect(tt.semi);
-    if (!this.match(tt.parenR)) {
-      this.parseExpression();
-    }
-    this.expect(tt.parenR);
-    this.parseStatement(false);
+  if (simpleName == null) {
+    semicolon();
+    return;
   }
+  if (eat(tt.colon)) {
+    parseLabeledStatement();
+  } else {
+    // This was an identifier, so we might want to handle flow/typescript-specific cases.
+    parseIdentifierStatement(simpleName);
+  }
+}
 
-  // Parse a `for`/`in` and `for`/`of` loop, which are almost
-  // same from parser's perspective.
+export function parseDecorators(): void {
+  while (match(tt.at)) {
+    parseDecorator();
+  }
+}
 
-  parseForIn(forAwait: boolean): void {
+function parseDecorator(): void {
+  next();
+  parseIdentifier();
+  while (eat(tt.dot)) {
+    parseIdentifier();
+  }
+  if (eat(tt.parenL)) {
+    parseCallExpressionArguments(tt.parenR);
+  }
+}
+
+function parseBreakContinueStatement(): void {
+  next();
+  if (!isLineTerminator()) {
+    parseIdentifier();
+    semicolon();
+  }
+}
+
+function parseDebuggerStatement(): void {
+  next();
+  semicolon();
+}
+
+function parseDoStatement(): void {
+  next();
+  parseStatement(false);
+  expect(tt._while);
+  parseParenExpression();
+  eat(tt.semi);
+}
+
+function parseForStatement(): void {
+  const startTokenIndex = state.tokens.length;
+  parseAmbiguousForStatement();
+  const endTokenIndex = state.tokens.length;
+  state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: false});
+}
+
+// Disambiguating between a `for` and a `for`/`in` or `for`/`of`
+// loop is non-trivial. Basically, we have to parse the init `var`
+// statement or expression, disallowing the `in` operator (see
+// the second parameter to `parseExpression`), and then check
+// whether the next token is `in` or `of`. When there is no init
+// part (semicolon immediately after the opening parenthesis), it
+// is a regular `for` loop.
+function parseAmbiguousForStatement(): void {
+  next();
+
+  let forAwait = false;
+  if (isContextual(ContextualKeyword._await)) {
+    forAwait = true;
+    next();
+  }
+  expect(tt.parenL);
+
+  if (match(tt.semi)) {
     if (forAwait) {
-      this.eatContextual(ContextualKeyword._of);
+      unexpected();
+    }
+    parseFor();
+    return;
+  }
+
+  if (match(tt._var) || match(tt._let) || match(tt._const)) {
+    const varKind = state.type;
+    next();
+    parseVar(true, varKind);
+    if (match(tt._in) || isContextual(ContextualKeyword._of)) {
+      parseForIn(forAwait);
+      return;
+    }
+    parseFor();
+    return;
+  }
+
+  parseExpression(true);
+  if (match(tt._in) || isContextual(ContextualKeyword._of)) {
+    parseForIn(forAwait);
+    return;
+  }
+  if (forAwait) {
+    unexpected();
+  }
+  parseFor();
+}
+
+function parseFunctionStatement(): void {
+  const functionStart = state.start;
+  next();
+  parseFunction(functionStart, true);
+}
+
+function parseIfStatement(): void {
+  next();
+  parseParenExpression();
+  parseStatement(false);
+  if (eat(tt._else)) {
+    parseStatement(false);
+  }
+}
+
+function parseReturnStatement(): void {
+  next();
+
+  // In `return` (and `break`/`continue`), the keywords with
+  // optional arguments, we eagerly look for a semicolon or the
+  // possibility to insert one.
+
+  if (!isLineTerminator()) {
+    parseExpression();
+    semicolon();
+  }
+}
+
+function parseSwitchStatement(): void {
+  next();
+  parseParenExpression();
+  const startTokenIndex = state.tokens.length;
+  expect(tt.braceL);
+
+  // Don't bother validation; just go through any sequence of cases, defaults, and statements.
+  while (!match(tt.braceR)) {
+    if (match(tt._case) || match(tt._default)) {
+      const isCase = match(tt._case);
+      next();
+      if (isCase) {
+        parseExpression();
+      }
+      expect(tt.colon);
     } else {
-      this.next();
-    }
-    this.parseExpression();
-    this.expect(tt.parenR);
-    this.parseStatement(false);
-  }
-
-  // Parse a list of variable declarations.
-
-  parseVar(isFor: boolean, kind: TokenType): void {
-    while (true) {
-      const isBlockScope = kind === tt._const || kind === tt._let;
-      this.parseVarHead(isBlockScope);
-      if (this.eat(tt.eq)) {
-        this.parseMaybeAssign(isFor);
-      }
-      if (!this.eat(tt.comma)) break;
+      parseStatement(true);
     }
   }
+  next(); // Closing brace
+  const endTokenIndex = state.tokens.length;
+  state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: false});
+}
 
-  parseVarHead(isBlockScope: boolean): void {
-    this.parseBindingAtom(isBlockScope);
-  }
+function parseThrowStatement(): void {
+  next();
+  parseExpression();
+  semicolon();
+}
 
-  // Parse a function declaration or literal (depending on the
-  // `isStatement` parameter).
+function parseTryStatement(): void {
+  next();
 
-  parseFunction(
-    functionStart: number,
-    isStatement: boolean,
-    allowExpressionBody?: boolean,
-    optionalId?: boolean,
-  ): void {
-    let isGenerator = false;
-    if (this.match(tt.star)) {
-      isGenerator = true;
-      this.next();
+  parseBlock();
+
+  if (match(tt._catch)) {
+    next();
+    let catchBindingStartTokenIndex = null;
+    if (match(tt.parenL)) {
+      catchBindingStartTokenIndex = state.tokens.length;
+      expect(tt.parenL);
+      parseBindingAtom(true /* isBlockScope */);
+      expect(tt.parenR);
     }
-
-    if (isStatement && !optionalId && !this.match(tt.name) && !this.match(tt._yield)) {
-      this.unexpected();
-    }
-
-    let nameScopeStartTokenIndex = null;
-
-    if (this.match(tt.name)) {
-      // Expression-style functions should limit their name's scope to the function body, so we make
-      // a new function scope to enforce that.
-      if (!isStatement) {
-        nameScopeStartTokenIndex = this.state.tokens.length;
-      }
-      this.parseBindingIdentifier();
-      this.state.tokens[this.state.tokens.length - 1].identifierRole =
-        IdentifierRole.FunctionScopedDeclaration;
-    }
-
-    const startTokenIndex = this.state.tokens.length;
-    this.parseFunctionParams();
-    this.parseFunctionBodyAndFinish(functionStart, isGenerator, allowExpressionBody);
-    const endTokenIndex = this.state.tokens.length;
-    // In addition to the block scope of the function body, we need a separate function-style scope
-    // that includes the params.
-    this.state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: true});
-    if (nameScopeStartTokenIndex !== null) {
-      this.state.scopes.push({
-        startTokenIndex: nameScopeStartTokenIndex,
-        endTokenIndex,
-        isFunctionScope: true,
-      });
-    }
-  }
-
-  parseFunctionParams(allowModifiers?: boolean, funcContextId?: number): void {
-    this.expect(tt.parenL);
-    if (funcContextId) {
-      this.state.tokens[this.state.tokens.length - 1].contextId = funcContextId;
-    }
-    this.parseBindingList(
-      tt.parenR,
-      false /* isBlockScope */,
-      false /* allowEmpty */,
-      allowModifiers,
-    );
-    if (funcContextId) {
-      this.state.tokens[this.state.tokens.length - 1].contextId = funcContextId;
-    }
-  }
-
-  // Parse a class declaration or literal (depending on the
-  // `isStatement` parameter).
-
-  parseClass(isStatement: boolean, optionalId: boolean = false): void {
-    // Put a context ID on the class keyword, the open-brace, and the close-brace, so that later
-    // code can easily navigate to meaningful points on the class.
-    const contextId = this.nextContextId++;
-
-    this.next();
-    this.state.tokens[this.state.tokens.length - 1].contextId = contextId;
-    this.state.tokens[this.state.tokens.length - 1].isExpression = !isStatement;
-    // Like with functions, we declare a special "name scope" from the start of the name to the end
-    // of the class, but only with expression-style classes, to represent the fact that the name is
-    // available to the body of the class but not an outer declaration.
-    let nameScopeStartTokenIndex = null;
-    if (!isStatement) {
-      nameScopeStartTokenIndex = this.state.tokens.length;
-    }
-    this.parseClassId(isStatement, optionalId);
-    this.parseClassSuper();
-    const openBraceIndex = this.state.tokens.length;
-    this.parseClassBody(contextId);
-    this.state.tokens[openBraceIndex].contextId = contextId;
-    this.state.tokens[this.state.tokens.length - 1].contextId = contextId;
-    if (nameScopeStartTokenIndex !== null) {
-      const endTokenIndex = this.state.tokens.length;
-      this.state.scopes.push({
-        startTokenIndex: nameScopeStartTokenIndex,
+    parseBlock();
+    if (catchBindingStartTokenIndex != null) {
+      // We need a special scope for the catch binding which includes the binding itself and the
+      // catch block.
+      const endTokenIndex = state.tokens.length;
+      state.scopes.push({
+        startTokenIndex: catchBindingStartTokenIndex,
         endTokenIndex,
         isFunctionScope: false,
       });
     }
   }
-
-  isClassProperty(): boolean {
-    return this.match(tt.eq) || this.match(tt.semi) || this.match(tt.braceR);
+  if (eat(tt._finally)) {
+    parseBlock();
   }
+}
 
-  isClassMethod(): boolean {
-    return this.match(tt.parenL);
+export function parseVarStatement(kind: TokenType): void {
+  next();
+  parseVar(false, kind);
+  semicolon();
+}
+
+function parseWhileStatement(): void {
+  next();
+  parseParenExpression();
+  parseStatement(false);
+}
+
+function parseEmptyStatement(): void {
+  next();
+}
+
+function parseLabeledStatement(): void {
+  parseStatement(true);
+}
+
+/**
+ * Parse a statement starting with an identifier of the given name. Subclasses match on the name
+ * to handle statements like "declare".
+ */
+function parseIdentifierStatement(contextualKeyword: ContextualKeyword): void {
+  if (hasPlugin("typescript")) {
+    tsParseIdentifierStatement(contextualKeyword);
+  } else if (hasPlugin("flow")) {
+    flowParseIdentifierStatement(contextualKeyword);
+  } else {
+    semicolon();
   }
+}
 
-  parseClassBody(classContextId: number): void {
-    this.expect(tt.braceL);
+// Parse a semicolon-enclosed block of statements, handling `"use
+// strict"` declarations when `allowStrict` is true (used for
+// function bodies).
 
-    while (!this.eat(tt.braceR)) {
-      if (this.eat(tt.semi)) {
-        continue;
-      }
+export function parseBlock(
+  allowDirectives: boolean = false,
+  isFunctionScope: boolean = false,
+  contextId?: number,
+): void {
+  const startTokenIndex = state.tokens.length;
+  expect(tt.braceL);
+  if (contextId) {
+    state.tokens[state.tokens.length - 1].contextId = contextId;
+  }
+  parseBlockBody(false, tt.braceR);
+  if (contextId) {
+    state.tokens[state.tokens.length - 1].contextId = contextId;
+  }
+  const endTokenIndex = state.tokens.length;
+  state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope});
+}
 
-      if (this.match(tt.at)) {
-        this.parseDecorator();
-        continue;
-      }
-      const memberStart = this.state.start;
-      this.parseClassMember(memberStart, classContextId);
+export function parseBlockBody(topLevel: boolean, end: TokenType): void {
+  while (!eat(end)) {
+    parseStatement(true, topLevel);
+  }
+}
+
+// Parse a regular `for` loop. The disambiguation code in
+// `parseStatement` will already have parsed the init statement or
+// expression.
+
+function parseFor(): void {
+  expect(tt.semi);
+  if (!match(tt.semi)) {
+    parseExpression();
+  }
+  expect(tt.semi);
+  if (!match(tt.parenR)) {
+    parseExpression();
+  }
+  expect(tt.parenR);
+  parseStatement(false);
+}
+
+// Parse a `for`/`in` and `for`/`of` loop, which are almost
+// same from parser's perspective.
+
+function parseForIn(forAwait: boolean): void {
+  if (forAwait) {
+    eatContextual(ContextualKeyword._of);
+  } else {
+    next();
+  }
+  parseExpression();
+  expect(tt.parenR);
+  parseStatement(false);
+}
+
+// Parse a list of variable declarations.
+
+function parseVar(isFor: boolean, kind: TokenType): void {
+  while (true) {
+    const isBlockScope = kind === tt._const || kind === tt._let;
+    parseVarHead(isBlockScope);
+    if (eat(tt.eq)) {
+      parseMaybeAssign(isFor);
     }
+    if (!eat(tt.comma)) break;
+  }
+}
+
+function parseVarHead(isBlockScope: boolean): void {
+  parseBindingAtom(isBlockScope);
+  if (hasPlugin("typescript")) {
+    tsAfterParseVarHead();
+  } else if (hasPlugin("flow")) {
+    flowAfterParseVarHead();
+  }
+}
+
+// Parse a function declaration or literal (depending on the
+// `isStatement` parameter).
+
+export function parseFunction(
+  functionStart: number,
+  isStatement: boolean,
+  allowExpressionBody?: boolean,
+  optionalId?: boolean,
+): void {
+  let isGenerator = false;
+  if (match(tt.star)) {
+    isGenerator = true;
+    next();
   }
 
-  parseClassMember(memberStart: number, classContextId: number): void {
-    let isStatic = false;
-    if (this.match(tt.name) && this.state.contextualKeyword === ContextualKeyword._static) {
-      this.parseIdentifier(); // eats 'static'
-      if (this.isClassMethod()) {
-        this.parseClassMethod(memberStart, false, /* isConstructor */ false);
-        return;
-      } else if (this.isClassProperty()) {
-        this.parseClassProperty();
-        return;
-      }
-      // otherwise something static
-      this.state.tokens[this.state.tokens.length - 1].type = tt._static;
-      isStatic = true;
+  if (isStatement && !optionalId && !match(tt.name) && !match(tt._yield)) {
+    unexpected();
+  }
+
+  let nameScopeStartTokenIndex = null;
+
+  if (match(tt.name)) {
+    // Expression-style functions should limit their name's scope to the function body, so we make
+    // a new function scope to enforce that.
+    if (!isStatement) {
+      nameScopeStartTokenIndex = state.tokens.length;
+    }
+    parseBindingIdentifier();
+    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.FunctionScopedDeclaration;
+  }
+
+  const startTokenIndex = state.tokens.length;
+  parseFunctionParams();
+  parseFunctionBodyAndFinish(functionStart, isGenerator, allowExpressionBody);
+  const endTokenIndex = state.tokens.length;
+  // In addition to the block scope of the function body, we need a separate function-style scope
+  // that includes the params.
+  state.scopes.push({startTokenIndex, endTokenIndex, isFunctionScope: true});
+  if (nameScopeStartTokenIndex !== null) {
+    state.scopes.push({
+      startTokenIndex: nameScopeStartTokenIndex,
+      endTokenIndex,
+      isFunctionScope: true,
+    });
+  }
+}
+
+export function parseFunctionParams(allowModifiers?: boolean, funcContextId?: number): void {
+  if (hasPlugin("typescript")) {
+    tsStartParseFunctionParams();
+  } else if (hasPlugin("flow")) {
+    flowStartParseFunctionParams();
+  }
+
+  expect(tt.parenL);
+  if (funcContextId) {
+    state.tokens[state.tokens.length - 1].contextId = funcContextId;
+  }
+  parseBindingList(tt.parenR, false /* isBlockScope */, false /* allowEmpty */, allowModifiers);
+  if (funcContextId) {
+    state.tokens[state.tokens.length - 1].contextId = funcContextId;
+  }
+}
+
+// Parse a class declaration or literal (depending on the
+// `isStatement` parameter).
+
+export function parseClass(isStatement: boolean, optionalId: boolean = false): void {
+  // Put a context ID on the class keyword, the open-brace, and the close-brace, so that later
+  // code can easily navigate to meaningful points on the class.
+  const contextId = getNextContextId();
+
+  next();
+  state.tokens[state.tokens.length - 1].contextId = contextId;
+  state.tokens[state.tokens.length - 1].isExpression = !isStatement;
+  // Like with functions, we declare a special "name scope" from the start of the name to the end
+  // of the class, but only with expression-style classes, to represent the fact that the name is
+  // available to the body of the class but not an outer declaration.
+  let nameScopeStartTokenIndex = null;
+  if (!isStatement) {
+    nameScopeStartTokenIndex = state.tokens.length;
+  }
+  parseClassId(isStatement, optionalId);
+  parseClassSuper();
+  const openBraceIndex = state.tokens.length;
+  parseClassBody(contextId);
+  state.tokens[openBraceIndex].contextId = contextId;
+  state.tokens[state.tokens.length - 1].contextId = contextId;
+  if (nameScopeStartTokenIndex !== null) {
+    const endTokenIndex = state.tokens.length;
+    state.scopes.push({
+      startTokenIndex: nameScopeStartTokenIndex,
+      endTokenIndex,
+      isFunctionScope: false,
+    });
+  }
+}
+
+function isClassProperty(): boolean {
+  return match(tt.eq) || match(tt.semi) || match(tt.braceR) || match(tt.colon);
+}
+
+function isClassMethod(): boolean {
+  return match(tt.parenL) || match(tt.lessThan);
+}
+
+function parseClassBody(classContextId: number): void {
+  expect(tt.braceL);
+
+  while (!eat(tt.braceR)) {
+    if (eat(tt.semi)) {
+      continue;
     }
 
-    this.parseClassMemberWithIsStatic(memberStart, isStatic, classContextId);
+    if (match(tt.at)) {
+      parseDecorator();
+      continue;
+    }
+    const memberStart = state.start;
+    parseClassMember(memberStart, classContextId);
   }
+}
 
-  parseClassMemberWithIsStatic(
-    memberStart: number,
-    isStatic: boolean,
-    classContextId: number,
-  ): void {
-    if (this.eat(tt.star)) {
-      // a generator
-      this.parseClassPropertyName(classContextId);
-      this.parseClassMethod(memberStart, true, /* isConstructor */ false);
+function parseClassMember(memberStart: number, classContextId: number): void {
+  if (hasPlugin("typescript")) {
+    tsParseAccessModifier();
+  }
+  let isStatic = false;
+  if (match(tt.name) && state.contextualKeyword === ContextualKeyword._static) {
+    parseIdentifier(); // eats 'static'
+    if (isClassMethod()) {
+      parseClassMethod(memberStart, false, /* isConstructor */ false);
+      return;
+    } else if (isClassProperty()) {
+      parseClassProperty();
       return;
     }
+    // otherwise something static
+    state.tokens[state.tokens.length - 1].type = tt._static;
+    isStatic = true;
+  }
 
-    // Get the identifier name so we can tell if it's actually a keyword like "async", "get", or
-    // "set".
-    this.parseClassPropertyName(classContextId);
-    let isConstructor = false;
-    const token = this.state.tokens[this.state.tokens.length - 1];
-    // We allow "constructor" as either an identifier or a string.
-    if (token.contextualKeyword === ContextualKeyword._constructor) {
-      isConstructor = true;
+  parseClassMemberWithIsStatic(memberStart, isStatic, classContextId);
+}
+
+function parseClassMemberWithIsStatic(
+  memberStart: number,
+  isStatic: boolean,
+  classContextId: number,
+): void {
+  if (hasPlugin("typescript")) {
+    if (tsTryParseClassMemberWithIsStatic(isStatic, classContextId)) {
+      return;
     }
-    this.parsePostMemberNameModifiers();
+  }
+  if (eat(tt.star)) {
+    // a generator
+    parseClassPropertyName(classContextId);
+    parseClassMethod(memberStart, true, /* isConstructor */ false);
+    return;
+  }
 
-    if (this.isClassMethod()) {
-      this.parseClassMethod(memberStart, false, isConstructor);
-    } else if (this.isClassProperty()) {
-      this.parseClassProperty();
-    } else if (token.contextualKeyword === ContextualKeyword._async && !this.isLineTerminator()) {
-      this.state.tokens[this.state.tokens.length - 1].type = tt._async;
-      // an async method
-      const isGenerator = this.match(tt.star);
-      if (isGenerator) {
-        this.next();
-      }
+  // Get the identifier name so we can tell if it's actually a keyword like "async", "get", or
+  // "set".
+  parseClassPropertyName(classContextId);
+  let isConstructor = false;
+  const token = state.tokens[state.tokens.length - 1];
+  // We allow "constructor" as either an identifier or a string.
+  if (token.contextualKeyword === ContextualKeyword._constructor) {
+    isConstructor = true;
+  }
+  parsePostMemberNameModifiers();
 
-      // The so-called parsed name would have been "async": get the real name.
-      this.parseClassPropertyName(classContextId);
-      this.parseClassMethod(memberStart, isGenerator, false /* isConstructor */);
-    } else if (
-      (token.contextualKeyword === ContextualKeyword._get ||
-        token.contextualKeyword === ContextualKeyword._set) &&
-      !(this.isLineTerminator() && this.match(tt.star))
-    ) {
-      if (token.contextualKeyword === ContextualKeyword._get) {
-        this.state.tokens[this.state.tokens.length - 1].type = tt._get;
-      } else {
-        this.state.tokens[this.state.tokens.length - 1].type = tt._set;
-      }
-      // `get\n*` is an uninitialized property named 'get' followed by a generator.
-      // a getter or setter
-      // The so-called parsed name would have been "get/set": get the real name.
-      this.parseClassPropertyName(classContextId);
-      this.parseClassMethod(memberStart, false, /* isConstructor */ false);
-    } else if (this.isLineTerminator()) {
-      // an uninitialized class property (due to ASI, since we don't otherwise recognize the next token)
-      this.parseClassProperty();
+  if (isClassMethod()) {
+    parseClassMethod(memberStart, false, isConstructor);
+  } else if (isClassProperty()) {
+    parseClassProperty();
+  } else if (token.contextualKeyword === ContextualKeyword._async && !isLineTerminator()) {
+    state.tokens[state.tokens.length - 1].type = tt._async;
+    // an async method
+    const isGenerator = match(tt.star);
+    if (isGenerator) {
+      next();
+    }
+
+    // The so-called parsed name would have been "async": get the real name.
+    parseClassPropertyName(classContextId);
+    parseClassMethod(memberStart, isGenerator, false /* isConstructor */);
+  } else if (
+    (token.contextualKeyword === ContextualKeyword._get ||
+      token.contextualKeyword === ContextualKeyword._set) &&
+    !(isLineTerminator() && match(tt.star))
+  ) {
+    if (token.contextualKeyword === ContextualKeyword._get) {
+      state.tokens[state.tokens.length - 1].type = tt._get;
     } else {
-      this.unexpected();
+      state.tokens[state.tokens.length - 1].type = tt._set;
+    }
+    // `get\n*` is an uninitialized property named 'get' followed by a generator.
+    // a getter or setter
+    // The so-called parsed name would have been "get/set": get the real name.
+    parseClassPropertyName(classContextId);
+    parseClassMethod(memberStart, false, /* isConstructor */ false);
+  } else if (isLineTerminator()) {
+    // an uninitialized class property (due to ASI, since we don't otherwise recognize the next token)
+    parseClassProperty();
+  } else {
+    unexpected();
+  }
+}
+
+function parseClassMethod(
+  functionStart: number,
+  isGenerator: boolean,
+  isConstructor: boolean,
+): void {
+  if (hasPlugin("typescript")) {
+    tsTryParseTypeParameters();
+  } else if (hasPlugin("flow")) {
+    if (match(tt.lessThan)) {
+      flowParseTypeParameterDeclaration();
+    }
+  }
+  parseMethod(functionStart, isGenerator, isConstructor);
+}
+
+// Return the name of the class property, if it is a simple identifier.
+export function parseClassPropertyName(classContextId: number): void {
+  parsePropertyName(classContextId);
+}
+
+// Overridden in typescript.js
+export function parsePostMemberNameModifiers(): void {
+  if (hasPlugin("typescript")) {
+    eat(tt.question);
+  }
+}
+
+export function parseClassProperty(): void {
+  if (hasPlugin("typescript")) {
+    tsTryParseTypeAnnotation();
+  } else if (hasPlugin("flow")) {
+    if (match(tt.colon)) {
+      flowParseTypeAnnotation();
     }
   }
 
-  parseClassMethod(functionStart: number, isGenerator: boolean, isConstructor: boolean): void {
-    this.parseMethod(functionStart, isGenerator, isConstructor);
+  if (match(tt.eq)) {
+    const equalsTokenIndex = state.tokens.length;
+    next();
+    parseMaybeAssign();
+    state.tokens[equalsTokenIndex].rhsEndIndex = state.tokens.length;
+  }
+  semicolon();
+}
+
+function parseClassId(isStatement: boolean, optionalId: boolean = false): void {
+  if (
+    hasPlugin("typescript") &&
+    (!isStatement || optionalId) &&
+    isContextual(ContextualKeyword._implements)
+  ) {
+    return;
   }
 
-  // Return the name of the class property, if it is a simple identifier.
-  parseClassPropertyName(classContextId: number): void {
-    this.parsePropertyName(classContextId);
+  if (match(tt.name)) {
+    parseIdentifier();
+    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.BlockScopedDeclaration;
   }
 
-  // Overridden in typescript.js
-  parsePostMemberNameModifiers(): void {}
-
-  parseClassProperty(): void {
-    if (this.match(tt.eq)) {
-      const equalsTokenIndex = this.state.tokens.length;
-      this.next();
-      this.parseMaybeAssign();
-      this.state.tokens[equalsTokenIndex].rhsEndIndex = this.state.tokens.length;
+  if (hasPlugin("typescript")) {
+    tsTryParseTypeParameters();
+  } else if (hasPlugin("flow")) {
+    if (match(tt.lessThan)) {
+      flowParseTypeParameterDeclaration();
     }
-    this.semicolon();
   }
+}
 
-  parseClassId(isStatement: boolean, optionalId: boolean = false): void {
-    if (this.match(tt.name)) {
-      this.parseIdentifier();
-      this.state.tokens[this.state.tokens.length - 1].identifierRole =
-        IdentifierRole.BlockScopedDeclaration;
+// Returns true if there was a superclass.
+function parseClassSuper(): void {
+  let hasSuper;
+  if (eat(tt._extends)) {
+    parseExprSubscripts();
+    hasSuper = true;
+  } else {
+    hasSuper = false;
+  }
+  if (hasPlugin("typescript")) {
+    tsAfterParseClassSuper(hasSuper);
+  } else if (hasPlugin("flow")) {
+    flowAfterParseClassSuper(hasSuper);
+  }
+}
+
+// Parses module export declaration.
+
+export function parseExport(): void {
+  if (hasPlugin("typescript")) {
+    if (tsTryParseExport()) {
+      return;
     }
   }
-
-  // Returns true if there was a superclass.
-  parseClassSuper(): boolean {
-    if (this.eat(tt._extends)) {
-      this.parseExprSubscripts();
-      return true;
+  // export * from '...'
+  if (shouldParseExportStar()) {
+    parseExportStar();
+  } else if (isExportDefaultSpecifier()) {
+    // export default from
+    parseIdentifier();
+    if (match(tt.comma) && lookaheadType() === tt.star) {
+      expect(tt.comma);
+      expect(tt.star);
+      expectContextual(ContextualKeyword._as);
+      parseIdentifier();
+    } else {
+      parseExportSpecifiersMaybe();
     }
+    parseExportFrom();
+  } else if (eat(tt._default)) {
+    // export default ...
+    parseExportDefaultExpression();
+  } else if (shouldParseExportDeclaration()) {
+    parseExportDeclaration();
+  } else {
+    // export { x, y as z } [from '...']
+    parseExportSpecifiers();
+    parseExportFrom();
+  }
+}
+
+function parseExportDefaultExpression(): void {
+  if (hasPlugin("typescript")) {
+    if (tsTryParseExportDefaultExpression()) {
+      return;
+    }
+  }
+  const functionStart = state.start;
+  if (eat(tt._function)) {
+    parseFunction(functionStart, true, false, true);
+  } else if (isContextual(ContextualKeyword._async) && lookaheadType() === tt._function) {
+    // async function declaration
+    eatContextual(ContextualKeyword._async);
+    eat(tt._function);
+    parseFunction(functionStart, true, false, true);
+  } else if (match(tt._class)) {
+    parseClass(true, true);
+  } else {
+    parseMaybeAssign();
+    semicolon();
+  }
+}
+
+function parseExportDeclaration(): void {
+  if (hasPlugin("typescript")) {
+    tsParseExportDeclaration();
+  } else if (hasPlugin("flow")) {
+    flowParseExportDeclaration();
+  } else {
+    parseStatement(true);
+  }
+}
+
+function isExportDefaultSpecifier(): boolean {
+  if (hasPlugin("typescript") && tsIsDeclarationStart()) {
+    return false;
+  } else if (hasPlugin("flow") && flowShouldDisallowExportDefaultSpecifier()) {
+    return false;
+  }
+  if (match(tt.name)) {
+    return state.contextualKeyword !== ContextualKeyword._async;
+  }
+
+  if (!match(tt._default)) {
     return false;
   }
 
-  // Parses module export declaration.
+  const lookahead = lookaheadTypeAndKeyword();
+  return (
+    lookahead.type === tt.comma ||
+    (lookahead.type === tt.name && lookahead.contextualKeyword === ContextualKeyword._from)
+  );
+}
 
-  parseExport(): void {
-    // export * from '...'
-    if (this.shouldParseExportStar()) {
-      this.parseExportStar();
-    } else if (this.isExportDefaultSpecifier()) {
-      // export default from
-      this.parseIdentifier();
-      if (this.match(tt.comma) && this.lookaheadType() === tt.star) {
-        this.expect(tt.comma);
-        this.expect(tt.star);
-        this.expectContextual(ContextualKeyword._as);
-        this.parseIdentifier();
-      } else {
-        this.parseExportSpecifiersMaybe();
-      }
-      this.parseExportFrom();
-    } else if (this.eat(tt._default)) {
-      // export default ...
-      this.parseExportDefaultExpression();
-    } else if (this.shouldParseExportDeclaration()) {
-      this.parseExportDeclaration();
+function parseExportSpecifiersMaybe(): void {
+  if (eat(tt.comma)) {
+    parseExportSpecifiers();
+  }
+}
+
+export function parseExportFrom(): void {
+  if (eatContextual(ContextualKeyword._from)) {
+    parseExprAtom();
+  }
+  semicolon();
+}
+
+function shouldParseExportStar(): boolean {
+  if (hasPlugin("flow")) {
+    return flowShouldParseExportStar();
+  } else {
+    return match(tt.star);
+  }
+}
+
+function parseExportStar(): void {
+  if (hasPlugin("flow")) {
+    flowParseExportStar();
+  } else {
+    baseParseExportStar();
+  }
+}
+
+export function baseParseExportStar(): void {
+  expect(tt.star);
+
+  if (isContextual(ContextualKeyword._as)) {
+    parseExportNamespace();
+  } else {
+    parseExportFrom();
+  }
+}
+
+function parseExportNamespace(): void {
+  next();
+  state.tokens[state.tokens.length - 1].type = tt._as;
+  parseIdentifier();
+  parseExportSpecifiersMaybe();
+  parseExportFrom();
+}
+
+function shouldParseExportDeclaration(): boolean {
+  return (
+    (hasPlugin("typescript") && tsIsDeclarationStart()) ||
+    (hasPlugin("flow") && flowShouldParseExportDeclaration()) ||
+    state.type === tt._var ||
+    state.type === tt._const ||
+    state.type === tt._let ||
+    state.type === tt._function ||
+    state.type === tt._class ||
+    isContextual(ContextualKeyword._async) ||
+    match(tt.at)
+  );
+}
+
+// Parses a comma-separated list of module exports.
+export function parseExportSpecifiers(): void {
+  let first = true;
+
+  // export { x, y as z } [from '...']
+  expect(tt.braceL);
+
+  while (!eat(tt.braceR)) {
+    if (first) {
+      first = false;
     } else {
-      // export { x, y as z } [from '...']
-      this.parseExportSpecifiers();
-      this.parseExportFrom();
+      expect(tt.comma);
+      if (eat(tt.braceR)) break;
+    }
+
+    parseIdentifier();
+    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ExportAccess;
+    if (eatContextual(ContextualKeyword._as)) {
+      parseIdentifier();
     }
   }
+}
 
-  parseExportDefaultExpression(): void {
-    const functionStart = this.state.start;
-    if (this.eat(tt._function)) {
-      this.parseFunction(functionStart, true, false, true);
-    } else if (
-      this.isContextual(ContextualKeyword._async) &&
-      this.lookaheadType() === tt._function
-    ) {
-      // async function declaration
-      this.eatContextual(ContextualKeyword._async);
-      this.eat(tt._function);
-      this.parseFunction(functionStart, true, false, true);
-    } else if (this.match(tt._class)) {
-      this.parseClass(true, true);
+// Parses import declaration.
+
+export function parseImport(): void {
+  if (hasPlugin("typescript") && match(tt.name) && lookaheadType() === tt.eq) {
+    tsParseImportEqualsDeclaration();
+    return;
+  }
+
+  // import '...'
+  if (match(tt.string)) {
+    parseExprAtom();
+  } else {
+    parseImportSpecifiers();
+    expectContextual(ContextualKeyword._from);
+    parseExprAtom();
+  }
+  semicolon();
+}
+
+// eslint-disable-next-line no-unused-vars
+function shouldParseDefaultImport(): boolean {
+  return match(tt.name);
+}
+
+function parseImportSpecifierLocal(): void {
+  parseIdentifier();
+}
+
+// Parses a comma-separated list of module imports.
+function parseImportSpecifiers(): void {
+  if (hasPlugin("flow")) {
+    flowStartParseImportSpecifiers();
+  }
+
+  let first = true;
+  if (shouldParseDefaultImport()) {
+    // import defaultObj, { x, y as z } from '...'
+    parseImportSpecifierLocal();
+
+    if (!eat(tt.comma)) return;
+  }
+
+  if (match(tt.star)) {
+    next();
+    expectContextual(ContextualKeyword._as);
+
+    parseImportSpecifierLocal();
+
+    return;
+  }
+
+  expect(tt.braceL);
+  while (!eat(tt.braceR)) {
+    if (first) {
+      first = false;
     } else {
-      this.parseMaybeAssign();
-      this.semicolon();
-    }
-  }
-
-  // eslint-disable-next-line no-unused-vars
-  parseExportDeclaration(): void {
-    this.parseStatement(true);
-  }
-
-  isExportDefaultSpecifier(): boolean {
-    if (this.match(tt.name)) {
-      return this.state.contextualKeyword !== ContextualKeyword._async;
-    }
-
-    if (!this.match(tt._default)) {
-      return false;
-    }
-
-    const lookahead = this.lookaheadTypeAndKeyword();
-    return (
-      lookahead.type === tt.comma ||
-      (lookahead.type === tt.name && lookahead.contextualKeyword === ContextualKeyword._from)
-    );
-  }
-
-  parseExportSpecifiersMaybe(): void {
-    if (this.eat(tt.comma)) {
-      this.parseExportSpecifiers();
-    }
-  }
-
-  parseExportFrom(): void {
-    if (this.eatContextual(ContextualKeyword._from)) {
-      this.parseExprAtom();
-    }
-    this.semicolon();
-  }
-
-  shouldParseExportStar(): boolean {
-    return this.match(tt.star);
-  }
-
-  parseExportStar(): void {
-    this.expect(tt.star);
-
-    if (this.isContextual(ContextualKeyword._as)) {
-      this.parseExportNamespace();
-    } else {
-      this.parseExportFrom();
-    }
-  }
-
-  parseExportNamespace(): void {
-    this.next();
-    this.state.tokens[this.state.tokens.length - 1].type = tt._as;
-    this.parseIdentifier();
-    this.parseExportSpecifiersMaybe();
-    this.parseExportFrom();
-  }
-
-  shouldParseExportDeclaration(): boolean {
-    return (
-      this.state.type === tt._var ||
-      this.state.type === tt._const ||
-      this.state.type === tt._let ||
-      this.state.type === tt._function ||
-      this.state.type === tt._class ||
-      this.isContextual(ContextualKeyword._async) ||
-      this.match(tt.at)
-    );
-  }
-
-  // Parses a comma-separated list of module exports.
-  parseExportSpecifiers(): void {
-    let first = true;
-
-    // export { x, y as z } [from '...']
-    this.expect(tt.braceL);
-
-    while (!this.eat(tt.braceR)) {
-      if (first) {
-        first = false;
-      } else {
-        this.expect(tt.comma);
-        if (this.eat(tt.braceR)) break;
-      }
-
-      this.parseIdentifier();
-      this.state.tokens[this.state.tokens.length - 1].identifierRole = IdentifierRole.ExportAccess;
-      if (this.eatContextual(ContextualKeyword._as)) {
-        this.parseIdentifier();
-      }
-    }
-  }
-
-  // Parses import declaration.
-
-  parseImport(): void {
-    // import '...'
-    if (this.match(tt.string)) {
-      this.parseExprAtom();
-    } else {
-      this.parseImportSpecifiers();
-      this.expectContextual(ContextualKeyword._from);
-      this.parseExprAtom();
-    }
-    this.semicolon();
-  }
-
-  // eslint-disable-next-line no-unused-vars
-  shouldParseDefaultImport(): boolean {
-    return this.match(tt.name);
-  }
-
-  parseImportSpecifierLocal(): void {
-    this.parseIdentifier();
-  }
-
-  // Parses a comma-separated list of module imports.
-  parseImportSpecifiers(): void {
-    let first = true;
-    if (this.shouldParseDefaultImport()) {
-      // import defaultObj, { x, y as z } from '...'
-      this.parseImportSpecifierLocal();
-
-      if (!this.eat(tt.comma)) return;
-    }
-
-    if (this.match(tt.star)) {
-      this.next();
-      this.expectContextual(ContextualKeyword._as);
-
-      this.parseImportSpecifierLocal();
-
-      return;
-    }
-
-    this.expect(tt.braceL);
-    while (!this.eat(tt.braceR)) {
-      if (first) {
-        first = false;
-      } else {
-        // Detect an attempt to deep destructure
-        if (this.eat(tt.colon)) {
-          this.unexpected(
-            null,
-            "ES2015 named imports do not destructure. Use another statement for destructuring after the import.",
-          );
-        }
-
-        this.expect(tt.comma);
-        if (this.eat(tt.braceR)) break;
+      // Detect an attempt to deep destructure
+      if (eat(tt.colon)) {
+        unexpected(
+          null,
+          "ES2015 named imports do not destructure. Use another statement for destructuring after the import.",
+        );
       }
 
-      this.parseImportSpecifier();
+      expect(tt.comma);
+      if (eat(tt.braceR)) break;
     }
-  }
 
-  parseImportSpecifier(): void {
-    this.parseIdentifier();
-    if (this.eatContextual(ContextualKeyword._as)) {
-      this.parseIdentifier();
-    }
+    parseImportSpecifier();
+  }
+}
+
+function parseImportSpecifier(): void {
+  if (hasPlugin("flow")) {
+    flowParseImportSpecifier();
+    return;
+  }
+  parseIdentifier();
+  if (eatContextual(ContextualKeyword._as)) {
+    parseIdentifier();
   }
 }

--- a/sucrase-babylon/parser/util.ts
+++ b/sucrase-babylon/parser/util.ts
@@ -1,71 +1,70 @@
-import Tokenizer, {ContextualKeyword} from "../tokenizer";
+import {ContextualKeyword, eat, lookaheadTypeAndKeyword, match} from "../tokenizer";
 import {formatTokenType, TokenType, TokenType as tt} from "../tokenizer/types";
 import {lineBreak} from "../util/whitespace";
+import {input, raise, state} from "./base";
 
 // ## Parser utilities
 
-export default class UtilParser extends Tokenizer {
-  // Tests whether parsed token is a contextual keyword.
-  isContextual(contextualKeyword: ContextualKeyword): boolean {
-    return this.state.contextualKeyword === contextualKeyword;
-  }
+// Tests whether parsed token is a contextual keyword.
+export function isContextual(contextualKeyword: ContextualKeyword): boolean {
+  return state.contextualKeyword === contextualKeyword;
+}
 
-  isLookaheadContextual(contextualKeyword: ContextualKeyword): boolean {
-    const l = this.lookaheadTypeAndKeyword();
-    return l.type === tt.name && l.contextualKeyword === contextualKeyword;
-  }
+export function isLookaheadContextual(contextualKeyword: ContextualKeyword): boolean {
+  const l = lookaheadTypeAndKeyword();
+  return l.type === tt.name && l.contextualKeyword === contextualKeyword;
+}
 
-  // Consumes contextual keyword if possible.
-  eatContextual(contextualKeyword: ContextualKeyword): boolean {
-    return this.state.contextualKeyword === contextualKeyword && this.eat(tt.name);
-  }
+// Consumes contextual keyword if possible.
+export function eatContextual(contextualKeyword: ContextualKeyword): boolean {
+  return state.contextualKeyword === contextualKeyword && eat(tt.name);
+}
 
-  // Asserts that following token is given contextual keyword.
-  expectContextual(contextualKeyword: ContextualKeyword): void {
-    if (!this.eatContextual(contextualKeyword)) {
-      this.unexpected(null);
-    }
+// Asserts that following token is given contextual keyword.
+export function expectContextual(contextualKeyword: ContextualKeyword): void {
+  if (!eatContextual(contextualKeyword)) {
+    unexpected(null);
   }
+}
 
-  // Test whether a semicolon can be inserted at the current position.
-  canInsertSemicolon(): boolean {
-    return this.match(tt.eof) || this.match(tt.braceR) || this.hasPrecedingLineBreak();
-  }
+// Test whether a semicolon can be inserted at the current position.
+export function canInsertSemicolon(): boolean {
+  return match(tt.eof) || match(tt.braceR) || hasPrecedingLineBreak();
+}
 
-  hasPrecedingLineBreak(): boolean {
-    const prevToken = this.state.tokens[this.state.tokens.length - 1];
-    const lastTokEnd = prevToken ? prevToken.end : 0;
-    return lineBreak.test(this.input.slice(lastTokEnd, this.state.start));
-  }
+export function hasPrecedingLineBreak(): boolean {
+  const prevToken = state.tokens[state.tokens.length - 1];
+  const lastTokEnd = prevToken ? prevToken.end : 0;
+  return lineBreak.test(input.slice(lastTokEnd, state.start));
+}
 
-  isLineTerminator(): boolean {
-    return this.eat(tt.semi) || this.canInsertSemicolon();
-  }
+export function isLineTerminator(): boolean {
+  return eat(tt.semi) || canInsertSemicolon();
+}
 
-  // Consume a semicolon, or, failing that, see if we are allowed to
-  // pretend that there is a semicolon at this position.
-  semicolon(): void {
-    if (!this.isLineTerminator()) this.unexpected(null, tt.semi);
-  }
+// Consume a semicolon, or, failing that, see if we are allowed to
+// pretend that there is a semicolon at this position.
+export function semicolon(): void {
+  if (!isLineTerminator()) unexpected(null, tt.semi);
+}
 
-  // Expect a token of a given type. If found, consume it, otherwise,
-  // raise an unexpected token error at given pos.
-  expect(type: TokenType, pos?: number | null): void {
-    const matched = this.eat(type);
-    if (!matched) {
-      this.unexpected(pos, type);
-    }
+// Expect a token of a given type. If found, consume it, otherwise,
+// raise an unexpected token error at given pos.
+export function expect(type: TokenType, pos?: number | null): void {
+  const matched = eat(type);
+  if (!matched) {
+    unexpected(pos, type);
   }
+}
 
-  // Raise an unexpected token error. Can take the expected token type
-  // instead of a message string.
-  unexpected(
-    pos: number | null = null,
-    messageOrType: string | TokenType = "Unexpected token",
-  ): never {
-    if (typeof messageOrType !== "string") {
-      messageOrType = `Unexpected token, expected "${formatTokenType(messageOrType)}"`;
-    }
-    throw this.raise(pos != null ? pos : this.state.start, messageOrType);
+// Raise an unexpected token error. Can take the expected token type
+// instead of a message string.
+export function unexpected(
+  pos: number | null = null,
+  messageOrType: string | TokenType = "Unexpected token",
+): never {
+  if (typeof messageOrType !== "string") {
+    messageOrType = `Unexpected token, expected "${formatTokenType(messageOrType)}"`;
   }
+  throw raise(pos != null ? pos : state.start, messageOrType);
 }

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -1,10 +1,10 @@
 /* eslint max-len: 0 */
 
-import BaseParser from "../parser/base";
-import {charCodes, isDigit} from "../util/charcodes";
+import {hasPlugin, input, raise, state} from "../parser/base";
+import {unexpected} from "../parser/util";
+import {charCodes} from "../util/charcodes";
 import {isIdentifierChar, isIdentifierStart, isKeyword} from "../util/identifier";
-import {isNewLine, lineBreak, nonASCIIwhitespace} from "../util/whitespace";
-import State from "./state";
+import {nonASCIIwhitespace} from "../util/whitespace";
 import {keywords as keywordTypes, TokenType, TokenType as tt} from "./types";
 
 export enum IdentifierRole {
@@ -96,7 +96,7 @@ const contextualKeywordByName = {
 // used for the onToken callback and the external tokenizer.
 
 export class Token {
-  constructor(state: State) {
+  constructor() {
     this.type = state.type;
     this.contextualKeyword = state.contextualKeyword;
     this.start = state.start;
@@ -123,751 +123,718 @@ export class Token {
 
 // ## Tokenizer
 
-export default abstract class Tokenizer extends BaseParser {
-  // Forward-declarations
-  // parser/util.js
-  abstract unexpected(pos?: number | null, messageOrType?: string | TokenType): never;
+// Move to the next token
+export function next(): void {
+  state.tokens.push(new Token());
+  nextToken();
+}
 
-  state: State;
-  input: string;
-  nextContextId: number;
+// Call instead of next when inside a template, since that needs to be handled differently.
+export function nextTemplateToken(): void {
+  state.tokens.push(new Token());
+  state.start = state.pos;
+  readTmplToken();
+}
 
-  constructor(input: string) {
-    super();
-    this.state = new State();
-    this.state.init(input);
-    this.nextContextId = 1;
+// The tokenizer never parses regexes by default. Instead, the parser is responsible for
+// instructing it to parse a regex when we see a slash at the start of an expression.
+export function retokenizeSlashAsRegex(): void {
+  if (state.type === tt.assign) {
+    --state.pos;
   }
+  readRegexp();
+}
 
-  // Move to the next token
-
-  next(): void {
-    this.state.tokens.push(new Token(this.state));
-    this.nextToken();
+export function runInTypeContext<T>(existingTokensInType: number, func: () => T): T {
+  for (let i = state.tokens.length - existingTokensInType; i < state.tokens.length; i++) {
+    state.tokens[i].isType = true;
   }
+  const oldIsType = state.isType;
+  state.isType = true;
+  const result = func();
+  state.isType = oldIsType;
+  return result;
+}
 
-  // Call instead of next when inside a template, since that needs to be handled differently.
-  nextTemplateToken(): void {
-    this.state.tokens.push(new Token(this.state));
-    this.state.start = this.state.pos;
-    this.readTmplToken();
+export function eat(type: TokenType): boolean {
+  if (match(type)) {
+    next();
+    return true;
+  } else {
+    return false;
   }
+}
 
-  // The tokenizer never parses regexes by default. Instead, the parser is responsible for
-  // instructing it to parse a regex when we see a slash at the start of an expression.
-  retokenizeSlashAsRegex(): void {
-    if (this.state.type === tt.assign) {
-      --this.state.pos;
-    }
-    this.readRegexp();
-  }
+export function match(type: TokenType): boolean {
+  return state.type === type;
+}
 
-  runInTypeContext<T>(existingTokensInType: number, func: () => T): T {
-    for (
-      let i = this.state.tokens.length - existingTokensInType;
-      i < this.state.tokens.length;
-      i++
-    ) {
-      this.state.tokens[i].isType = true;
-    }
-    const oldIsType = this.state.isType;
-    this.state.isType = true;
-    const result = func();
-    this.state.isType = oldIsType;
-    return result;
-  }
+export function lookaheadType(): TokenType {
+  const snapshot = state.snapshot();
+  next();
+  const type = state.type;
+  state.restoreFromSnapshot(snapshot);
+  return type;
+}
 
-  eat(type: TokenType): boolean {
-    if (this.match(type)) {
-      this.next();
-      return true;
-    } else {
-      return false;
-    }
-  }
+export function lookaheadTypeAndKeyword(): {type: TokenType; contextualKeyword: ContextualKeyword} {
+  const snapshot = state.snapshot();
+  next();
+  const type = state.type;
+  const contextualKeyword = state.contextualKeyword;
+  state.restoreFromSnapshot(snapshot);
+  return {type, contextualKeyword};
+}
 
-  match(type: TokenType): boolean {
-    return this.state.type === type;
-  }
-
-  lookaheadType(): TokenType {
-    const snapshot = this.state.snapshot();
-    this.next();
-    const type = this.state.type;
-    this.state.restoreFromSnapshot(snapshot);
-    return type;
-  }
-
-  lookaheadTypeAndKeyword(): {type: TokenType; contextualKeyword: ContextualKeyword} {
-    const snapshot = this.state.snapshot();
-    this.next();
-    const type = this.state.type;
-    const contextualKeyword = this.state.contextualKeyword;
-    this.state.restoreFromSnapshot(snapshot);
-    return {type, contextualKeyword};
-  }
-
-  // Read a single token, updating the parser object's token-related
-  // properties.
-  nextToken(): void {
-    this.skipSpace();
-    this.state.start = this.state.pos;
-    if (this.state.pos >= this.input.length) {
-      const tokens = this.state.tokens;
-      // We normally run past the end a bit, but if we're way past the end, avoid an infinite loop.
-      // Also check the token positions rather than the types since sometimes we rewrite the token
-      // type to something else.
-      if (
-        tokens.length >= 2 &&
-        tokens[tokens.length - 1].start >= this.input.length &&
-        tokens[tokens.length - 2].start >= this.input.length
-      ) {
-        this.unexpected(null, "Unexpectedly reached the end of input.");
-      }
-      this.finishToken(tt.eof);
-      return;
-    }
-    this.readToken(this.input.charCodeAt(this.state.pos));
-  }
-
-  readToken(code: number): void {
-    // Identifier or keyword. '\uXXXX' sequences are allowed in
-    // identifiers, so '\' also dispatches to that.
-    if (isIdentifierStart(code) || code === charCodes.backslash) {
-      this.readWord();
-    } else {
-      this.getTokenFromCode(code);
-    }
-  }
-
-  skipBlockComment(): void {
-    const end = this.input.indexOf("*/", (this.state.pos += 2));
-    if (end === -1) this.raise(this.state.pos - 2, "Unterminated comment");
-
-    this.state.pos = end + 2;
-  }
-
-  skipLineComment(startSkip: number): void {
-    let ch = this.input.charCodeAt((this.state.pos += startSkip));
-    if (this.state.pos < this.input.length) {
-      while (
-        ch !== charCodes.lineFeed &&
-        ch !== charCodes.carriageReturn &&
-        ch !== charCodes.lineSeparator &&
-        ch !== charCodes.paragraphSeparator &&
-        ++this.state.pos < this.input.length
-      ) {
-        ch = this.input.charCodeAt(this.state.pos);
-      }
-    }
-  }
-
-  // Called at the start of the parse and after every token. Skips
-  // whitespace and comments.
-  skipSpace(): void {
-    loop: while (this.state.pos < this.input.length) {
-      const ch = this.input.charCodeAt(this.state.pos);
-      switch (ch) {
-        case charCodes.space:
-        case charCodes.nonBreakingSpace:
-          ++this.state.pos;
-          break;
-
-        case charCodes.carriageReturn:
-          if (this.input.charCodeAt(this.state.pos + 1) === charCodes.lineFeed) {
-            ++this.state.pos;
-          }
-
-        case charCodes.lineFeed:
-        case charCodes.lineSeparator:
-        case charCodes.paragraphSeparator:
-          ++this.state.pos;
-          break;
-
-        case charCodes.slash:
-          switch (this.input.charCodeAt(this.state.pos + 1)) {
-            case charCodes.asterisk:
-              this.skipBlockComment();
-              break;
-
-            case charCodes.slash:
-              this.skipLineComment(2);
-              break;
-
-            default:
-              break loop;
-          }
-          break;
-
-        default:
-          if (
-            (ch > charCodes.backSpace && ch < charCodes.shiftOut) ||
-            (ch >= charCodes.oghamSpaceMark && nonASCIIwhitespace.test(String.fromCharCode(ch)))
-          ) {
-            ++this.state.pos;
-          } else {
-            break loop;
-          }
-      }
-    }
-  }
-
-  // Called at the end of every token. Sets `end`, `val`, and
-  // maintains `context` and `exprAllowed`, and skips the space after
-  // the token, so that the next one's `start` will point at the
-  // right position.
-
-  finishToken(
-    type: TokenType,
-    contextualKeyword: ContextualKeyword = ContextualKeyword.NONE,
-  ): void {
-    this.state.end = this.state.pos;
-    this.state.type = type;
-    this.state.contextualKeyword = contextualKeyword;
-  }
-
-  // ### Token reading
-
-  // This is the function that is called to fetch the next token. It
-  // is somewhat obscure, because it works in character codes rather
-  // than characters, and because operator parsing has been inlined
-  // into it.
-  //
-  // All in the name of speed.
-  readToken_dot(): void {
-    const next = this.input.charCodeAt(this.state.pos + 1);
-    if (next >= charCodes.digit0 && next <= charCodes.digit9) {
-      this.readNumber(true);
-      return;
-    }
-
-    const next2 = this.input.charCodeAt(this.state.pos + 2);
-    if (next === charCodes.dot && next2 === charCodes.dot) {
-      this.state.pos += 3;
-      this.finishToken(tt.ellipsis);
-    } else {
-      ++this.state.pos;
-      this.finishToken(tt.dot);
-    }
-  }
-
-  readToken_slash(): void {
-    const next = this.input.charCodeAt(this.state.pos + 1);
-    if (next === charCodes.equalsTo) {
-      this.finishOp(tt.assign, 2);
-    } else {
-      this.finishOp(tt.slash, 1);
-    }
-  }
-
-  readToken_mult_modulo(code: number): void {
-    // '%*'
-    let type = code === charCodes.asterisk ? tt.star : tt.modulo;
-    let width = 1;
-    let next = this.input.charCodeAt(this.state.pos + 1);
-
-    // Exponentiation operator **
-    if (code === charCodes.asterisk && next === charCodes.asterisk) {
-      width++;
-      next = this.input.charCodeAt(this.state.pos + 2);
-      type = tt.exponent;
-    }
-
-    // Match *= or %=, disallowing *=> which can be valid in flow.
+// Read a single token, updating the parser object's token-related
+// properties.
+export function nextToken(): void {
+  skipSpace();
+  state.start = state.pos;
+  if (state.pos >= input.length) {
+    const tokens = state.tokens;
+    // We normally run past the end a bit, but if we're way past the end, avoid an infinite loop.
+    // Also check the token positions rather than the types since sometimes we rewrite the token
+    // type to something else.
     if (
-      next === charCodes.equalsTo &&
-      this.input.charCodeAt(this.state.pos + 2) !== charCodes.greaterThan
+      tokens.length >= 2 &&
+      tokens[tokens.length - 1].start >= input.length &&
+      tokens[tokens.length - 2].start >= input.length
     ) {
-      width++;
-      type = tt.assign;
+      unexpected(null, "Unexpectedly reached the end of input.");
     }
+    finishToken(tt.eof);
+    return;
+  }
+  readToken(input.charCodeAt(state.pos));
+}
 
-    this.finishOp(type, width);
+function readToken(code: number): void {
+  // Identifier or keyword. '\uXXXX' sequences are allowed in
+  // identifiers, so '\' also dispatches to that.
+  if (isIdentifierStart(code) || code === charCodes.backslash) {
+    readWord();
+  } else {
+    getTokenFromCode(code);
+  }
+}
+
+function skipBlockComment(): void {
+  const end = input.indexOf("*/", (state.pos += 2));
+  if (end === -1) raise(state.pos - 2, "Unterminated comment");
+
+  state.pos = end + 2;
+}
+
+export function skipLineComment(startSkip: number): void {
+  let ch = input.charCodeAt((state.pos += startSkip));
+  if (state.pos < input.length) {
+    while (
+      ch !== charCodes.lineFeed &&
+      ch !== charCodes.carriageReturn &&
+      ch !== charCodes.lineSeparator &&
+      ch !== charCodes.paragraphSeparator &&
+      ++state.pos < input.length
+    ) {
+      ch = input.charCodeAt(state.pos);
+    }
+  }
+}
+
+// Called at the start of the parse and after every token. Skips
+// whitespace and comments.
+export function skipSpace(): void {
+  loop: while (state.pos < input.length) {
+    const ch = input.charCodeAt(state.pos);
+    switch (ch) {
+      case charCodes.space:
+      case charCodes.nonBreakingSpace:
+        ++state.pos;
+        break;
+
+      case charCodes.carriageReturn:
+        if (input.charCodeAt(state.pos + 1) === charCodes.lineFeed) {
+          ++state.pos;
+        }
+
+      case charCodes.lineFeed:
+      case charCodes.lineSeparator:
+      case charCodes.paragraphSeparator:
+        ++state.pos;
+        break;
+
+      case charCodes.slash:
+        switch (input.charCodeAt(state.pos + 1)) {
+          case charCodes.asterisk:
+            skipBlockComment();
+            break;
+
+          case charCodes.slash:
+            skipLineComment(2);
+            break;
+
+          default:
+            break loop;
+        }
+        break;
+
+      default:
+        if (
+          (ch > charCodes.backSpace && ch < charCodes.shiftOut) ||
+          (ch >= charCodes.oghamSpaceMark && nonASCIIwhitespace.test(String.fromCharCode(ch)))
+        ) {
+          ++state.pos;
+        } else {
+          break loop;
+        }
+    }
+  }
+}
+
+// Called at the end of every token. Sets various fields, and skips the space after the token, so
+// that the next one's `start` will point at the right position.
+export function finishToken(
+  type: TokenType,
+  contextualKeyword: ContextualKeyword = ContextualKeyword.NONE,
+): void {
+  state.end = state.pos;
+  state.type = type;
+  state.contextualKeyword = contextualKeyword;
+}
+
+// ### Token reading
+
+// This is the function that is called to fetch the next token. It
+// is somewhat obscure, because it works in character codes rather
+// than characters, and because operator parsing has been inlined
+// into it.
+//
+// All in the name of speed.
+function readToken_dot(): void {
+  const nextChar = input.charCodeAt(state.pos + 1);
+  if (nextChar >= charCodes.digit0 && nextChar <= charCodes.digit9) {
+    readNumber(true);
+    return;
   }
 
-  readToken_pipe_amp(code: number): void {
-    // '|&'
-    const next = this.input.charCodeAt(this.state.pos + 1);
+  const next2 = input.charCodeAt(state.pos + 2);
+  if (nextChar === charCodes.dot && next2 === charCodes.dot) {
+    state.pos += 3;
+    finishToken(tt.ellipsis);
+  } else {
+    ++state.pos;
+    finishToken(tt.dot);
+  }
+}
 
-    if (next === code) {
-      this.finishOp(code === charCodes.verticalBar ? tt.logicalOR : tt.logicalAND, 2);
+function readToken_slash(): void {
+  const nextChar = input.charCodeAt(state.pos + 1);
+  if (nextChar === charCodes.equalsTo) {
+    finishOp(tt.assign, 2);
+  } else {
+    finishOp(tt.slash, 1);
+  }
+}
+
+function readToken_mult_modulo(code: number): void {
+  // '%*'
+  let type = code === charCodes.asterisk ? tt.star : tt.modulo;
+  let width = 1;
+  let nextChar = input.charCodeAt(state.pos + 1);
+
+  // Exponentiation operator **
+  if (code === charCodes.asterisk && nextChar === charCodes.asterisk) {
+    width++;
+    nextChar = input.charCodeAt(state.pos + 2);
+    type = tt.exponent;
+  }
+
+  // Match *= or %=, disallowing *=> which can be valid in flow.
+  if (
+    nextChar === charCodes.equalsTo &&
+    input.charCodeAt(state.pos + 2) !== charCodes.greaterThan
+  ) {
+    width++;
+    type = tt.assign;
+  }
+
+  finishOp(type, width);
+}
+
+function readToken_pipe_amp(code: number): void {
+  // '|&'
+  const nextChar = input.charCodeAt(state.pos + 1);
+
+  if (nextChar === code) {
+    finishOp(code === charCodes.verticalBar ? tt.logicalOR : tt.logicalAND, 2);
+    return;
+  }
+
+  if (code === charCodes.verticalBar) {
+    // '|>'
+    if (nextChar === charCodes.greaterThan) {
+      finishOp(tt.pipeline, 2);
+      return;
+    } else if (nextChar === charCodes.rightCurlyBrace && hasPlugin("flow")) {
+      // '|}'
+      finishOp(tt.braceBarR, 2);
       return;
     }
+  }
 
-    if (code === charCodes.verticalBar) {
-      // '|>'
-      if (next === charCodes.greaterThan) {
-        this.finishOp(tt.pipeline, 2);
-        return;
-      } else if (next === charCodes.rightCurlyBrace && this.hasPlugin("flow")) {
-        // '|}'
-        this.finishOp(tt.braceBarR, 2);
+  if (nextChar === charCodes.equalsTo) {
+    finishOp(tt.assign, 2);
+    return;
+  }
+
+  finishOp(code === charCodes.verticalBar ? tt.bitwiseOR : tt.bitwiseAND, 1);
+}
+
+function readToken_caret(): void {
+  // '^'
+  const nextChar = input.charCodeAt(state.pos + 1);
+  if (nextChar === charCodes.equalsTo) {
+    finishOp(tt.assign, 2);
+  } else {
+    finishOp(tt.bitwiseXOR, 1);
+  }
+}
+
+function readToken_plus_min(code: number): void {
+  // '+-'
+  const nextChar = input.charCodeAt(state.pos + 1);
+
+  if (nextChar === code) {
+    finishOp(tt.incDec, 2);
+    return;
+  }
+
+  if (nextChar === charCodes.equalsTo) {
+    finishOp(tt.assign, 2);
+  } else if (code === charCodes.plusSign) {
+    finishOp(tt.plus, 1);
+  } else {
+    finishOp(tt.minus, 1);
+  }
+}
+
+// '<>'
+function readToken_lt_gt(code: number): void {
+  // Avoid right-shift for things like Array<Array<string>>.
+  if (code === charCodes.greaterThan && state.isType) {
+    finishOp(tt.greaterThan, 1);
+    return;
+  }
+  const nextChar = input.charCodeAt(state.pos + 1);
+
+  if (nextChar === code) {
+    const size =
+      code === charCodes.greaterThan && input.charCodeAt(state.pos + 2) === charCodes.greaterThan
+        ? 3
+        : 2;
+    if (input.charCodeAt(state.pos + size) === charCodes.equalsTo) {
+      finishOp(tt.assign, size + 1);
+      return;
+    }
+    finishOp(tt.bitShift, size);
+    return;
+  }
+
+  if (nextChar === charCodes.equalsTo) {
+    // <= | >=
+    finishOp(tt.relationalOrEqual, 2);
+  } else if (code === charCodes.lessThan) {
+    finishOp(tt.lessThan, 1);
+  } else {
+    finishOp(tt.greaterThan, 1);
+  }
+}
+
+function readToken_eq_excl(code: number): void {
+  // '=!'
+  const nextChar = input.charCodeAt(state.pos + 1);
+  if (nextChar === charCodes.equalsTo) {
+    finishOp(tt.equality, input.charCodeAt(state.pos + 2) === charCodes.equalsTo ? 3 : 2);
+    return;
+  }
+  if (code === charCodes.equalsTo && nextChar === charCodes.greaterThan) {
+    // '=>'
+    state.pos += 2;
+    finishToken(tt.arrow);
+    return;
+  }
+  finishOp(code === charCodes.equalsTo ? tt.eq : tt.bang, 1);
+}
+
+function readToken_question(): void {
+  // '?'
+  const nextChar = input.charCodeAt(state.pos + 1);
+  const nextChar2 = input.charCodeAt(state.pos + 2);
+  if (nextChar === charCodes.questionMark) {
+    // '??'
+    finishOp(tt.nullishCoalescing, 2);
+  } else if (
+    nextChar === charCodes.dot &&
+    !(nextChar2 >= charCodes.digit0 && nextChar2 <= charCodes.digit9)
+  ) {
+    // '.' not followed by a number
+    state.pos += 2;
+    finishToken(tt.questionDot);
+  } else {
+    ++state.pos;
+    finishToken(tt.question);
+  }
+}
+
+export function getTokenFromCode(code: number): void {
+  switch (code) {
+    case charCodes.numberSign:
+      ++state.pos;
+      finishToken(tt.hash);
+      return;
+
+    // The interpretation of a dot depends on whether it is followed
+    // by a digit or another two dots.
+
+    case charCodes.dot:
+      readToken_dot();
+      return;
+
+    // Punctuation tokens.
+    case charCodes.leftParenthesis:
+      ++state.pos;
+      finishToken(tt.parenL);
+      return;
+    case charCodes.rightParenthesis:
+      ++state.pos;
+      finishToken(tt.parenR);
+      return;
+    case charCodes.semicolon:
+      ++state.pos;
+      finishToken(tt.semi);
+      return;
+    case charCodes.comma:
+      ++state.pos;
+      finishToken(tt.comma);
+      return;
+    case charCodes.leftSquareBracket:
+      ++state.pos;
+      finishToken(tt.bracketL);
+      return;
+    case charCodes.rightSquareBracket:
+      ++state.pos;
+      finishToken(tt.bracketR);
+      return;
+
+    case charCodes.leftCurlyBrace:
+      if (hasPlugin("flow") && input.charCodeAt(state.pos + 1) === charCodes.verticalBar) {
+        finishOp(tt.braceBarL, 2);
+      } else {
+        ++state.pos;
+        finishToken(tt.braceL);
+      }
+      return;
+
+    case charCodes.rightCurlyBrace:
+      ++state.pos;
+      finishToken(tt.braceR);
+      return;
+
+    case charCodes.colon:
+      if (input.charCodeAt(state.pos + 1) === charCodes.colon) {
+        finishOp(tt.doubleColon, 2);
+      } else {
+        ++state.pos;
+        finishToken(tt.colon);
+      }
+      return;
+
+    case charCodes.questionMark:
+      readToken_question();
+      return;
+    case charCodes.atSign:
+      ++state.pos;
+      finishToken(tt.at);
+      return;
+
+    case charCodes.graveAccent:
+      ++state.pos;
+      finishToken(tt.backQuote);
+      return;
+
+    case charCodes.digit0: {
+      const nextChar = input.charCodeAt(state.pos + 1);
+      // '0x', '0X', '0o', '0O', '0b', '0B'
+      if (
+        nextChar === charCodes.lowercaseX ||
+        nextChar === charCodes.uppercaseX ||
+        nextChar === charCodes.lowercaseO ||
+        nextChar === charCodes.uppercaseO ||
+        nextChar === charCodes.lowercaseB ||
+        nextChar === charCodes.uppercaseB
+      ) {
+        readRadixNumber();
         return;
       }
     }
-
-    if (next === charCodes.equalsTo) {
-      this.finishOp(tt.assign, 2);
+    // Anything else beginning with a digit is an integer, octal
+    // number, or float.
+    case charCodes.digit1:
+    case charCodes.digit2:
+    case charCodes.digit3:
+    case charCodes.digit4:
+    case charCodes.digit5:
+    case charCodes.digit6:
+    case charCodes.digit7:
+    case charCodes.digit8:
+    case charCodes.digit9:
+      readNumber(false);
       return;
-    }
 
-    this.finishOp(code === charCodes.verticalBar ? tt.bitwiseOR : tt.bitwiseAND, 1);
+    // Quotes produce strings.
+    case charCodes.quotationMark:
+    case charCodes.apostrophe:
+      readString(code);
+      return;
+
+    // Operators are parsed inline in tiny state machines. '=' (charCodes.equalsTo) is
+    // often referred to. `finishOp` simply skips the amount of
+    // characters it is given as second argument, and returns a token
+    // of the type given by its first argument.
+
+    case charCodes.slash:
+      readToken_slash();
+      return;
+
+    case charCodes.percentSign:
+    case charCodes.asterisk:
+      readToken_mult_modulo(code);
+      return;
+
+    case charCodes.verticalBar:
+    case charCodes.ampersand:
+      readToken_pipe_amp(code);
+      return;
+
+    case charCodes.caret:
+      readToken_caret();
+      return;
+
+    case charCodes.plusSign:
+    case charCodes.dash:
+      readToken_plus_min(code);
+      return;
+
+    case charCodes.lessThan:
+    case charCodes.greaterThan:
+      readToken_lt_gt(code);
+      return;
+
+    case charCodes.equalsTo:
+    case charCodes.exclamationMark:
+      readToken_eq_excl(code);
+      return;
+
+    case charCodes.tilde:
+      finishOp(tt.tilde, 1);
+      return;
+
+    default:
+      break;
   }
 
-  readToken_caret(): void {
-    // '^'
-    const next = this.input.charCodeAt(this.state.pos + 1);
-    if (next === charCodes.equalsTo) {
-      this.finishOp(tt.assign, 2);
+  raise(state.pos, `Unexpected character '${String.fromCharCode(code)}'`);
+}
+
+function finishOp(type: TokenType, size: number): void {
+  state.pos += size;
+  finishToken(type);
+}
+
+function readRegexp(): void {
+  const start = state.pos;
+  let escaped;
+  let inClass;
+  for (;;) {
+    if (state.pos >= input.length) {
+      raise(start, "Unterminated regular expression");
+    }
+    const ch = input.charAt(state.pos);
+    if (escaped) {
+      escaped = false;
     } else {
-      this.finishOp(tt.bitwiseXOR, 1);
-    }
-  }
-
-  readToken_plus_min(code: number): void {
-    // '+-'
-    const next = this.input.charCodeAt(this.state.pos + 1);
-
-    if (next === code) {
-      this.finishOp(tt.incDec, 2);
-      return;
-    }
-
-    if (next === charCodes.equalsTo) {
-      this.finishOp(tt.assign, 2);
-    } else if (code === charCodes.plusSign) {
-      this.finishOp(tt.plus, 1);
-    } else {
-      this.finishOp(tt.minus, 1);
-    }
-  }
-
-  // '<>'
-  readToken_lt_gt(code: number): void {
-    // Avoid right-shift for things like Array<Array<string>>.
-    if (code === charCodes.greaterThan && this.state.isType) {
-      this.finishOp(tt.greaterThan, 1);
-      return;
-    }
-    const next = this.input.charCodeAt(this.state.pos + 1);
-
-    if (next === code) {
-      const size =
-        code === charCodes.greaterThan &&
-        this.input.charCodeAt(this.state.pos + 2) === charCodes.greaterThan
-          ? 3
-          : 2;
-      if (this.input.charCodeAt(this.state.pos + size) === charCodes.equalsTo) {
-        this.finishOp(tt.assign, size + 1);
-        return;
+      if (ch === "[") {
+        inClass = true;
+      } else if (ch === "]" && inClass) {
+        inClass = false;
+      } else if (ch === "/" && !inClass) {
+        break;
       }
-      this.finishOp(tt.bitShift, size);
-      return;
+      escaped = ch === "\\";
     }
-
-    if (next === charCodes.equalsTo) {
-      // <= | >=
-      this.finishOp(tt.relationalOrEqual, 2);
-    } else if (code === charCodes.lessThan) {
-      this.finishOp(tt.lessThan, 1);
-    } else {
-      this.finishOp(tt.greaterThan, 1);
-    }
+    ++state.pos;
   }
+  ++state.pos;
+  // Need to use `readWord1` because '\uXXXX' sequences are allowed
+  // here (don't ask).
+  readWord1();
 
-  readToken_eq_excl(code: number): void {
-    // '=!'
-    const next = this.input.charCodeAt(this.state.pos + 1);
-    if (next === charCodes.equalsTo) {
-      this.finishOp(
-        tt.equality,
-        this.input.charCodeAt(this.state.pos + 2) === charCodes.equalsTo ? 3 : 2,
-      );
-      return;
-    }
-    if (code === charCodes.equalsTo && next === charCodes.greaterThan) {
-      // '=>'
-      this.state.pos += 2;
-      this.finishToken(tt.arrow);
-      return;
-    }
-    this.finishOp(code === charCodes.equalsTo ? tt.eq : tt.bang, 1);
-  }
+  finishToken(tt.regexp);
+}
 
-  readToken_question(): void {
-    // '?'
-    const next = this.input.charCodeAt(this.state.pos + 1);
-    const next2 = this.input.charCodeAt(this.state.pos + 2);
-    if (next === charCodes.questionMark) {
-      // '??'
-      this.finishOp(tt.nullishCoalescing, 2);
-    } else if (
-      next === charCodes.dot &&
-      !(next2 >= charCodes.digit0 && next2 <= charCodes.digit9)
+// Read an integer. We allow any valid digit, including hex digits, plus numeric separators, and
+// stop at any other character.
+function readInt(): void {
+  while (true) {
+    const code = input.charCodeAt(state.pos);
+    if (
+      (code >= charCodes.digit0 && code <= charCodes.digit9) ||
+      (code >= charCodes.lowercaseA && code <= charCodes.lowercaseF) ||
+      (code >= charCodes.uppercaseA && code <= charCodes.uppercaseF) ||
+      code === charCodes.underscore
     ) {
-      // '.' not followed by a number
-      this.state.pos += 2;
-      this.finishToken(tt.questionDot);
+      state.pos++;
     } else {
-      ++this.state.pos;
-      this.finishToken(tt.question);
+      break;
     }
   }
+}
 
-  getTokenFromCode(code: number): void {
-    switch (code) {
-      case charCodes.numberSign:
-        ++this.state.pos;
-        this.finishToken(tt.hash);
-        return;
+function readRadixNumber(): void {
+  let isBigInt = false;
 
-      // The interpretation of a dot depends on whether it is followed
-      // by a digit or another two dots.
+  state.pos += 2; // 0x
+  readInt();
 
-      case charCodes.dot:
-        this.readToken_dot();
-        return;
+  if (input.charCodeAt(state.pos) === charCodes.lowercaseN) {
+    ++state.pos;
+    isBigInt = true;
+  }
 
-      // Punctuation tokens.
-      case charCodes.leftParenthesis:
-        ++this.state.pos;
-        this.finishToken(tt.parenL);
-        return;
-      case charCodes.rightParenthesis:
-        ++this.state.pos;
-        this.finishToken(tt.parenR);
-        return;
-      case charCodes.semicolon:
-        ++this.state.pos;
-        this.finishToken(tt.semi);
-        return;
-      case charCodes.comma:
-        ++this.state.pos;
-        this.finishToken(tt.comma);
-        return;
-      case charCodes.leftSquareBracket:
-        ++this.state.pos;
-        this.finishToken(tt.bracketL);
-        return;
-      case charCodes.rightSquareBracket:
-        ++this.state.pos;
-        this.finishToken(tt.bracketR);
-        return;
+  if (isBigInt) {
+    finishToken(tt.bigint);
+    return;
+  }
 
-      case charCodes.leftCurlyBrace:
-        if (
-          this.hasPlugin("flow") &&
-          this.input.charCodeAt(this.state.pos + 1) === charCodes.verticalBar
-        ) {
-          this.finishOp(tt.braceBarL, 2);
+  finishToken(tt.num);
+}
+
+// Read an integer, octal integer, or floating-point number.
+function readNumber(startsWithDot: boolean): void {
+  let isBigInt = false;
+
+  if (!startsWithDot) {
+    readInt();
+  }
+
+  let nextChar = input.charCodeAt(state.pos);
+  if (nextChar === charCodes.dot) {
+    ++state.pos;
+    readInt();
+    nextChar = input.charCodeAt(state.pos);
+  }
+
+  if (nextChar === charCodes.uppercaseE || nextChar === charCodes.lowercaseE) {
+    nextChar = input.charCodeAt(++state.pos);
+    if (nextChar === charCodes.plusSign || nextChar === charCodes.dash) {
+      ++state.pos;
+    }
+    readInt();
+    nextChar = input.charCodeAt(state.pos);
+  }
+
+  if (nextChar === charCodes.lowercaseN) {
+    ++state.pos;
+    isBigInt = true;
+  }
+
+  if (isBigInt) {
+    finishToken(tt.bigint);
+    return;
+  }
+  finishToken(tt.num);
+}
+
+function readString(quote: number): void {
+  state.pos++;
+  for (;;) {
+    if (state.pos >= input.length) {
+      raise(state.start, "Unterminated string constant");
+    }
+    const ch = input.charCodeAt(state.pos);
+    if (ch === charCodes.backslash) {
+      state.pos++;
+    } else if (ch === quote) {
+      break;
+    }
+    state.pos++;
+  }
+  state.pos++;
+  finishToken(tt.string);
+}
+
+// Reads template string tokens.
+function readTmplToken(): void {
+  for (;;) {
+    if (state.pos >= input.length) {
+      raise(state.start, "Unterminated template");
+    }
+    const ch = input.charCodeAt(state.pos);
+    if (
+      ch === charCodes.graveAccent ||
+      (ch === charCodes.dollarSign && input.charCodeAt(state.pos + 1) === charCodes.leftCurlyBrace)
+    ) {
+      if (state.pos === state.start && match(tt.template)) {
+        if (ch === charCodes.dollarSign) {
+          state.pos += 2;
+          finishToken(tt.dollarBraceL);
+          return;
         } else {
-          ++this.state.pos;
-          this.finishToken(tt.braceL);
-        }
-        return;
-
-      case charCodes.rightCurlyBrace:
-        ++this.state.pos;
-        this.finishToken(tt.braceR);
-        return;
-
-      case charCodes.colon:
-        if (this.input.charCodeAt(this.state.pos + 1) === charCodes.colon) {
-          this.finishOp(tt.doubleColon, 2);
-        } else {
-          ++this.state.pos;
-          this.finishToken(tt.colon);
-        }
-        return;
-
-      case charCodes.questionMark:
-        this.readToken_question();
-        return;
-      case charCodes.atSign:
-        ++this.state.pos;
-        this.finishToken(tt.at);
-        return;
-
-      case charCodes.graveAccent:
-        ++this.state.pos;
-        this.finishToken(tt.backQuote);
-        return;
-
-      case charCodes.digit0: {
-        const next = this.input.charCodeAt(this.state.pos + 1);
-        // '0x', '0X', '0o', '0O', '0b', '0B'
-        if (
-          next === charCodes.lowercaseX ||
-          next === charCodes.uppercaseX ||
-          next === charCodes.lowercaseO ||
-          next === charCodes.uppercaseO ||
-          next === charCodes.lowercaseB ||
-          next === charCodes.uppercaseB
-        ) {
-          this.readRadixNumber();
+          ++state.pos;
+          finishToken(tt.backQuote);
           return;
         }
       }
-      // Anything else beginning with a digit is an integer, octal
-      // number, or float.
-      case charCodes.digit1:
-      case charCodes.digit2:
-      case charCodes.digit3:
-      case charCodes.digit4:
-      case charCodes.digit5:
-      case charCodes.digit6:
-      case charCodes.digit7:
-      case charCodes.digit8:
-      case charCodes.digit9:
-        this.readNumber(false);
-        return;
-
-      // Quotes produce strings.
-      case charCodes.quotationMark:
-      case charCodes.apostrophe:
-        this.readString(code);
-        return;
-
-      // Operators are parsed inline in tiny state machines. '=' (charCodes.equalsTo) is
-      // often referred to. `finishOp` simply skips the amount of
-      // characters it is given as second argument, and returns a token
-      // of the type given by its first argument.
-
-      case charCodes.slash:
-        this.readToken_slash();
-        return;
-
-      case charCodes.percentSign:
-      case charCodes.asterisk:
-        this.readToken_mult_modulo(code);
-        return;
-
-      case charCodes.verticalBar:
-      case charCodes.ampersand:
-        this.readToken_pipe_amp(code);
-        return;
-
-      case charCodes.caret:
-        this.readToken_caret();
-        return;
-
-      case charCodes.plusSign:
-      case charCodes.dash:
-        this.readToken_plus_min(code);
-        return;
-
-      case charCodes.lessThan:
-      case charCodes.greaterThan:
-        this.readToken_lt_gt(code);
-        return;
-
-      case charCodes.equalsTo:
-      case charCodes.exclamationMark:
-        this.readToken_eq_excl(code);
-        return;
-
-      case charCodes.tilde:
-        this.finishOp(tt.tilde, 1);
-        return;
-
-      default:
-        break;
-    }
-
-    this.raise(this.state.pos, `Unexpected character '${String.fromCharCode(code)}'`);
-  }
-
-  finishOp(type: TokenType, size: number): void {
-    this.state.pos += size;
-    this.finishToken(type);
-  }
-
-  readRegexp(): void {
-    const start = this.state.pos;
-    let escaped;
-    let inClass;
-    for (;;) {
-      if (this.state.pos >= this.input.length) {
-        this.raise(start, "Unterminated regular expression");
-      }
-      const ch = this.input.charAt(this.state.pos);
-      if (escaped) {
-        escaped = false;
-      } else {
-        if (ch === "[") {
-          inClass = true;
-        } else if (ch === "]" && inClass) {
-          inClass = false;
-        } else if (ch === "/" && !inClass) {
-          break;
-        }
-        escaped = ch === "\\";
-      }
-      ++this.state.pos;
-    }
-    ++this.state.pos;
-    // Need to use `readWord1` because '\uXXXX' sequences are allowed
-    // here (don't ask).
-    this.readWord1();
-
-    this.finishToken(tt.regexp);
-  }
-
-  // Read an integer. We allow any valid digit, including hex digits, plus numeric separators, and
-  // stop at any other character.
-  readInt(): void {
-    while (true) {
-      const code = this.input.charCodeAt(this.state.pos);
-      if (
-        (code >= charCodes.digit0 && code <= charCodes.digit9) ||
-        (code >= charCodes.lowercaseA && code <= charCodes.lowercaseF) ||
-        (code >= charCodes.uppercaseA && code <= charCodes.uppercaseF) ||
-        code === charCodes.underscore
-      ) {
-        this.state.pos++;
-      } else {
-        break;
-      }
-    }
-  }
-
-  readRadixNumber(): void {
-    let isBigInt = false;
-
-    this.state.pos += 2; // 0x
-    this.readInt();
-
-    if (this.input.charCodeAt(this.state.pos) === charCodes.lowercaseN) {
-      ++this.state.pos;
-      isBigInt = true;
-    }
-
-    if (isBigInt) {
-      this.finishToken(tt.bigint);
+      finishToken(tt.template);
       return;
     }
-
-    this.finishToken(tt.num);
+    if (ch === charCodes.backslash) {
+      state.pos++;
+    }
+    state.pos++;
   }
+}
 
-  // Read an integer, octal integer, or floating-point number.
-  readNumber(startsWithDot: boolean): void {
-    let isBigInt = false;
-
-    if (!startsWithDot) {
-      this.readInt();
-    }
-
-    let next = this.input.charCodeAt(this.state.pos);
-    if (next === charCodes.dot) {
-      ++this.state.pos;
-      this.readInt();
-      next = this.input.charCodeAt(this.state.pos);
-    }
-
-    if (next === charCodes.uppercaseE || next === charCodes.lowercaseE) {
-      next = this.input.charCodeAt(++this.state.pos);
-      if (next === charCodes.plusSign || next === charCodes.dash) {
-        ++this.state.pos;
-      }
-      this.readInt();
-      next = this.input.charCodeAt(this.state.pos);
-    }
-
-    if (next === charCodes.lowercaseN) {
-      ++this.state.pos;
-      isBigInt = true;
-    }
-
-    if (isBigInt) {
-      this.finishToken(tt.bigint);
-      return;
-    }
-    this.finishToken(tt.num);
-  }
-
-  readString(quote: number): void {
-    this.state.pos++;
-    for (;;) {
-      if (this.state.pos >= this.input.length) {
-        this.raise(this.state.start, "Unterminated string constant");
-      }
-      const ch = this.input.charCodeAt(this.state.pos);
-      if (ch === charCodes.backslash) {
-        this.state.pos++;
-      } else if (ch === quote) {
-        break;
-      }
-      this.state.pos++;
-    }
-    this.state.pos++;
-    this.finishToken(tt.string);
-  }
-
-  // Reads template string tokens.
-  readTmplToken(): void {
-    for (;;) {
-      if (this.state.pos >= this.input.length) {
-        this.raise(this.state.start, "Unterminated template");
-      }
-      const ch = this.input.charCodeAt(this.state.pos);
-      if (
-        ch === charCodes.graveAccent ||
-        (ch === charCodes.dollarSign &&
-          this.input.charCodeAt(this.state.pos + 1) === charCodes.leftCurlyBrace)
-      ) {
-        if (this.state.pos === this.state.start && this.match(tt.template)) {
-          if (ch === charCodes.dollarSign) {
-            this.state.pos += 2;
-            this.finishToken(tt.dollarBraceL);
-            return;
-          } else {
-            ++this.state.pos;
-            this.finishToken(tt.backQuote);
-            return;
-          }
+function readWord1(): string {
+  const start = state.pos;
+  while (state.pos < input.length) {
+    const ch = input.charCodeAt(state.pos);
+    if (isIdentifierChar(ch)) {
+      state.pos++;
+    } else if (ch === charCodes.backslash) {
+      // \u
+      state.pos += 2;
+      if (state.input.charCodeAt(state.pos) === charCodes.leftCurlyBrace) {
+        while (state.input.charCodeAt(state.pos) !== charCodes.leftCurlyBrace) {
+          state.pos++;
         }
-        this.finishToken(tt.template);
-        return;
+        state.pos++;
       }
-      if (ch === charCodes.backslash) {
-        this.state.pos++;
-      }
-      this.state.pos++;
-    }
-  }
-
-  readWord1(): string {
-    const start = this.state.pos;
-    while (this.state.pos < this.input.length) {
-      const ch = this.input.charCodeAt(this.state.pos);
-      if (isIdentifierChar(ch)) {
-        this.state.pos++;
-      } else if (ch === charCodes.backslash) {
-        // \u
-        this.state.pos += 2;
-        if (this.state.input.charCodeAt(this.state.pos) === charCodes.leftCurlyBrace) {
-          while (this.state.input.charCodeAt(this.state.pos) !== charCodes.leftCurlyBrace) {
-            this.state.pos++;
-          }
-          this.state.pos++;
-        }
-      } else {
-        break;
-      }
-    }
-    return this.input.slice(start, this.state.pos);
-  }
-
-  // Read an identifier or keyword token.
-  readWord(): void {
-    const word = this.readWord1();
-    if (isKeyword(word)) {
-      this.finishToken(keywordTypes[word]);
-    } else if (contextualKeywordByName[word] != null) {
-      this.finishToken(tt.name, contextualKeywordByName[word]);
     } else {
-      this.finishToken(tt.name);
+      break;
     }
+  }
+  return input.slice(start, state.pos);
+}
+
+// Read an identifier or keyword token.
+function readWord(): void {
+  const word = readWord1();
+  if (isKeyword(word)) {
+    finishToken(keywordTypes[word]);
+  } else if (contextualKeywordByName[word] != null) {
+    finishToken(tt.name, contextualKeywordByName[word]);
+  } else {
+    finishToken(tt.name);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,
+    "noImplicitThis": true,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,


### PR DESCRIPTION
This overhauls all parser code to use globals to track state, and replaces all
uses of method overriding with plain if statements. The idea is to reduce the
cost of function invocation, which is likely one of the biggest remaining costs
in the parser.

It looks like this gives about a 20% overall performance improvement and will
make it easier to move to AssemblyScript in the future.