### PR TITLE
add rollup-plugin-sucrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ const compiledCode = transform(code, {transforms: ["typescript", "imports"]});
 
 There are also integrations for
 [Webpack](https://github.com/alangpierce/sucrase/tree/master/integrations/webpack-loader),
-[Gulp](https://github.com/alangpierce/sucrase/tree/master/integrations/gulp-plugin),
-and [Jest](https://github.com/alangpierce/sucrase/tree/master/integrations/jest-plugin).
+[Gulp](https://github.com/alangpierce/sucrase/tree/master/integrations/gulp-plugin), [Jest](https://github.com/alangpierce/sucrase/tree/master/integrations/jest-plugin) and [Rollup](https://github.com/rollup/rollup-plugin-sucrase).
 
 ## Motivation
 


### PR DESCRIPTION
hey, nice work! I whipped up a Rollup plugin — https://github.com/rollup/rollup-plugin-sucrase — and it's already [speeding up my builds](https://github.com/sveltejs/svelte/pull/1511) by a decent factor. I'm also impressed by how much leaner the output is. The only drawback I can see currently is that sourcemaps don't seem to be emitted (unless I've misunderstood?); look forward to being able to do that.

thanks!