### PR TITLE
Add support for custom JSX pragmas

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ The following proposed JS features are built-in and always transformed:
 * [Optional catch binding](https://github.com/tc39/proposal-optional-catch-binding):
   `try { doThing(); } catch { }`.
 
-When using the `import` transform, there are some options to enable legacy
-CommonJS interop approaches:
+### JSX Options
+Like Babel, Sucrase compiles JSX to React functions by default, but can be
+configured for any JSX use case.
+* **jsxPragma**: Element creation function, defaults to `React.createElement`.
+* **jsxFragmentPragma**: Fragment component, defaults to `React.Fragment`.
+
+### Legacy CommonJS interop
+Two legacy modes can be used with the `import` tranform:
 * **enableLegacyTypeScriptModuleInterop**: Use the default TypeScript approach
   to CommonJS interop instead of assuming that TypeScript's `--esModuleInterop`
   flag is enabled. For example, if a CJS module exports a function, legacy

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type Transform = "jsx" | "typescript" | "flow" | "imports";
 
 export type Options = {
   transforms: Array<Transform>;
+  jsxPragma?: string;
+  jsxFragmentPragma?: string;
   enableLegacyTypeScriptModuleInterop?: boolean;
   enableLegacyBabel5ModuleInterop?: boolean;
   filePath?: string;
@@ -35,7 +37,7 @@ export function transform(code: string, options: Options): string {
       sucraseContext,
       options.transforms,
       Boolean(options.enableLegacyBabel5ModuleInterop),
-      options.filePath || null,
+      options,
     ).transform();
   } catch (e) {
     if (options.filePath) {

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,6 +1,7 @@
 import {ContextualKeyword, IdentifierRole} from "../../sucrase-babylon/tokenizer";
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
 import CJSImportProcessor from "../CJSImportProcessor";
+import {Options} from "../index";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
 import Transformer from "./Transformer";
@@ -18,7 +19,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
     readonly rootTransformer: RootTransformer,
     readonly tokens: TokenProcessor,
     readonly importProcessor: CJSImportProcessor | null,
-    readonly filePath: string | null,
+    readonly options: Options,
   ) {
     super();
   }
@@ -104,7 +105,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
   }
 
   private getDisplayNameFromFilename(): string {
-    const filePath = this.filePath || "unknown";
+    const filePath = this.options.filePath || "unknown";
     const pathSegments = filePath.split("/");
     const filename = pathSegments[pathSegments.length - 1];
     const dotIndex = filename.lastIndexOf(".");

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -1,5 +1,5 @@
 import {TokenType as tt} from "../../sucrase-babylon/tokenizer/types";
-import {SucraseContext, Transform} from "../index";
+import {Options, SucraseContext, Transform} from "../index";
 import NameManager from "../NameManager";
 import TokenProcessor from "../TokenProcessor";
 import getClassInfo, {ClassInfo} from "../util/getClassInfo";
@@ -24,7 +24,7 @@ export default class RootTransformer {
     sucraseContext: SucraseContext,
     transforms: Array<Transform>,
     enableLegacyBabel5ModuleInterop: boolean,
-    filePath: string | null,
+    options: Options,
   ) {
     this.nameManager = sucraseContext.nameManager;
     const {tokenProcessor, importProcessor} = sucraseContext;
@@ -35,10 +35,10 @@ export default class RootTransformer {
     this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
     if (transforms.includes("jsx")) {
       this.transformers.push(
-        new JSXTransformer(this, tokenProcessor, importProcessor, this.nameManager, filePath),
+        new JSXTransformer(this, tokenProcessor, importProcessor, this.nameManager, options),
       );
       this.transformers.push(
-        new ReactDisplayNameTransformer(this, tokenProcessor, importProcessor, filePath),
+        new ReactDisplayNameTransformer(this, tokenProcessor, importProcessor, options),
       );
     }
 


### PR DESCRIPTION
Fixes #207

As with Babel, we assume the pragma is a dot-separated list of identifiers (or
just an identifier), which we parse so that we can replace the base name if
necessary.