### PR TITLE
Switch from object literal types to interfaces

### DIFF
--- a/benchmark/loadReactFiles.ts
+++ b/benchmark/loadReactFiles.ts
@@ -1,10 +1,10 @@
 import {readdir, readFile, stat} from "mz/fs";
 import {join} from "path";
 
-export type FileInfo = {
+export interface FileInfo {
   path: string;
   code: string;
-};
+}
 
 export async function loadReactFiles(): Promise<Array<FileInfo>> {
   const results: Array<FileInfo> = [];

--- a/generator/generateReadWord.ts
+++ b/generator/generateReadWord.ts
@@ -118,11 +118,11 @@ export default function readWord(): void {
 }
 `;
 
-type Keyword = {
+interface Keyword {
   name: string;
   remainingName: string;
   isContextual: boolean;
-};
+}
 
 const ALL_KEYWORDS: Array<Keyword> = [
   ...KEYWORDS.map((name) => ({name, remainingName: name, isContextual: false})),

--- a/generator/generateTokenTypes.ts
+++ b/generator/generateTokenTypes.ts
@@ -2,14 +2,14 @@ const isAssign = true;
 const prefix = true;
 const postfix = true;
 
-type TokenOptions = {
+interface TokenOptions {
   keyword?: string;
   rightAssociative?: boolean;
   isAssign?: boolean;
   prefix?: boolean;
   postfix?: boolean;
   binop?: number;
-};
+}
 
 class TokenType {
   label: string;

--- a/src/CJSImportProcessor.ts
+++ b/src/CJSImportProcessor.ts
@@ -4,12 +4,12 @@ import {TokenType as tt} from "./parser/tokenizer/types";
 import TokenProcessor from "./TokenProcessor";
 import {getNonTypeIdentifiers} from "./util/getNonTypeIdentifiers";
 
-type NamedImport = {
+interface NamedImport {
   importedName: string;
   localName: string;
-};
+}
 
-type ImportInfo = {
+interface ImportInfo {
   defaultNames: Array<string>;
   wildcardNames: Array<string>;
   namedImports: Array<NamedImport>;
@@ -17,7 +17,7 @@ type ImportInfo = {
   hasBareImport: boolean;
   exportStarNames: Array<string>;
   hasStarExport: boolean;
-};
+}
 
 /**
  * Class responsible for preprocessing and bookkeeping import and export declarations within the

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -1,10 +1,10 @@
 import {ContextualKeyword, Token} from "./parser/tokenizer";
 import {TokenType, TokenType as tt} from "./parser/tokenizer/types";
 
-export type TokenProcessorSnapshot = {
+export interface TokenProcessorSnapshot {
   resultCode: string;
   tokenIndex: number;
-};
+}
 
 export default class TokenProcessor {
   private resultCode: string = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,25 +9,25 @@ import formatTokens from "./util/formatTokens";
 
 export type Transform = "jsx" | "typescript" | "flow" | "imports";
 
-export type Options = {
+export interface Options {
   transforms: Array<Transform>;
   jsxPragma?: string;
   jsxFragmentPragma?: string;
   enableLegacyTypeScriptModuleInterop?: boolean;
   enableLegacyBabel5ModuleInterop?: boolean;
   filePath?: string;
-};
+}
 
-export type TransformResult = {
+export interface TransformResult {
   code: string;
-};
+}
 
-export type SucraseContext = {
+export interface SucraseContext {
   tokenProcessor: TokenProcessor;
   scopes: Array<Scope>;
   nameManager: NameManager;
   importProcessor: CJSImportProcessor | null;
-};
+}
 
 export function getVersion(): string {
   // eslint-disable-next-line

--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -3,13 +3,13 @@ import {TokenType as tt} from "../parser/tokenizer/types";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "../transformers/RootTransformer";
 
-export type ClassHeaderInfo = {
+export interface ClassHeaderInfo {
   isExpression: boolean;
   className: string | null;
   hasSuperclass: boolean;
-};
+}
 
-export type ClassInfo = {
+export interface ClassInfo {
   headerInfo: ClassHeaderInfo;
   // Array of non-semicolon-delimited code strings to go in the constructor, after super if
   // necessary.
@@ -21,7 +21,7 @@ export type ClassInfo = {
   // constructor, or after the super call), or null if there was no constructor.
   constructorInsertPos: number | null;
   fieldRanges: Array<{start: number; end: number}>;
-};
+}
 
 /**
  * Get information about the class fields for this class, given a token processor pointing to the

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
     "adjacent-overload-signatures": true,
     "array-type": [true, "generic"],
     "await-promise": true,
-    "ordered-imports": true,
+    "interface-over-type-literal": true,
     "no-any": true,
     "no-empty-interface": true,
     "no-floating-promises": true,
@@ -13,6 +13,7 @@
     "no-namespace": true,
     "no-internal-module": true,
     "no-unnecessary-type-assertion": true,
+    "ordered-imports": true,
     "typedef": [true, "call-signature", "parameter", "property-declaration"]
   }
 }


### PR DESCRIPTION
Interfaces have some minor advantages over object types, and TSLint can easily
enforce them and autofix usages, so switch to interfaces wherever possible.