### PR TITLE
Change transform to return an object instead of a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ Call from JS directly:
 
 ```js
 import {transform} from "sucrase";
-const compiledCode = transform(code, {transforms: ["typescript", "imports"]});
+const compiledCode = transform(code, {transforms: ["typescript", "imports"]}).code;
 ```
 
 There are also integrations for
 [Webpack](https://github.com/alangpierce/sucrase/tree/master/integrations/webpack-loader),
-[Gulp](https://github.com/alangpierce/sucrase/tree/master/integrations/gulp-plugin), [Jest](https://github.com/alangpierce/sucrase/tree/master/integrations/jest-plugin) and [Rollup](https://github.com/rollup/rollup-plugin-sucrase).
+[Gulp](https://github.com/alangpierce/sucrase/tree/master/integrations/gulp-plugin),
+[Jest](https://github.com/alangpierce/sucrase/tree/master/integrations/jest-plugin) and
+[Rollup](https://github.com/rollup/rollup-plugin-sucrase).
 
 ## What Sucrase is not
 

--- a/integrations/gulp-plugin/src/index.ts
+++ b/integrations/gulp-plugin/src/index.ts
@@ -27,7 +27,8 @@ function gulpSucrase(options: Options): Transform {
     }
 
     try {
-      const resultCode = transform(file.contents.toString(), {filePath: file.path, ...options});
+      const resultCode = transform(file.contents.toString(), {filePath: file.path, ...options})
+        .code;
       file.contents = Buffer.from(resultCode);
       file.path = replaceExt(file.path, ".js");
       this.push(file);

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -14,7 +14,7 @@ function getTransforms(filename: string): Array<Transform> | null {
 export function process(src: string, filename: string): string {
   const transforms = getTransforms(filename);
   if (transforms !== null) {
-    return transform(src, {transforms, filePath: filename});
+    return transform(src, {transforms, filePath: filename}).code;
   } else {
     return src;
   }

--- a/integrations/webpack-loader/src/index.ts
+++ b/integrations/webpack-loader/src/index.ts
@@ -5,7 +5,7 @@ function loader(code: string): string {
   const webpackRemainingChain = getRemainingRequest(this).split("!");
   const filePath = webpackRemainingChain[webpackRemainingChain.length - 1];
   const options: Options = getOptions(this) as Options;
-  return transform(code, {filePath, ...options});
+  return transform(code, {filePath, ...options}).code;
 }
 
 export = loader;

--- a/script/build.ts
+++ b/script/build.ts
@@ -32,6 +32,8 @@ async function buildSucrase(): Promise<void> {
   await run(`${SUCRASE} ./src -d ./dist --transforms imports,typescript`);
   if (!fast) {
     await run(`${TSC} --emitDeclarationOnly --project ./src --outDir ./dist`);
+    // Link all integrations to Sucrase so that all building/linting/testing is up to date.
+    await run("yarn link");
   }
 }
 
@@ -41,6 +43,7 @@ async function buildIntegration(path: string): Promise<void> {
     const originalDir = process.cwd();
     process.chdir(path);
     await run("yarn");
+    await run("yarn link sucrase");
     process.chdir(originalDir);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,6 @@ async function buildDirectory(
 async function buildFile(srcPath: string, outPath: string, options: Options): Promise<void> {
   console.log(`${srcPath} -> ${outPath}`);
   const code = (await readFile(srcPath)).toString();
-  const transformedCode = transform(code, {...options, filePath: srcPath});
+  const transformedCode = transform(code, {...options, filePath: srcPath}).code;
   await writeFile(outPath, transformedCode);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ export type Options = {
   filePath?: string;
 };
 
+export type TransformResult = {
+  code: string;
+};
+
 export type SucraseContext = {
   tokenProcessor: TokenProcessor;
   scopes: Array<Scope>;
@@ -30,15 +34,18 @@ export function getVersion(): string {
   return require("../../package.json").version;
 }
 
-export function transform(code: string, options: Options): string {
+export function transform(code: string, options: Options): TransformResult {
   try {
     const sucraseContext = getSucraseContext(code, options);
-    return new RootTransformer(
+    const transformer = new RootTransformer(
       sucraseContext,
       options.transforms,
       Boolean(options.enableLegacyBabel5ModuleInterop),
       options,
-    ).transform();
+    );
+    return {
+      code: transformer.transform(),
+    };
   } catch (e) {
     if (options.filePath) {
       e.message = `Error transforming ${options.filePath}: ${e.message}`;

--- a/src/register.ts
+++ b/src/register.ts
@@ -4,7 +4,7 @@ import {Options, transform} from "./index";
 
 export function addHook(extension: string, options: Options): void {
   pirates.addHook(
-    (code: string, filePath: string): string => transform(code, {...options, filePath}),
+    (code: string, filePath: string): string => transform(code, {...options, filePath}).code,
     {exts: [extension]},
   );
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,7 +7,7 @@ export function assertResult(
   expectedResult: string,
   options: Options = {transforms: ["jsx", "imports"]},
 ): void {
-  assert.equal(transform(code, options), expectedResult);
+  assert.equal(transform(code, options).code, expectedResult);
 }
 
 export function devProps(lineNumber: number): string {


### PR DESCRIPTION
This gives us more flexibility to return a source map and maybe other useful
metadata. This is a breaking change, so I'm getting the major version bump out
of the way independently of the actual source map implementation.