### PR TITLE
Remove runInTypeContext in favor of explicit push/pop

### DIFF
--- a/generator/generateTokenTypes.ts
+++ b/generator/generateTokenTypes.ts
@@ -253,7 +253,3 @@ export function formatTokenType(tokenType: TokenType): string {
 `;
   return code;
 }
-
-function generateLines<T>(arr: Array<T>, f: (t: T) => string): string {
-  return arr.map((t) => `  ${f(t)}\n`).join("");
-}

--- a/src/CJSImportProcessor.ts
+++ b/src/CJSImportProcessor.ts
@@ -1,8 +1,7 @@
-import {ContextualKeyword, IdentifierRole} from "../sucrase-babylon/tokenizer";
-import {TokenType, TokenType as tt} from "../sucrase-babylon/tokenizer/types";
+import {ContextualKeyword} from "../sucrase-babylon/tokenizer";
+import {TokenType as tt} from "../sucrase-babylon/tokenizer/types";
 import NameManager from "./NameManager";
 import TokenProcessor from "./TokenProcessor";
-import {startsWithLowerCase} from "./transformers/JSXTransformer";
 import {getNonTypeIdentifiers} from "./util/getNonTypeIdentifiers";
 
 type NamedImport = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import commander from "commander";
 import {exists, mkdir, readdir, readFile, stat, writeFile} from "mz/fs";
 import {join} from "path";
 
-import {Options, Transform, transform} from "./index";
+import {Options, transform} from "./index";
 
 export default function run(): void {
   commander

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,6 +1,6 @@
 // @ts-ignore: no types available.
 import * as pirates from "pirates";
-import {Options, Transform, transform} from "./index";
+import {Options, transform} from "./index";
 
 export function addHook(extension: string, options: Options): void {
   pirates.addHook(

--- a/sucrase-babylon/parser/expression.ts
+++ b/sucrase-babylon/parser/expression.ts
@@ -48,8 +48,9 @@ import {
   match,
   next,
   nextTemplateToken,
+  popTypeContext,
+  pushTypeContext,
   retokenizeSlashAsRegex,
-  runInTypeContext,
 } from "../tokenizer";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
 import {
@@ -193,9 +194,9 @@ function parseExprOp(minPrec: number, noIn: boolean | null): void {
     eatContextual(ContextualKeyword._as)
   ) {
     state.tokens[state.tokens.length - 1].type = tt._as;
-    runInTypeContext(1, () => {
-      tsParseType();
-    });
+    const oldIsType = pushTypeContext(1);
+    tsParseType();
+    popTypeContext(oldIsType);
     parseExprOp(minPrec, noIn);
     return;
   }

--- a/sucrase-babylon/parser/lval.ts
+++ b/sucrase-babylon/parser/lval.ts
@@ -4,7 +4,15 @@ import {
   tsParseAssignableListItemTypes,
   tsParseModifier,
 } from "../plugins/typescript";
-import {ContextualKeyword, eat, IdentifierRole, match, next, runInTypeContext} from "../tokenizer";
+import {
+  ContextualKeyword,
+  eat,
+  IdentifierRole,
+  match,
+  next,
+  popTypeContext,
+  pushTypeContext,
+} from "../tokenizer";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
 import {isFlowEnabled, isTypeScriptEnabled, state} from "./base";
 import {parseIdentifier, parseMaybeAssign, parseObj} from "./expression";
@@ -27,12 +35,13 @@ export function parseBindingIdentifier(): void {
 // Parses lvalue (assignable) atom.
 export function parseBindingAtom(isBlockScope: boolean): void {
   switch (state.type) {
-    case tt._this:
+    case tt._this: {
       // In TypeScript, "this" may be the name of a parameter, so allow it.
-      runInTypeContext(0, () => {
-        next();
-      });
+      const oldIsType = pushTypeContext(0);
+      next();
+      popTypeContext(oldIsType);
       return;
+    }
 
     case tt._yield:
     case tt.name: {

--- a/sucrase-babylon/tokenizer/index.ts
+++ b/sucrase-babylon/tokenizer/index.ts
@@ -121,6 +121,19 @@ export function runInTypeContext<T>(existingTokensInType: number, func: () => T)
   return result;
 }
 
+export function pushTypeContext(existingTokensInType: number): boolean {
+  for (let i = state.tokens.length - existingTokensInType; i < state.tokens.length; i++) {
+    state.tokens[i].isType = true;
+  }
+  const oldIsType = state.isType;
+  state.isType = true;
+  return oldIsType;
+}
+
+export function popTypeContext(oldIsType: boolean): void {
+  state.isType = oldIsType;
+}
+
 export function eat(type: TokenType): boolean {
   if (match(type)) {
     next();

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import {Options, transform, Transform} from "../src";
+import {Options, transform} from "../src";
 
 export function assertResult(
   code: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noUnusedLocals": true,
     "suppressImplicitAnyIndexErrors": true,
     "noImplicitThis": true,
     "downlevelIteration": true,


### PR DESCRIPTION
The arrow function style wasn't really necessary, and won't work in
AssemblyScript.

Also enforce unused variable checking.