### PR TITLE
Overhaul import processing to allow import pruning when targeting ESM

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -1,11 +1,14 @@
 import {ContextualKeyword, IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
-import ImportProcessor from "../ImportProcessor";
+import CJSImportProcessor from "../CJSImportProcessor";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
-export default class ImportTransformer extends Transformer {
+/**
+ * Class for editing import statements when we are transforming to commonjs.
+ */
+export default class CJSImportTransformer extends Transformer {
   private hadExport: boolean = false;
   private hadNamedExport: boolean = false;
   private hadDefaultExport: boolean = false;
@@ -13,7 +16,7 @@ export default class ImportTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
-    readonly importProcessor: ImportProcessor,
+    readonly importProcessor: CJSImportProcessor,
     readonly enableLegacyBabel5ModuleInterop: boolean,
   ) {
     super();
@@ -35,6 +38,7 @@ export default class ImportTransformer extends Transformer {
   }
 
   process(): boolean {
+    // TypeScript `import foo = require('foo');` should always just be translated to plain require.
     if (this.tokens.matches3(tt._import, tt.name, tt.eq)) {
       this.tokens.replaceToken("const");
       return true;

--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -1,0 +1,185 @@
+import {ContextualKeyword} from "../../sucrase-babylon/tokenizer";
+import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+import {getNonTypeIdentifiers} from "../util/getNonTypeIdentifiers";
+import Transformer from "./Transformer";
+
+/**
+ * Class for editing import statements when we are keeping the code as ESM. We still need to remove
+ * type-only imports in TypeScript and Flow.
+ */
+export default class ESMImportTransformer extends Transformer {
+  private nonTypeIdentifiers: Set<string>;
+
+  constructor(readonly tokens: TokenProcessor, readonly isTypeScriptTransformEnabled: boolean) {
+    super();
+    this.nonTypeIdentifiers = isTypeScriptTransformEnabled
+      ? getNonTypeIdentifiers(tokens)
+      : new Set();
+  }
+
+  process(): boolean {
+    // TypeScript `import foo = require('foo');` should always just be translated to plain require.
+    if (this.tokens.matches3(tt._import, tt.name, tt.eq)) {
+      this.tokens.replaceToken("const");
+      return true;
+    }
+    if (this.tokens.matches2(tt._export, tt.eq)) {
+      this.tokens.replaceToken("module.exports");
+      return true;
+    }
+    if (this.tokens.matches1(tt._import)) {
+      return this.processImport();
+    }
+    return false;
+  }
+
+  private processImport(): boolean {
+    if (this.tokens.matches2(tt._import, tt.parenL)) {
+      // Dynamic imports don't need to be transformed.
+      return false;
+    }
+
+    const snapshot = this.tokens.snapshot();
+    const allImportsRemoved = this.removeTypeBindings();
+    if (allImportsRemoved) {
+      this.tokens.restoreToSnapshot(snapshot);
+      while (!this.tokens.matches1(tt.string)) {
+        this.tokens.removeToken();
+      }
+      this.tokens.removeToken();
+      if (this.tokens.matches1(tt.semi)) {
+        this.tokens.removeToken();
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Remove type bindings from this import, leaving the rest of the import intact.
+   *
+   * Return true if this import was ONLY types, and thus is eligible for removal. This will bail out
+   * of the replacement operation, so we can return early here.
+   */
+  private removeTypeBindings(): boolean {
+    this.tokens.copyExpectedToken(tt._import);
+    if (
+      this.tokens.matchesContextual(ContextualKeyword._type) &&
+      !this.tokens.matchesAtIndex(this.tokens.currentIndex() + 1, [tt.comma]) &&
+      !this.tokens.matchesContextualAtIndex(this.tokens.currentIndex() + 1, ContextualKeyword._from)
+    ) {
+      // This is an "import type" statement, so exit early.
+      return true;
+    }
+
+    if (this.tokens.matches1(tt.string)) {
+      // This is a bare import, so we should proceed with the import.
+      this.tokens.copyToken();
+      return false;
+    }
+
+    let foundNonTypeImport = false;
+
+    if (this.tokens.matches1(tt.name)) {
+      if (this.isTypeName(this.tokens.identifierName())) {
+        this.tokens.removeToken();
+        if (this.tokens.matches1(tt.comma)) {
+          this.tokens.removeToken();
+        }
+      } else {
+        foundNonTypeImport = true;
+        this.tokens.copyToken();
+        if (this.tokens.matches1(tt.comma)) {
+          this.tokens.copyToken();
+        }
+      }
+    }
+
+    if (this.tokens.matches1(tt.star)) {
+      if (this.isTypeName(this.tokens.identifierNameAtIndex(this.tokens.currentIndex() + 2))) {
+        this.tokens.removeToken();
+        this.tokens.removeToken();
+        this.tokens.removeToken();
+      } else {
+        foundNonTypeImport = true;
+        this.tokens.copyExpectedToken(tt.star);
+        this.tokens.copyExpectedToken(tt.name);
+        this.tokens.copyExpectedToken(tt.name);
+      }
+    } else if (this.tokens.matches1(tt.braceL)) {
+      this.tokens.copyToken();
+      while (!this.tokens.matches1(tt.braceR)) {
+        if (
+          this.tokens.matches3(tt.name, tt.name, tt.comma) ||
+          this.tokens.matches3(tt.name, tt.name, tt.braceR)
+        ) {
+          // type foo
+          this.tokens.removeToken();
+          this.tokens.removeToken();
+          if (this.tokens.matches1(tt.comma)) {
+            this.tokens.removeToken();
+          }
+        } else if (
+          this.tokens.matches5(tt.name, tt.name, tt.name, tt.name, tt.comma) ||
+          this.tokens.matches5(tt.name, tt.name, tt.name, tt.name, tt.braceR)
+        ) {
+          // type foo as bar
+          this.tokens.removeToken();
+          this.tokens.removeToken();
+          this.tokens.removeToken();
+          this.tokens.removeToken();
+          if (this.tokens.matches1(tt.comma)) {
+            this.tokens.removeToken();
+          }
+        } else if (
+          this.tokens.matches2(tt.name, tt.comma) ||
+          this.tokens.matches2(tt.name, tt.braceR)
+        ) {
+          // foo
+          if (this.isTypeName(this.tokens.identifierName())) {
+            this.tokens.removeToken();
+            if (this.tokens.matches1(tt.comma)) {
+              this.tokens.removeToken();
+            }
+          } else {
+            foundNonTypeImport = true;
+            this.tokens.copyToken();
+            if (this.tokens.matches1(tt.comma)) {
+              this.tokens.copyToken();
+            }
+          }
+        } else if (
+          this.tokens.matches4(tt.name, tt.name, tt.name, tt.comma) ||
+          this.tokens.matches4(tt.name, tt.name, tt.name, tt.braceR)
+        ) {
+          // foo as bar
+          if (this.isTypeName(this.tokens.identifierNameAtIndex(this.tokens.currentIndex() + 2))) {
+            this.tokens.removeToken();
+            this.tokens.removeToken();
+            this.tokens.removeToken();
+            if (this.tokens.matches1(tt.comma)) {
+              this.tokens.removeToken();
+            }
+          } else {
+            foundNonTypeImport = true;
+            this.tokens.copyToken();
+            this.tokens.copyToken();
+            this.tokens.copyToken();
+            if (this.tokens.matches1(tt.comma)) {
+              this.tokens.copyToken();
+            }
+          }
+        } else {
+          throw new Error("Unexpected import form.");
+        }
+      }
+      this.tokens.copyExpectedToken(tt.braceR);
+    }
+
+    return !foundNonTypeImport;
+  }
+
+  private isTypeName(name: string): boolean {
+    return this.isTypeScriptTransformEnabled && !this.nonTypeIdentifiers.has(name);
+  }
+}

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -1,6 +1,6 @@
 import XHTMLEntities from "../../sucrase-babylon/plugins/jsx/xhtml";
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
-import ImportProcessor from "../ImportProcessor";
+import CJSImportProcessor from "../CJSImportProcessor";
 import NameManager from "../NameManager";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
@@ -17,7 +17,7 @@ export default class JSXTransformer extends Transformer {
   constructor(
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
-    readonly importProcessor: ImportProcessor,
+    readonly importProcessor: CJSImportProcessor | null,
     readonly nameManager: NameManager,
     readonly filePath: string | null,
   ) {
@@ -181,7 +181,9 @@ export default class JSXTransformer extends Transformer {
   }
 
   processJSXTag(): void {
-    const resolvedReactName = this.importProcessor.getIdentifierReplacement("React") || "React";
+    const resolvedReactName = this.importProcessor
+      ? this.importProcessor.getIdentifierReplacement("React") || "React"
+      : "React";
     const firstTokenStart = this.tokens.currentToken().start;
     // First tag is always jsxTagStart.
     this.tokens.replaceToken(`${resolvedReactName}.createElement(`);

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -5,7 +5,11 @@ import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
 
 export default class TypeScriptTransformer extends Transformer {
-  constructor(readonly rootTransformer: RootTransformer, readonly tokens: TokenProcessor) {
+  constructor(
+    readonly rootTransformer: RootTransformer,
+    readonly tokens: TokenProcessor,
+    readonly isImportsTransformEnabled: boolean,
+  ) {
     super();
   }
 
@@ -47,11 +51,14 @@ export default class TypeScriptTransformer extends Transformer {
     }
     const enumName = this.tokens.identifierName();
     this.tokens.removeToken();
+    if (isExport && !this.isImportsTransformEnabled) {
+      this.tokens.appendCode("export ");
+    }
     this.tokens.appendCode(`var ${enumName}; (function (${enumName})`);
     this.tokens.copyExpectedToken(tt.braceL);
     this.processEnumBody(enumName);
     this.tokens.copyExpectedToken(tt.braceR);
-    if (isExport) {
+    if (isExport && this.isImportsTransformEnabled) {
       this.tokens.appendCode(`)(${enumName} || (exports.${enumName} = ${enumName} = {}));`);
     } else {
       this.tokens.appendCode(`)(${enumName} || (${enumName} = {}));`);

--- a/src/util/getNonTypeIdentifiers.ts
+++ b/src/util/getNonTypeIdentifiers.ts
@@ -1,0 +1,29 @@
+import {IdentifierRole} from "../../sucrase-babylon/tokenizer";
+import {TokenType, TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+import {startsWithLowerCase} from "../transformers/JSXTransformer";
+
+export function getNonTypeIdentifiers(tokens: TokenProcessor): Set<string> {
+  const nonTypeIdentifiers: Set<string> = new Set();
+  for (let i = 0; i < tokens.tokens.length; i++) {
+    const token = tokens.tokens[i];
+    if (
+      token.type === tt.name &&
+      !token.isType &&
+      (token.identifierRole === IdentifierRole.Access ||
+        token.identifierRole === IdentifierRole.ObjectShorthand ||
+        token.identifierRole === IdentifierRole.ExportAccess)
+    ) {
+      nonTypeIdentifiers.add(tokens.identifierNameForToken(token));
+    }
+    if (token.type === tt.jsxName && token.identifierRole === IdentifierRole.Access) {
+      nonTypeIdentifiers.add("React");
+      const identifierName = tokens.identifierNameForToken(token);
+      // Lower-case single-component tag names like "div" don't count.
+      if (!startsWithLowerCase(identifierName) || tokens.tokens[i + 1].type === TokenType.dot) {
+        nonTypeIdentifiers.add(tokens.identifierNameForToken(token));
+      }
+    }
+  }
+  return nonTypeIdentifiers;
+}

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -5,6 +5,10 @@ function assertFlowResult(code: string, expectedResult: string): void {
   assertResult(code, expectedResult, {transforms: ["jsx", "imports", "flow"]});
 }
 
+function assertFlowESMResult(code: string, expectedResult: string): void {
+  assertResult(code, expectedResult, {transforms: ["jsx", "flow"]});
+}
+
 describe("transform flow", () => {
   it("removes `import type` statements", () => {
     assertFlowResult(
@@ -196,6 +200,19 @@ describe("transform flow", () => {
     `,
       `"use strict";${IMPORT_PREFIX}
       
+    `,
+    );
+  });
+
+  it("properly prunes flow imported names", () => {
+    assertFlowESMResult(
+      `
+      import a, {type n as b, m as c, type d} from './e';
+      import type f from './g';
+    `,
+      `
+      import a, { m as c,} from './e';
+
     `,
     );
   });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -493,4 +493,16 @@ describe("sucrase", () => {
       {transforms: ["jsx", "imports", "typescript"]},
     );
   });
+
+  it("handles variables named createReactClass", () => {
+    assertResult(
+      `
+      const createReactClass = 3;
+    `,
+      `"use strict";${IMPORT_PREFIX}
+      const createReactClass = 3;
+    `,
+      {transforms: ["jsx", "imports", "typescript"]},
+    );
+  });
 });


### PR DESCRIPTION
We now support typescript or flow with the import transform disabled, this uses
a new ESMImportTransformer classes that focuses on removing bindings that are
marked with `type` (in flow) or that are only used as types (in TypeScript).

This also fixes `export enum` syntax to work properly whether we are targeting
CJS or ESM.