### PR TITLE
Port all Babylon changes from 2017-12-25 to 2018-04-20

### DIFF
--- a/generator/generateReadWord.ts
+++ b/generator/generateReadWord.ts
@@ -52,6 +52,7 @@ const CONTEXTUAL_KEYWORDS = [
   "get",
   "global",
   "implements",
+  "infer",
   "interface",
   "is",
   "keyof",
@@ -65,9 +66,10 @@ const CONTEXTUAL_KEYWORDS = [
   "public",
   "readonly",
   "require",
+  "set",
   "static",
   "type",
-  "set",
+  "unique",
   // Custom identifiers we want to match.
   "React",
   "createClass",
@@ -106,6 +108,8 @@ export default function readWord(): void {
         }
         state.pos++;
       }
+    } else if (ch === charCodes.atSign && input.charCodeAt(state.pos + 1) === charCodes.atSign) {
+      state.pos += 2;
     } else {
       break;
     }

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -299,6 +299,8 @@ export default class ImportTransformer extends Transformer {
       }
       const name = this.rootTransformer.processNamedClass();
       this.tokens.appendCode(` exports.default = ${name};`);
+    } else if (this.tokens.matches3(tt._export, tt._default, tt.at)) {
+      throw new Error("Export default statements with decorators are not yet supported.");
     } else {
       this.tokens.replaceToken("exports.");
       this.tokens.copyToken();

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -931,11 +931,9 @@ function parseExprListItem(allowEmpty: boolean | null): void {
     // Empty item; nothing more to parse for this item.
   } else if (match(tt.ellipsis)) {
     parseSpread();
+    parseParenItem();
   } else {
     parseMaybeAssign(false, parseParenItem);
-  }
-  if (hasPlugin("flow") && match(tt.colon)) {
-    flowParseTypeAnnotation();
   }
 }
 

--- a/sucrase-babylon/parser/statement.ts
+++ b/sucrase-babylon/parser/statement.ts
@@ -240,9 +240,14 @@ export function parseDecorators(): void {
 
 function parseDecorator(): void {
   next();
-  parseIdentifier();
-  while (eat(tt.dot)) {
+  if (eat(tt.parenL)) {
+    parseExpression();
+    expect(tt.parenR);
+  } else {
     parseIdentifier();
+    while (eat(tt.dot)) {
+      parseIdentifier();
+    }
   }
   if (eat(tt.parenL)) {
     parseCallExpressionArguments(tt.parenR);
@@ -628,7 +633,7 @@ export function parseClass(isStatement: boolean, optionalId: boolean = false): v
 }
 
 function isClassProperty(): boolean {
-  return match(tt.eq) || match(tt.semi) || match(tt.braceR) || match(tt.colon);
+  return match(tt.eq) || match(tt.semi) || match(tt.braceR) || match(tt.bang) || match(tt.colon);
 }
 
 function isClassMethod(): boolean {
@@ -760,7 +765,6 @@ export function parseClassPropertyName(classContextId: number): void {
   parsePropertyName(classContextId);
 }
 
-// Overridden in typescript.js
 export function parsePostMemberNameModifiers(): void {
   if (hasPlugin("typescript")) {
     eat(tt.question);
@@ -769,6 +773,7 @@ export function parsePostMemberNameModifiers(): void {
 
 export function parseClassProperty(): void {
   if (hasPlugin("typescript")) {
+    eat(tt.bang);
     tsTryParseTypeAnnotation();
   } else if (hasPlugin("flow")) {
     if (match(tt.colon)) {
@@ -874,6 +879,9 @@ function parseExportDefaultExpression(): void {
     eat(tt._function);
     parseFunction(functionStart, true, false, true);
   } else if (match(tt._class)) {
+    parseClass(true, true);
+  } else if (match(tt.at)) {
+    parseDecorators();
     parseClass(true, true);
   } else {
     parseMaybeAssign();

--- a/sucrase-babylon/plugins/flow.ts
+++ b/sucrase-babylon/plugins/flow.ts
@@ -233,6 +233,13 @@ function flowParseInterfaceish(isClass?: boolean): void {
     } while (eat(tt.comma));
   }
 
+  if (isContextual(ContextualKeyword._implements)) {
+    next();
+    do {
+      flowParseInterfaceExtends();
+    } while (eat(tt.comma));
+  }
+
   flowParseObjectType(true, false);
 }
 

--- a/sucrase-babylon/tokenizer/readWord.ts
+++ b/sucrase-babylon/tokenizer/readWord.ts
@@ -528,6 +528,17 @@ export default function readWord(): void {
             return;
           }
           switch (input.charCodeAt(state.pos++)) {
+            case charCodes.lowercaseF:
+              if (
+                input.charCodeAt(state.pos++) === charCodes.lowercaseE &&
+                input.charCodeAt(state.pos++) === charCodes.lowercaseR &&
+                !isIdentifierChar(input.charCodeAt(state.pos)) &&
+                input.charCodeAt(state.pos) !== charCodes.backslash
+              ) {
+                finishToken(tt.name, ContextualKeyword._infer);
+                return;
+              }
+              break;
             case charCodes.lowercaseS:
               if (
                 input.charCodeAt(state.pos++) === charCodes.lowercaseT &&
@@ -913,6 +924,20 @@ export default function readWord(): void {
           break;
       }
       break;
+    case charCodes.lowercaseU:
+      if (
+        input.charCodeAt(state.pos++) === charCodes.lowercaseN &&
+        input.charCodeAt(state.pos++) === charCodes.lowercaseI &&
+        input.charCodeAt(state.pos++) === charCodes.lowercaseQ &&
+        input.charCodeAt(state.pos++) === charCodes.lowercaseU &&
+        input.charCodeAt(state.pos++) === charCodes.lowercaseE &&
+        !isIdentifierChar(input.charCodeAt(state.pos)) &&
+        input.charCodeAt(state.pos) !== charCodes.backslash
+      ) {
+        finishToken(tt.name, ContextualKeyword._unique);
+        return;
+      }
+      break;
     case charCodes.lowercaseV:
       switch (input.charCodeAt(state.pos++)) {
         case charCodes.lowercaseA:
@@ -994,6 +1019,8 @@ export default function readWord(): void {
         }
         state.pos++;
       }
+    } else if (ch === charCodes.atSign && input.charCodeAt(state.pos + 1) === charCodes.atSign) {
+      state.pos += 2;
     } else {
       break;
     }

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -173,4 +173,30 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("properly handles @@iterator in a declared class", () => {
+    assertFlowResult(
+      `
+      declare class A {
+        @@iterator(): Iterator<File>;
+      }
+    `,
+      `"use strict";${IMPORT_PREFIX}
+      
+
+
+    `,
+    );
+  });
+
+  it("supports the implements keyword", () => {
+    assertFlowResult(
+      `
+      declare class A implements B, C {}
+    `,
+      `"use strict";${IMPORT_PREFIX}
+      
+    `,
+    );
+  });
 });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -432,4 +432,65 @@ describe("sucrase", () => {
       ["jsx", "imports", "typescript"],
     );
   });
+
+  // Decorators aren't yet supported in any runtime, so passing them through correctly is low priority.
+  it.skip("handles decorated classes with static fields", () => {
+    assertResult(
+      `
+      export default @dec class A {
+        static x = 1;
+      }
+    `,
+      `"use strict";
+       @dec class A {
+        
+      } A.x = 1; exports.default = A;
+    `,
+      ["jsx", "imports"],
+    );
+  });
+
+  it("handles logical assignment operators", () => {
+    assertResult(
+      `
+      a &&= b;
+      c ||= d;
+      e ??= f;
+    `,
+      `"use strict";
+      a &&= b;
+      c ||= d;
+      e ??= f;
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
+
+  it("handles decorators with a parenthesized expression", () => {
+    assertResult(
+      `
+      class Bar{
+        @(
+          @classDec class { 
+            @inner 
+            innerMethod() {} 
+          }
+        )
+        outerMethod() {}
+      }
+    `,
+      `"use strict";
+      class Bar{
+        @(
+          @classDec class { 
+             
+            innerMethod() {} 
+          }
+        )
+        outerMethod() {}
+      }
+    `,
+      ["jsx", "imports", "typescript"],
+    );
+  });
 });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -742,4 +742,118 @@ describe("typescript transform", () => {
       ["typescript", "imports"],
     );
   });
+
+  it("handles assert and assign syntax", () => {
+    assertResult(
+      `
+      (a as b) = c;
+    `,
+      `"use strict";
+      (a ) = c;
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles possible JSX ambiguities", () => {
+    assertResult(
+      `
+      f<T>();
+      new C<T>();
+      type A = T<T>;
+    `,
+      `"use strict";
+      f();
+      new C();
+      
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles the 'unique' contextual keyword", () => {
+    assertResult(
+      `
+      let y: unique symbol;
+    `,
+      `"use strict";
+      let y;
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles async arrow functions with rest params", () => {
+    assertResult(
+      `
+      const foo = async (...args: any[]) => {}
+      const bar = async (...args?: any[]) => {}
+    `,
+      `"use strict";
+      const foo = async (...args) => {}
+      const bar = async (...args) => {}
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles conditional types", () => {
+    assertResult(
+      `
+      type A = B extends C ? D : E;
+    `,
+      `"use strict";
+      
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles the 'infer' contextual keyword in types", () => {
+    assertResult(
+      `
+      type Element<T> = T extends (infer U)[] ? U : T;
+    `,
+      `"use strict";
+      
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles definite assignment assertions in classes", () => {
+    assertResult(
+      `
+      class A {
+        foo!: number;
+        getFoo(): number {
+          return foo;
+        }
+      }
+    `,
+      `"use strict";
+      class A {
+        
+        getFoo() {
+          return foo;
+        }
+      }
+    `,
+      ["typescript", "imports"],
+    );
+  });
+
+  it("handles mapped type modifiers", () => {
+    assertResult(
+      `
+      let map: { +readonly [P in string]+?: number; };
+      let map2: { -readonly [P in string]-?: number };
+    `,
+      `"use strict";
+      let map;
+      let map2;
+    `,
+      ["typescript", "imports"],
+    );
+  });
 });

--- a/website/src/Worker.worker.js
+++ b/website/src/Worker.worker.js
@@ -93,7 +93,16 @@ function runBabel() {
           "proposal-optional-catch-binding",
           "dynamic-import-node",
         ],
-        parserOpts: {plugins: ["jsx", "classProperties", "numericSeparator"]},
+        parserOpts: {
+          plugins: [
+            "classProperties",
+            "decorators",
+            "jsx",
+            "logicalAssignment",
+            "numericSeparator",
+            "optionalChaining",
+          ],
+        },
       }).code,
   );
 }


### PR DESCRIPTION
Changes in chronological order:
f3410e761 Flow comment parsing (#7007)
🚫 No need to support the flowComments plugin.

49775e2f1 Remove redundant property declarations (#7144)
🚫 Affected code was removed.

e872f0d97 Regex parsing issue fix  after function declaration. (#7121)
🚫 updateContext no longer exists.

8250ff963 Suggest JSX fragment syntax in adjacent tag error (#7152)
🚫 Only affects error message.

7c99f4653 v7.0.0-beta.37
🚫 Version bump.

74682f33b Support 'assert and assign' TypeScript syntax (#7098)
🚫 Affects lval code that was removed. Added test to verify that this case
works.

0f42accb8 Renamed files
🚫 Only affects tests.

64161fa0b Fix syntax plugins in babylon readme (#7182)
🚫 Docs only.

9e384f391 Cleaning up some TS parsing tests (#7184)
🚫 Test only.

c3352ad2e Fix: unicode characters not allowed in regexes (#7179)
🚫 Adds stricter error message.

2d0548729 Add support for @@iterator (#7058)
✅ Handled in a simpler way that doesn't require state and doesn't condition on
the flow plugin.

667f5815c typescript: Properly set this.state.inType one token before parsing a type (#7225)
🚫 Doesn't seem to affect Sucrase, but I added a test.

b5d20ab17 v7.0.0-beta.38
🚫 Version bump.

dccfed360 TypeScript: Support parsing 'unique' type operator (#7239)
✅ Added a "unique" contextual keyword and allowed it in TS type parsing.

fa5eb4f60 Make comment props more consistent (#7246)
🚫 Only affects comment props.

65ae4ff15 Fix: export default decorated class parsed as class expression (#7189)
✅ Caused an incorrect transform, although the proper sucrase transform is
harder and not useful yet, so I fixed the parser bug and added a failing test.

023550c87 Docs: updated link relative to babel/babylon (#7292)
🚫 Docs only.

cc4913699 Update packages/babylon/README.md
🚫 Docs only.

73e64c6cb v7.0.0-beta.39
🚫 Version bump.

f19d559ff Compile Babylon with Gulp (#7240)
🚫 Build system only.

ed98d2491 [Typescript] - Fix SyntaxError in async arrow functions with rest params (#7297)
✅ Crashed in sucrase, and the fix was similar. I also removed a flow-specific
check since it looks like it's redundant now.

a3ad518ce [BugFix] : OptionalChaining Bug fixes (#7288)
🚫 New state only used to determine node type to create and error messages,
neither of which are relevant here.

92580e750 Fixes issues regarding super in optionalChain (#7356)
🚫 Only affects tests.

ea3f2d929 v7.0.0-beta.40
🚫 Version bump.

7e90d5602 Proposal: Logical Assignment Operators (#7385)
✅ Small addition to lexer that was straightforward to port.

6f6c8dabb TypeScript: Support conditional types syntax (#7404)
✅ Added "infer" contextual keyword and parsing for conditional types. No
transformation changes needed.

6f3be3a54 typescript: Support definite assignment assertion (#7159)
✅ Straightforward port of parsing changes.

8823e4247 Fix up flow errors (#7227)
🚫 No changes needed.

7ff4a7391 Upgrade flow to 0.66 and fix a few minor errors. (#7431)
🚫 Only added new errors.

ae0df8634 Remove broken check in checkFunctionNameAndParams (#7473)
🚫 Removed check that was already removed.

5c3092d86 Expand `.raise()` to allow more options.
🚫 Generalized options not needed for scurase.

5f6e3122a Give users helpful feedback if they are detected as using the wrong sourceType.
🚫 Additional error check not needed.

d187c2674 Spec Violation: Fix var initializer in for-in loop (#7392)
🚫 Only affects sloppy mode, which isn't supported by sucrase.

5d615dd19 Disallow setters to have RestElement (#7498)
🚫 Only adds additional validation.

f97d4313c Update test262 test script and a few keyword escape fixes (#7503)
🚫 Contextual keywords already disallow escaped letters.

7901e7d1b Fix flowtype errors introduced in #7503. (#7531)
🚫 containsEsc doesn't exist in sucrase.

958551fd8 Refactor unambiguous to track state during parsing.
🚫 We already parse as module.

3c8e9acd4 Make the unambiguous grammar select module when import.meta is used.
🚫 We already parse as module.

270ea17fe v7.0.0-beta.41
🚫 Version bump.

b6e54800b Remove outdated spec deviation note (#7571)
🚫 Docs only.

d260bfaec v7.0.0-beta.42
🚫 Version bump.

f0d681a23 Remove obsolete max-len eslint rule and reformat some stuff to fit (#7602)
🚫 Lint only.

840ba187a Prevent duplicate regex flags (#7617)
🚫 Only affects error reporting.

19708e015 TypeScript: support mapped type modifiers syntax (#7383)
✅ Straightforward port of parser change.

21309cc8d Make these tests re-throw the same error to keep the trace.
🚫 Only affects error reporting.

a7bddc02b Add ??= to Logical Assignment Operators (#7623)
✅ Straightforward port of lexer change.

ab7d1231a Fix flow errors with Logical Assignment Operators (#7629)
🚫 No changes necessary.

59ba3959d Add options.allowAwaitOutsideFunction. (#7637)
🚫 await is already always allowed.

bdfeeb38c v7.0.0-beta.43
🚫 Version bump.

a6df92f24 v7.0.0-beta.44
🚫 Version bump.

b051243a6 Fix typo in ast spec (#7662)
🚫 Docs only.

56cb4baf4 Add missing exponential operators to ast spec (#7663)
🚫 Docs only.

f797454a1 Disallow super in functions in class properties
🚫 Only affects error reporting.

a62cfe904 Disallow arguments in class properties
🚫 Only affects error reporting.

a86d14de6 Disallow super() in class properties
🚫 Only affects error reporting.

61ec5ce95 Provide better error message for invalid default export declaration (#7717)
🚫 Only affects error reporting.

341bdab90 Update decorators parsing (#7719)
✅ Straightforward port of parser change.

329908695 Add support for flow implements (#7741)
✅ Straightforward port of parser change.

4b97e837e Fix type error (#7752)
🚫 No change necessary.

b0e1e8447 drop support for Node.js v4 (#7755)
🚫 Not relevant for sucrase.