### PR TITLE
Various fixes in README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sucrase
 
 [![Build Status](https://travis-ci.org/alangpierce/sucrase.svg?branch=master)](https://travis-ci.org/alangpierce/sucrase)
-[![npm version](https://badge.fury.io/js/sucrase.svg)](https://www.npmjs.com/package/sucrase)
+[![npm version](https://img.shields.io/npm/v/sucrase.svg)](https://www.npmjs.com/package/sucrase)
 [![MIT License](https://img.shields.io/npm/l/express.svg?maxAge=2592000)](LICENSE)
 [![Join the chat at https://gitter.im/sucrasejs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sucrasejs/Lobby)
 
@@ -20,7 +20,8 @@ hundreds of thousands of lines of code. Still, you may find correctness issues
 when running on a large codebase. Feel free to file issues!
 
 Sucrase can build the following codebases with all tests passing:
-* Sucrase itself (6K lines of code excluding Babylon fork, typescript, imports).
+* Sucrase itself (6K lines of code excluding Babel parser fork, typescript,
+  imports).
 * The [Benchling](https://benchling.com/) frontend codebase
   (500K lines of code, JSX, imports).
 * [Babel](https://github.com/babel/babel) (63K lines of code, flow, imports).
@@ -199,9 +200,9 @@ Babel: 9591.515ms
 
 ## License and attribution
 
-Sucrase is MIT-licensed. A large part of Sucrase is based on a fork of
-[Babylon](https://github.com/babel/babel/tree/master/packages/babylon), which is
-also MIT-licensed.
+Sucrase is MIT-licensed. A large part of Sucrase is based on a fork of the
+[Babel parser](https://github.com/babel/babel/tree/master/packages/babel-parser),
+which is also MIT-licensed.
 
 ## Why the name?
 

--- a/example-runner/example-configs/babel.patch
+++ b/example-runner/example-configs/babel.patch
@@ -65,6 +65,43 @@ index 9f07ae0e2..64cd4c94e 100644
  	./node_modules/.bin/lerna bootstrap
  	make build
  	cd packages/babel-runtime; \
+diff --git a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/input.js b/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/input.js
+deleted file mode 100644
+index f791cb876..000000000
+--- a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/input.js
++++ /dev/null
+@@ -1,7 +0,0 @@
+-var func = function * (){
+-  yield obj
+-      .method()
+-      .method2();
+-
+-  const actual = true;
+-};
+diff --git a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/options.json b/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/options.json
+deleted file mode 100644
+index 21fd7445e..000000000
+--- a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/options.json
++++ /dev/null
+@@ -1,6 +0,0 @@
+-{
+-  "plugins": [
+-    "transform-regenerator"
+-  ],
+-  "retainLines": true
+-}
+diff --git a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/output.js b/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/output.js
+deleted file mode 100644
+index 8c4effa02..000000000
+--- a/packages/babel-plugin-transform-regenerator/test/fixtures/variable-renaming/retain-lines/output.js
++++ /dev/null
+@@ -1,6 +0,0 @@
+-var func = /*#__PURE__*/regeneratorRuntime.mark(function _callee() {var actual;return regeneratorRuntime.wrap(function _callee$(_context) {while (1) switch (_context.prev = _context.next) {case 0:_context.next = 2;return (
+-          obj.
+-          method().
+-          method2());case 2:
+-
+-        actual = true;case 3:case "end":return _context.stop();}}, _callee, this);});
 diff --git a/scripts/gulp-tasks.js b/scripts/gulp-tasks.js
 index 2e4891efb..5c4d51602 100644
 --- a/scripts/gulp-tasks.js


### PR DESCRIPTION
* The old README badge was showing version ???, so it seems broken.
  The shields.io one should work better.
* Change README to reference babel-parser instead of babylon.
* Silence a Babel test that appears to be broken on Babel master as well,
  possibly a bad dependency change.