### PR TITLE
Fix files accidentally included in final package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+*
+!bin/**
+!dist/**
+!register/**

--- a/package.json
+++ b/package.json
@@ -10,14 +10,9 @@
   "bin": {
     "sucrase": "./bin/sucrase"
   },
-  "files": [
-    "bin",
-    "dist",
-    "register"
-  ],
   "scripts": {
     "build": "script/build",
-    "clean": "rm -rf ./build ./dist",
+    "clean": "rm -rf ./build ./dist ./example-runner/example-repos",
     "generate": "ts-node ./generator/generate.ts",
     "self-build": "script/self-build",
     "self-test": "mocha test/**/*.ts --opts test/mocha-self-test.opts",
@@ -26,7 +21,7 @@
     "lint": "eslint './src/**/*.ts' './test/**/*.ts' './sucrase-babylon/**/*.ts' './integrations/gulp-plugin/src/**/*.ts'",
     "profile": "node --inspect-brk ./build/benchmark/profile.js",
     "profile-react": "node --inspect-brk ./build/benchmark/profile-react.js",
-    "prepublish": "yarn run build",
+    "prepublish": "yarn clean && yarn build",
     "run-examples": "ts-node ./example-runner/example-runner.ts",
     "test": "yarn lint && tsc --noEmit && tsc --project ./integrations/gulp-plugin --noEmit && mocha test",
     "test-dist": "./node_modules/.bin/mocha build/test --opts test/mocha-self-test.opts"


### PR DESCRIPTION
The example-repos directory contained a number .gitignore files that were
explicitly including files that we don't want to include, so we now clear all
example repos before publish.

Also, the implementation of `files` in package.json was including `dist`
directories in `integrations` advertently, so we now do the equivalent thing
in .npmignore with some fixes.