### PR TITLE
Use the file path if necessary when computing React display names

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -34,7 +34,7 @@ export default class RootTransformer {
         new JSXTransformer(this, tokenProcessor, importProcessor, this.nameManager, filePath),
       );
       this.transformers.push(
-        new ReactDisplayNameTransformer(this, tokenProcessor, importProcessor),
+        new ReactDisplayNameTransformer(this, tokenProcessor, importProcessor, filePath),
       );
     }
 

--- a/test/react-display-name-test.ts
+++ b/test/react-display-name-test.ts
@@ -82,16 +82,16 @@ describe("transform react-display-name", () => {
       `
       import React from 'react';
 
-      export default React.createClass({
+      React.createClass({
         render() {
           return <div />;
         }
       });
     `,
-      `"use strict";${JSX_PREFIX}${IMPORT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${JSX_PREFIX}${IMPORT_PREFIX}
       var _react = require('react'); var _react2 = _interopRequireDefault(_react);
 
-      exports. default = _react2.default.createClass({
+      _react2.default.createClass({
         render() {
           return _react2.default.createElement('div', {${devProps(6)}} );
         }
@@ -149,6 +149,31 @@ describe("transform react-display-name", () => {
         }
       });
     `,
+    );
+  });
+
+  it("names an anonymous export default component after the filename", () => {
+    assertResult(
+      `
+      import React from 'react';
+
+      export default React.createClass({
+        render() {
+          return <div />;
+        }
+      });
+    `,
+      `"use strict";const _jsxFileName = "MyComponent.js";${IMPORT_PREFIX}${ESMODULE_PREFIX}
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
+
+      exports. default = _react2.default.createClass({displayName: 'MyComponent',
+        render() {
+          return _react2.default.createElement('div', {${devProps(6)}} );
+        }
+      });
+    `,
+      ["jsx", "imports"],
+      "MyComponent.js",
     );
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,8 +6,9 @@ export function assertResult(
   code: string,
   expectedResult: string,
   transforms: Array<Transform> = ["jsx", "imports"],
+  filePath?: string,
 ): void {
-  assert.equal(transform(code, {transforms}), expectedResult);
+  assert.equal(transform(code, {transforms, filePath}), expectedResult);
 }
 
 export function devProps(lineNumber: number): string {


### PR DESCRIPTION
Following the same semantics as the babel plugin, if there's a default-exported
react class, then we infer the name via the filename. I intentionally didn't use
the node `path` library to avoid a dependency on node.