### PR TITLE
Fix TypeScript import pruning when using JSX

### DIFF
--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -206,7 +206,7 @@ export default class JSXTransformer extends Transformer {
   }
 }
 
-function startsWithLowerCase(s: string): boolean {
+export function startsWithLowerCase(s: string): boolean {
   return s[0] === s[0].toLowerCase();
 }
 

--- a/sucrase-babylon/plugins/jsx/index.ts
+++ b/sucrase-babylon/plugins/jsx/index.ts
@@ -84,11 +84,11 @@ function jsxParseIdentifier(): void {
 }
 
 // Parse namespaced identifier.
-function jsxParseNamespacedName(): void {
+function jsxParseNamespacedName(identifierRole: IdentifierRole): void {
   jsxParseIdentifier();
   if (!eat(tt.colon)) {
     // Plain identifier, so this is an access.
-    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.Access;
+    state.tokens[state.tokens.length - 1].identifierRole = identifierRole;
     return;
   }
   // Process the second half of the namespaced name.
@@ -98,7 +98,7 @@ function jsxParseNamespacedName(): void {
 // Parses element name in any form - namespaced, member
 // or single identifier.
 function jsxParseElementName(): void {
-  jsxParseNamespacedName();
+  jsxParseNamespacedName(IdentifierRole.Access);
   while (match(tt.dot)) {
     nextJSXTagToken();
     jsxParseIdentifier();
@@ -159,7 +159,7 @@ function jsxParseAttribute(): void {
     nextJSXTagToken();
     return;
   }
-  jsxParseNamespacedName();
+  jsxParseNamespacedName(IdentifierRole.ObjectKey);
   if (match(tt.eq)) {
     nextJSXTagToken();
     jsxParseAttributeValue();

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -308,7 +308,7 @@ describe("type transforms", () => {
     );
   });
 
-  it.skip("does not confuse type parameters with JSX in type expressions", () => {
+  it("does not confuse type parameters with JSX in type expressions", () => {
     assertTypeScriptAndFlowResult(
       `
       const f: <T>(t: T) => number = () => 3;


### PR DESCRIPTION
This required being more precise when giving identifier roles to JSX identifiers
and being careful about which names are actually accessed given a JSX identifier
(e.g. not "div" in normal cases).

Also re-enable a test that works now.