### PR TITLE
Change TypeScript ES module interop to act like Babel by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,10 @@ are four main transforms that you may want to enable:
   including adding `createReactClass` display names and JSX context information.
 * **typescript**: Compiles TypeScript code to JavaScript, removing type
   annotations and handling features like enums. Does not check types.
-* **flow**:  Removes Flow types, e.g. `const f = (x: number): string => "hi";`
-  to `const f = (x) => "hi";`. Does not check types.
+* **flow**:  Removes Flow type annotations. Does not check types.
 * **imports**: Transforms ES Modules (`import`/`export`) to CommonJS
-  (`require`/`module.exports`) using the same approach as Babel. With the
-  `typescript` transform enabled, the import conversion uses the behavior of the
-  TypeScript compiler (which is slightly more lenient). Also includes dynamic
-  `import`.
+  (`require`/`module.exports`) using the same approach as Babel 6 and TypeScript
+  with `--esModuleInterop`. Also includes dynamic `import`.
 
 The following proposed JS features are built-in and always transformed:
 * [Class fields](https://github.com/tc39/proposal-class-fields): `class C { x = 1; }`.
@@ -63,10 +60,19 @@ The following proposed JS features are built-in and always transformed:
 * [Optional catch binding](https://github.com/tc39/proposal-optional-catch-binding):
   `try { doThing(); } catch { }`.
 
-There are some additional opt-in transforms that are useful in legacy situations:
-* **add-module-exports**: Mimic the Babel 5 approach to CommonJS interop, so that
-  you can run `require('./MyModule')` instead of `require('./MyModule').default`.
-  Analogous to
+When using the `import` transform, there are some options to enable legacy
+CommonJS interop approaches:
+* **enableLegacyTypeScriptModuleInterop**: Use the default TypeScript approach
+  to CommonJS interop instead of assuming that TypeScript's `--esModuleInterop`
+  flag is enabled. For example, if a CJS module exports a function, legacy
+  TypeScript interop requires you to write `import * as add from './add';`,
+  while Babel, Webpack, Node.js, and TypeScript with `--esModuleInterop` require
+  you to write `import add from './add';`. As mentioned in the
+  [docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop),
+  the TypeScript team recommends you always use `--esModuleInterop`.
+* **enableLegacyBabel5ModuleInterop**: Use the Babel 5 approach to CommonJS
+  interop, so that you can run `require('./MyModule')` instead of
+  `require('./MyModule').default`. Analogous to
   [babel-plugin-add-module-exports](https://github.com/59naga/babel-plugin-add-module-exports).
 
 ## Usage

--- a/example-runner/example-configs/decaffeinate-parser.patch
+++ b/example-runner/example-configs/decaffeinate-parser.patch
@@ -16,5 +16,5 @@ index 1aee96b..d084985 100644
 +++ b/test/mocha.opts
 @@ -1,2 +1,2 @@
 ---compilers ts:ts-node/register,js:babel-register
-+--compilers ts:sucrase/register/ts
++--compilers ts:sucrase/register/ts-legacy-module-interop
  --recursive

--- a/example-runner/example-configs/tslint.patch
+++ b/example-runner/example-configs/tslint.patch
@@ -1,5 +1,5 @@
 diff --git a/package.json b/package.json
-index 826ad87f..650dbd39 100644
+index 826ad87f..1ac6cee3 100644
 --- a/package.json
 +++ b/package.json
 @@ -22,14 +22,14 @@
@@ -9,9 +9,9 @@ index 826ad87f..650dbd39 100644
 -    "compile:core": "tsc -p src",
 -    "compile:scripts": "tsc -p scripts",
 -    "compile:test": "tsc -p test",
-+    "compile:core": "sucrase ./src -d ./lib --transforms typescript,imports",
-+    "compile:scripts": "sucrase ./scripts -d ./scripts --transforms typescript,imports",
-+    "compile:test": "mkdir -p build && sucrase ./test -d ./build/test --exclude-dirs files,rules --transforms typescript,imports && sucrase ./src -d ./build/src --transforms typescript,imports",
++    "compile:core": "sucrase ./src -d ./lib --transforms typescript,imports --enable-legacy-typescript-module-interop",
++    "compile:scripts": "sucrase ./scripts -d ./scripts --transforms typescript,imports --enable-legacy-typescript-module-interop",
++    "compile:test": "mkdir -p build && sucrase ./test -d ./build/test --exclude-dirs files,rules --transforms typescript,imports --enable-legacy-typescript-module-interop && sucrase ./src -d ./build/src --transforms typescript,imports --enable-legacy-typescript-module-interop",
      "lint": "npm-run-all -p lint:global lint:from-bin",
      "lint:global": "tslint --project test/tsconfig.json --format stylish # test includes 'src' too",
      "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
@@ -71,5 +71,29 @@ index 4f1b0bf7..049d4f31 100644
 -    };
 -    return AlwaysFailWalker;
 -})(Lint.RuleWalker);
++    }
++}
+diff --git a/tsconfig.json b/tsconfig.json
+new file mode 100644
+index 00000000..60dc8db4
+--- /dev/null
++++ b/tsconfig.json
+@@ -0,0 +1,18 @@
++{
++    "compilerOptions": {
++        "module": "commonjs",
++        "noImplicitAny": true,
++        "noImplicitReturns": true,
++        "noImplicitThis": true,
++        "noUnusedParameters": true,
++        "noUnusedLocals": true,
++        "strictNullChecks": true,
++        "strictFunctionTypes": true,
++        "importHelpers": true,
++        "declaration": true,
++        "sourceMap": false,
++        "target": "es2017",
++        "lib": ["es6"],
++        "outDir": "../lib"
 +    }
 +}

--- a/example-runner/example-runner.ts
+++ b/example-runner/example-runner.ts
@@ -73,17 +73,20 @@ async function runProject(project: string, shouldSave: boolean): Promise<boolean
   if (!await exists(revPath) || !await exists(patchPath) || shouldSave) {
     console.log(`Generating metadata for ${project}`);
     await run(`git rev-parse HEAD > ${revPath}`);
-    await run(`git diff > ${patchPath}`);
+    await run(`git diff HEAD > ${patchPath}`);
   }
 
   try {
     await run(`cat ${revPath} | xargs git reset --hard`);
+    await run(`git clean -f`);
   } catch (e) {
     await run("git fetch");
     await run(`cat ${revPath} | xargs git reset --hard`);
+    await run(`git clean -f`);
   }
   if ((await readFile(patchPath)).length) {
     await run(`cat ${patchPath} | git apply`);
+    await run(`git add -A`);
   }
 
   await run("yarn");

--- a/register/ts-legacy-module-interop.js
+++ b/register/ts-legacy-module-interop.js
@@ -1,0 +1,1 @@
+require("../dist/src/register").registerTSLegacyModuleInterop();

--- a/register/tsx-legacy-module-interop.js
+++ b/register/tsx-legacy-module-interop.js
@@ -1,0 +1,1 @@
+require("../dist/src/register").registerTSXLegacyModuleInterop();

--- a/src/ImportProcessor.ts
+++ b/src/ImportProcessor.ts
@@ -38,11 +38,11 @@ export default class ImportProcessor {
   constructor(
     readonly nameManager: NameManager,
     readonly tokens: TokenProcessor,
-    readonly isTypeScript: boolean,
+    readonly enableLegacyTypeScriptModuleInterop: boolean,
   ) {}
 
   getPrefixCode(): string {
-    if (this.isTypeScript) {
+    if (this.enableLegacyTypeScriptModuleInterop) {
       return "";
     }
     let prefix = "";
@@ -70,7 +70,7 @@ export default class ImportProcessor {
   }
 
   preprocessTokens(): void {
-    if (!this.isTypeScript) {
+    if (!this.enableLegacyTypeScriptModuleInterop) {
       this.interopRequireWildcardName = this.nameManager.claimFreeName("_interopRequireWildcard");
       this.interopRequireDefaultName = this.nameManager.claimFreeName("_interopRequireDefault");
     }
@@ -167,7 +167,7 @@ export default class ImportProcessor {
 
       const primaryImportName = this.getFreeIdentifierForPath(path);
       let secondaryImportName;
-      if (this.isTypeScript) {
+      if (this.enableLegacyTypeScriptModuleInterop) {
         secondaryImportName = primaryImportName;
       } else {
         secondaryImportName =
@@ -176,7 +176,7 @@ export default class ImportProcessor {
       let requireCode = `var ${primaryImportName} = require('${path}');`;
       if (wildcardNames.length > 0) {
         for (const wildcardName of wildcardNames) {
-          const moduleExpr = this.isTypeScript
+          const moduleExpr = this.enableLegacyTypeScriptModuleInterop
             ? primaryImportName
             : `${this.interopRequireWildcardName}(${primaryImportName})`;
           requireCode += ` var ${wildcardName} = ${moduleExpr};`;

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,28 +1,42 @@
 // @ts-ignore: no types available.
 import * as pirates from "pirates";
-import {Transform, transform} from "./index";
+import {Options, Transform, transform} from "./index";
 
-export function addHook(extension: string, transforms: Array<Transform>): void {
+export function addHook(extension: string, options: Options): void {
   pirates.addHook(
-    (code: string, filePath: string): string => transform(code, {filePath, transforms}),
+    (code: string, filePath: string): string => transform(code, {...options, filePath}),
     {exts: [extension]},
   );
 }
 
 export function registerJS(): void {
-  addHook(".js", ["imports", "flow", "jsx"]);
+  addHook(".js", {transforms: ["imports", "flow", "jsx"]});
 }
 
 export function registerJSX(): void {
-  addHook(".jsx", ["imports", "flow", "jsx"]);
+  addHook(".jsx", {transforms: ["imports", "flow", "jsx"]});
 }
 
 export function registerTS(): void {
-  addHook(".ts", ["imports", "typescript"]);
+  addHook(".ts", {transforms: ["imports", "typescript"]});
 }
 
 export function registerTSX(): void {
-  addHook(".tsx", ["imports", "typescript", "jsx"]);
+  addHook(".tsx", {transforms: ["imports", "typescript", "jsx"]});
+}
+
+export function registerTSLegacyModuleInterop(): void {
+  addHook(".ts", {
+    transforms: ["imports", "typescript"],
+    enableLegacyTypeScriptModuleInterop: true,
+  });
+}
+
+export function registerTSXLegacyModuleInterop(): void {
+  addHook(".tsx", {
+    transforms: ["imports", "typescript", "jsx"],
+    enableLegacyTypeScriptModuleInterop: true,
+  });
 }
 
 export function registerAll(): void {

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -14,7 +14,7 @@ export default class ImportTransformer extends Transformer {
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
     readonly importProcessor: ImportProcessor,
-    readonly shouldAddModuleExports: boolean,
+    readonly enableLegacyBabel5ModuleInterop: boolean,
   ) {
     super();
   }
@@ -28,7 +28,7 @@ export default class ImportTransformer extends Transformer {
   }
 
   getSuffixCode(): string {
-    if (this.shouldAddModuleExports && this.hadDefaultExport && !this.hadNamedExport) {
+    if (this.enableLegacyBabel5ModuleInterop && this.hadDefaultExport && !this.hadNamedExport) {
       return "\nmodule.exports = exports.default;\n";
     }
     return "";

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -21,6 +21,7 @@ export default class RootTransformer {
   constructor(
     sucraseContext: SucraseContext,
     transforms: Array<Transform>,
+    enableLegacyBabel5ModuleInterop: boolean,
     filePath: string | null,
   ) {
     this.nameManager = sucraseContext.nameManager;
@@ -39,9 +40,13 @@ export default class RootTransformer {
     }
 
     if (transforms.includes("imports")) {
-      const shouldAddModuleExports = transforms.includes("add-module-exports");
       this.transformers.push(
-        new ImportTransformer(this, tokenProcessor, importProcessor, shouldAddModuleExports),
+        new ImportTransformer(
+          this,
+          tokenProcessor,
+          importProcessor,
+          enableLegacyBabel5ModuleInterop,
+        ),
       );
     }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -2,7 +2,7 @@ import {IMPORT_PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
 function assertFlowResult(code: string, expectedResult: string): void {
-  assertResult(code, expectedResult, ["jsx", "imports", "flow"]);
+  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "flow"]});
 }
 
 describe("transform flow", () => {

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -603,7 +603,7 @@ var _moduleName = require('moduleName');
     
 module.exports = exports.default;
 `,
-      ["imports", "add-module-exports"],
+      {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
     );
   });
 
@@ -617,7 +617,7 @@ module.exports = exports.default;
        exports.x = 1;
       exports. default = 4;
     `,
-      ["imports", "add-module-exports"],
+      {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
     );
   });
 

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -4,8 +4,8 @@ import * as util from "./util";
 const {devProps} = util;
 
 function assertResult(code: string, expectedResult: string): void {
-  util.assertResult(code, expectedResult, ["jsx"]);
-  util.assertResult(code, expectedResult, ["jsx", "flow"]);
+  util.assertResult(code, expectedResult, {transforms: ["jsx"]});
+  util.assertResult(code, expectedResult, {transforms: ["jsx", "flow"]});
 }
 
 describe("transform JSX", () => {

--- a/test/react-display-name-test.ts
+++ b/test/react-display-name-test.ts
@@ -172,8 +172,7 @@ describe("transform react-display-name", () => {
         }
       });
     `,
-      ["jsx", "imports"],
-      "MyComponent.js",
+      {transforms: ["jsx", "imports"], filePath: "MyComponent.js"},
     );
   });
 });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -115,13 +115,13 @@ describe("sucrase", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         [b]() {
         }
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -136,7 +136,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         get foo() {
           return 3;
@@ -145,7 +145,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -155,11 +155,11 @@ describe("sucrase", () => {
       if (foo.case === 3) {
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       if (foo.case === 3) {
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -173,7 +173,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       function foo() {
         outer: switch (a) {
           default:
@@ -181,7 +181,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -196,7 +196,7 @@ describe("sucrase", () => {
         const x = 3;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       /**
        * This is a JSDoc comment.
        */
@@ -205,7 +205,7 @@ describe("sucrase", () => {
         const x = 3;
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -219,7 +219,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         get() {
         }
@@ -227,7 +227,7 @@ describe("sucrase", () => {
         }
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -239,13 +239,13 @@ describe("sucrase", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         async foo() {
         }
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -255,11 +255,11 @@ describe("sucrase", () => {
       const n = 1_000_000;
       const x = 12_34.56_78;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const n = 1000000;
       const x = 1234.5678;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -268,10 +268,10 @@ describe("sucrase", () => {
       `
       export {Import as import};
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       exports.import = Import;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -282,12 +282,12 @@ describe("sucrase", () => {
         static x = 3;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
       } A.x = 3;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -298,12 +298,12 @@ describe("sucrase", () => {
         static x = 3;
       }
     `,
-      `"use strict"; var _class;
+      `"use strict";${IMPORT_PREFIX} var _class;
       const A = (_class = class {
         
       }, _class.x = 3, _class)
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -314,12 +314,12 @@ describe("sucrase", () => {
         static x = 3;
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class C {
         
       } C.x = 3; exports.default = C;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -333,15 +333,15 @@ describe("sucrase", () => {
         static b = B;
       }
     `,
-      `"use strict";
-      var _A = require('A');
-      var _B = require('B');
-      class C {constructor() { this.a = _A.default; }
+      `"use strict";${IMPORT_PREFIX}
+      var _A = require('A'); var _A2 = _interopRequireDefault(_A);
+      var _B = require('B'); var _B2 = _interopRequireDefault(_B);
+      class C {constructor() { this.a = _A2.default; }
         
         
-      } C.b = _B.default;
+      } C.b = _B2.default;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -351,9 +351,9 @@ describe("sucrase", () => {
       console.log("Hello");
     `,
       `#!/usr/bin/env node
-"use strict";      console.log("Hello");
+"use strict";${IMPORT_PREFIX}      console.log("Hello");
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -367,7 +367,7 @@ describe("sucrase", () => {
         console.log("Failed!");
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const e = 3;
       try {
         console.log(e);
@@ -375,7 +375,7 @@ describe("sucrase", () => {
         console.log("Failed!");
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -384,10 +384,10 @@ describe("sucrase", () => {
       `
       [a] = b;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       [a] = b;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -396,10 +396,10 @@ describe("sucrase", () => {
       `
       const x = +(y);
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const x = +(y);
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -411,13 +411,13 @@ describe("sucrase", () => {
         }
       };
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const o = {
         async f() {
         }
       };
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -426,10 +426,10 @@ describe("sucrase", () => {
       `
       const s = 'ab\\'cd';
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const s = 'ab\\'cd';
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -446,7 +446,7 @@ describe("sucrase", () => {
         
       } A.x = 1; exports.default = A;
     `,
-      ["jsx", "imports"],
+      {transforms: ["jsx", "imports"]},
     );
   });
 
@@ -457,12 +457,12 @@ describe("sucrase", () => {
       c ||= d;
       e ??= f;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       a &&= b;
       c ||= d;
       e ??= f;
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 
@@ -479,7 +479,7 @@ describe("sucrase", () => {
         outerMethod() {}
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class Bar{
         @(
           @classDec class { 
@@ -490,7 +490,7 @@ describe("sucrase", () => {
         outerMethod() {}
       }
     `,
-      ["jsx", "imports", "typescript"],
+      {transforms: ["jsx", "imports", "typescript"]},
     );
   });
 });

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -2,8 +2,8 @@ import {ESMODULE_PREFIX, IMPORT_PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
 function assertTypeScriptAndFlowResult(code: string, expectedResult: string): void {
-  assertResult(code, `"use strict";${expectedResult}`, ["jsx", "imports", "typescript"]);
-  assertResult(code, `"use strict";${IMPORT_PREFIX}${expectedResult}`, ["jsx", "imports", "flow"]);
+  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "typescript"]});
+  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "flow"]});
 }
 
 /**
@@ -16,7 +16,7 @@ describe("type transforms", () => {
       class A implements B {}
       class C extends D implements E {}
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A  {}
       class C extends D  {}
     `,
@@ -42,7 +42,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function f() {
         return 3;
       }
@@ -70,7 +70,7 @@ describe("type transforms", () => {
         const b = (a: number);
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo(x, y) {
         const a = "Hello";
         const b = (a);
@@ -86,7 +86,7 @@ describe("type transforms", () => {
         return [];
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo() {
         return [];
       }
@@ -101,7 +101,7 @@ describe("type transforms", () => {
         return [];
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo() {
         return [];
       }
@@ -117,7 +117,7 @@ describe("type transforms", () => {
         y: {} = {};
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A {constructor() { this.x = 2;this.y = {}; }
         
         
@@ -133,7 +133,7 @@ describe("type transforms", () => {
         x: number;
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
       }
@@ -156,7 +156,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function f(t) {
         console.log(t);
       }
@@ -179,7 +179,7 @@ describe("type transforms", () => {
         return x + 1;
       }
     `,
-      `${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        function foo(x) {
         return x + 1;
       } exports.foo = foo;
@@ -193,7 +193,7 @@ describe("type transforms", () => {
       type foo = number;
       const x: foo = 3;
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       
       const x = 3;
     `,
@@ -206,7 +206,7 @@ describe("type transforms", () => {
       export type foo = number | string;
       export const x = 1;
     `,
-      `${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       
        exports.x = 1;
     `,
@@ -220,7 +220,7 @@ describe("type transforms", () => {
         return x;
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo(x) {
         return x;
       }
@@ -233,7 +233,7 @@ describe("type transforms", () => {
       `
       const x: | number | string = "Hello";
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const x = "Hello";
     `,
     );
@@ -246,7 +246,7 @@ describe("type transforms", () => {
       const arr2: Array<Array<number>> = [[2]];
       const arr3: Array<Array<Array<number>>> = [[[3]]];
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const arr1 = [[1]];
       const arr2 = [[2]];
       const arr3 = [[[3]]];
@@ -260,7 +260,7 @@ describe("type transforms", () => {
       interface Cartesian { x: number; y: number; }
       export interface Polar { r: number; theta: number; }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       
 
     `,
@@ -274,7 +274,7 @@ describe("type transforms", () => {
         interface: true,
       };
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const o = {
         interface: true,
       };
@@ -289,7 +289,7 @@ describe("type transforms", () => {
         return 'Hi!';
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo(x) {
         return 'Hi!';
       }
@@ -302,7 +302,7 @@ describe("type transforms", () => {
       `
       const f = <T>(t: T): number => 3;
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const f = (t) => 3;
     `,
     );
@@ -313,7 +313,7 @@ describe("type transforms", () => {
       `
       const f: <T>(t: T) => number = () => 3;
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const f = () => 3;
     `,
     );
@@ -324,7 +324,7 @@ describe("type transforms", () => {
       `
       class Foo<T> {}
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class Foo {}
     `,
     );
@@ -337,7 +337,7 @@ describe("type transforms", () => {
         return -1;
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       function foo() {
         return -1;
       }
@@ -353,7 +353,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A {
         b() {
         }
@@ -369,7 +369,7 @@ describe("type transforms", () => {
         source: Map<B, C>,
       };
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       
 
 
@@ -385,7 +385,7 @@ describe("type transforms", () => {
         }
       }
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A {
         constructor() {
         }
@@ -399,7 +399,7 @@ describe("type transforms", () => {
       `
       const f = (x?: number) => x + 1;
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       const f = (x) => x + 1;
     `,
     );
@@ -410,7 +410,7 @@ describe("type transforms", () => {
       `
       class A extends B<C> {}
     `,
-      `
+      `"use strict";${IMPORT_PREFIX}
       class A extends B {}
     `,
     );

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2,7 +2,7 @@ import {ESMODULE_PREFIX, IMPORT_PREFIX, JSX_PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
 function assertTypeScriptResult(code: string, expectedResult: string): void {
-  assertResult(code, expectedResult, ["jsx", "imports", "typescript"]);
+  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "typescript"]});
 }
 
 describe("typescript transform", () => {
@@ -12,7 +12,7 @@ describe("typescript transform", () => {
       const x = 0;
       console.log(x as string);
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const x = 0;
       console.log(x );
     `,
@@ -25,7 +25,7 @@ describe("typescript transform", () => {
       const as = "Hello";
       console.log(as);
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const as = "Hello";
       console.log(as);
     `,
@@ -42,7 +42,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
          c() {
@@ -63,7 +63,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
         constructor() {;this.x = 1;
@@ -84,7 +84,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A extends B {
         
         constructor(a) {
@@ -102,7 +102,7 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {constructor() { this.x = 1; }
         
       }
@@ -117,7 +117,7 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A extends B {constructor(...args) { super(...args); this.x = 1; }
         
       }
@@ -132,7 +132,7 @@ describe("typescript transform", () => {
         args = 1;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A extends B {constructor(...args2) { super(...args2); this.args = 1; }
         
       }
@@ -148,7 +148,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         constructor( x) {;this.x = x;
         }
@@ -166,7 +166,7 @@ describe("typescript transform", () => {
       const a = (x)!(y);
       const b = x + !y;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const x = 1;
       const y = x;
       const z = !x; 
@@ -184,7 +184,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class Foo {
         static run() {
         }
@@ -201,7 +201,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class Foo {
         async run() {
         }
@@ -217,7 +217,7 @@ describe("typescript transform", () => {
         return x === 0;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       function foo(x) {
         return x === 0;
       }
@@ -232,7 +232,7 @@ describe("typescript transform", () => {
         return list.reduce((memo, item) => memo.concat(map(item)), [] as Array<U>);
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        function flatMap(list, map) {
         return list.reduce((memo, item) => memo.concat(map(item)), [] );
       } exports.default = flatMap;
@@ -246,7 +246,7 @@ describe("typescript transform", () => {
       export interface A extends B {
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
 
     `,
@@ -270,16 +270,16 @@ describe("typescript transform", () => {
         return true;
       }
     `,
-      `"use strict";
-      var _a = require('a');
+      `"use strict";${IMPORT_PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
       
       require('c');
-      var _d = require('d');
+      var _d = require('d'); var _d2 = _interopRequireDefault(_d);
       
       
       
       function f(a) {
-        return a instanceof _a.default;
+        return a instanceof _a2.default;
       }
       function g(b) {
         return true;
@@ -296,7 +296,7 @@ describe("typescript transform", () => {
         f: any = function() {};
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {constructor() { this.f = function() {}; }
         
         
@@ -310,7 +310,7 @@ describe("typescript transform", () => {
       `
       export abstract class A {}
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class A {} exports.A = A;
     `,
     );
@@ -321,7 +321,7 @@ describe("typescript transform", () => {
       `
       values.filter((node): node is Node => node !== null);
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       values.filter((node) => node !== null);
     `,
     );
@@ -334,7 +334,7 @@ describe("typescript transform", () => {
       values.filter<Node>((node): node is Node => node !== null);
       const c = new Cache<number>();
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const f = f(y);
       values.filter((node) => node !== null);
       const c = new Cache();
@@ -351,7 +351,7 @@ describe("typescript transform", () => {
         "Hello, world" = 2;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {constructor() { this[a + b] = 3;this[0] = 1;this["Hello, world"] = 2; }
         
         
@@ -370,7 +370,7 @@ describe("typescript transform", () => {
         C
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       var Foo; (function (Foo) {
         const A = 0; Foo[Foo["A"] = A] = "A";
         const B = A + 1; Foo[Foo["B"] = B] = "B";
@@ -389,7 +389,7 @@ describe("typescript transform", () => {
         C = "sea",
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       var Foo; (function (Foo) {
         const A = "eh"; Foo["A"] = A;
         const B = "bee"; Foo["B"] = B;
@@ -414,7 +414,7 @@ describe("typescript transform", () => {
         "'",
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       var Foo; (function (Foo) {
         const A = 15.5; Foo[Foo["A"] = A] = "A";
         Foo[Foo["Hello world"] = A / 2] = "Hello world";
@@ -439,7 +439,7 @@ describe("typescript transform", () => {
         console.log(x);
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
 
       function foo(x) {
@@ -457,7 +457,7 @@ describe("typescript transform", () => {
         export = result;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
 
 
@@ -472,7 +472,7 @@ describe("typescript transform", () => {
       export declare class Foo {
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
 
     `,
@@ -486,7 +486,7 @@ describe("typescript transform", () => {
         return "Hello!";
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       function foo(declare) {
         return "Hello!";
       }
@@ -503,7 +503,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class Foo {
         bar(readonly) {
           console.log(readonly);
@@ -519,7 +519,7 @@ describe("typescript transform", () => {
       export default abstract class Foo {
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class Foo {
       } exports.default = Foo;
     `,
@@ -532,8 +532,8 @@ describe("typescript transform", () => {
       import * as f from './myFunc';
       console.log(f());
     `,
-      `"use strict";
-      var _myFunc = require('./myFunc'); var f = _myFunc;
+      `"use strict";${IMPORT_PREFIX}
+      var _myFunc = require('./myFunc'); var f = _interopRequireWildcard(_myFunc);
       console.log(f());
     `,
     );
@@ -547,7 +547,7 @@ describe("typescript transform", () => {
         Bar,
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       var A; (function (A) {
         const Foo = 0; A[A["Foo"] = Foo] = "Foo";
         const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
@@ -564,7 +564,7 @@ describe("typescript transform", () => {
         Bar,
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       var A; (function (A) {
         const Foo = 0; A[A["Foo"] = Foo] = "Foo";
         const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
@@ -581,7 +581,7 @@ describe("typescript transform", () => {
         Bar,
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       var A; (function (A) {
         const Foo = 0; A[A["Foo"] = Foo] = "Foo";
         const Bar = Foo + 1; A[A["Bar"] = Bar] = "Bar";
@@ -596,7 +596,7 @@ describe("typescript transform", () => {
       abstract class A {
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
        class A {
       }
     `,
@@ -613,7 +613,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
        class A {
         
         b() {
@@ -630,9 +630,9 @@ describe("typescript transform", () => {
       import A from 'a';
       export {A};
     `,
-      `"use strict";${ESMODULE_PREFIX}
-      var _a = require('a');
-      exports.A = _a.default;
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
+      var _a = require('a'); var _a2 = _interopRequireDefault(_a);
+      exports.A = _a2.default;
     `,
     );
   });
@@ -644,7 +644,7 @@ describe("typescript transform", () => {
       console.log(a);
       export = 3;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const a = require('a');
       console.log(a);
       module.exports = 3;
@@ -659,7 +659,7 @@ describe("typescript transform", () => {
         return this + x;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       function foo( x) {
         return this + x;
       }
@@ -672,7 +672,7 @@ describe("typescript transform", () => {
       `
       export * from './MyVars';
     `,
-      `"use strict";${ESMODULE_PREFIX}
+      `"use strict";${IMPORT_PREFIX}${ESMODULE_PREFIX}
       var _MyVars = require('./MyVars'); Object.keys(_MyVars).filter(key => key !== 'default' && key !== '__esModule').forEach(key => { if (exports.hasOwnProperty(key)) { return; } Object.defineProperty(exports, key, {enumerable: true, get: () => _MyVars[key]}); });
     `,
     );
@@ -687,7 +687,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
          constructor() {;this.x = 1;
@@ -702,127 +702,119 @@ describe("typescript transform", () => {
       `
       const x = <number>3;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const x = 3;
     `,
-      ["typescript", "imports"],
+      {transforms: ["typescript", "imports"]},
     );
   });
 
   it("properly handles new declarations within interfaces", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       interface Foo {
         new(): Foo;
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
 
 
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles code with an index signature", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       const o: {[k: string]: number} = {
         a: 1,
         b: 2,
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const o = {
         a: 1,
         b: 2,
       }
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles assert and assign syntax", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       (a as b) = c;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       (a ) = c;
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles possible JSX ambiguities", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       f<T>();
       new C<T>();
       type A = T<T>;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       f();
       new C();
       
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles the 'unique' contextual keyword", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       let y: unique symbol;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       let y;
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles async arrow functions with rest params", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       const foo = async (...args: any[]) => {}
       const bar = async (...args?: any[]) => {}
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       const foo = async (...args) => {}
       const bar = async (...args) => {}
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles conditional types", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       type A = B extends C ? D : E;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles the 'infer' contextual keyword in types", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       type Element<T> = T extends (infer U)[] ? U : T;
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles definite assignment assertions in classes", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       class A {
         foo!: number;
@@ -831,7 +823,7 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       class A {
         
         getFoo() {
@@ -839,26 +831,24 @@ describe("typescript transform", () => {
         }
       }
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("handles mapped type modifiers", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       let map: { +readonly [P in string]+?: number; };
       let map2: { -readonly [P in string]-?: number };
     `,
-      `"use strict";
+      `"use strict";${IMPORT_PREFIX}
       let map;
       let map2;
     `,
-      ["typescript", "imports"],
     );
   });
 
   it("does not prune imported identifiers referenced by JSX", () => {
-    assertResult(
+    assertTypeScriptResult(
       `
       import React from 'react';
       
@@ -878,26 +868,25 @@ describe("typescript transform", () => {
         );
       }
     `,
-      `"use strict";${JSX_PREFIX}
-      var _react = require('react');
+      `"use strict";${JSX_PREFIX}${IMPORT_PREFIX}
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
       
-      var _Foo = require('./Foo');
+      var _Foo = require('./Foo'); var _Foo2 = _interopRequireDefault(_Foo);
       
       
-      var _lowercaseComponent = require('./lowercaseComponent');
+      var _lowercaseComponent = require('./lowercaseComponent'); var _lowercaseComponent2 = _interopRequireDefault(_lowercaseComponent);
       
       
       const x = 3;
       function render() {
         return (
-          _react.default.createElement('div', {__self: this, __source: {fileName: _jsxFileName, lineNumber: 13}}
-            , _react.default.createElement(_Foo.default.Bar, { someProp: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 14}} )
-            , _react.default.createElement(_lowercaseComponent.default.Thing, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 15}} )
+          _react2.default.createElement('div', {__self: this, __source: {fileName: _jsxFileName, lineNumber: 13}}
+            , _react2.default.createElement(_Foo2.default.Bar, { someProp: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 14}} )
+            , _react2.default.createElement(_lowercaseComponent2.default.Thing, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 15}} )
           )
         );
       }
     `,
-      ["typescript", "jsx", "imports"],
     );
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,14 +1,13 @@
 import * as assert from "assert";
 
-import {transform, Transform} from "../src";
+import {Options, transform, Transform} from "../src";
 
 export function assertResult(
   code: string,
   expectedResult: string,
-  transforms: Array<Transform> = ["jsx", "imports"],
-  filePath?: string,
+  options: Options = {transforms: ["jsx", "imports"]},
 ): void {
-  assert.equal(transform(code, {transforms, filePath}), expectedResult);
+  assert.equal(transform(code, options), expectedResult);
 }
 
 export function devProps(lineNumber: number): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "strictNullChecks": true,
     "target": "es2017",
     "module": "commonjs",
@@ -7,6 +8,7 @@
     "declaration": true,
     "lib": ["es2017"],
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
Instead of having a transform to mimic babel 5, there's now an option to do so
and also an option to mimic old-style TypeScript ESM/CJS interop.