### PR TITLE
Fix website build

### DIFF
--- a/website/config/webpack.config.dev.js
+++ b/website/config/webpack.config.dev.js
@@ -10,6 +10,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const ObjectRestSpreadPlugin = require('@sucrase/webpack-object-rest-spread-plugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 
@@ -218,6 +219,7 @@ module.exports = {
     ],
   },
   plugins: [
+    new ObjectRestSpreadPlugin(),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/website/config/webpack.config.prod.js
+++ b/website/config/webpack.config.prod.js
@@ -12,6 +12,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const ObjectRestSpreadPlugin = require('@sucrase/webpack-object-rest-spread-plugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 
@@ -235,6 +236,7 @@ module.exports = {
     ],
   },
   plugins: [
+    new ObjectRestSpreadPlugin(),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@babel/plugin-proposal-numeric-separator": "^7.0.0-beta.37",
     "@babel/standalone": "^7.0.0-beta.44",
+    "@sucrase/webpack-object-rest-spread-plugin": "^1.0.1",
     "autoprefixer": "7.1.2",
     "babel-core": "6.25.0",
     "babel-eslint": "7.2.3",
@@ -58,7 +59,7 @@
   },
   "scripts": {
     "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
+    "build": "node --max-old-space-size=8192 scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
     "publish-website": "scripts/publish.sh"
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -16,6 +16,14 @@
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.0.0-beta.44.tgz#5fed09f5263c11f9f79cba3883a6c72af47e5788"
 
+"@sucrase/webpack-object-rest-spread-plugin@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@sucrase/webpack-object-rest-spread-plugin/-/webpack-object-rest-spread-plugin-1.0.1.tgz#8136ae4a89f0f9ebcfb0ea4bfc60641fc69f9bb7"
+  dependencies:
+    acorn "^5.3.0"
+    acorn-dynamic-import "^3.0.0"
+    acorn-object-rest-spread "^1.1.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -37,6 +45,12 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
 acorn-globals@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -49,6 +63,12 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
+acorn-object-rest-spread@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-object-rest-spread/-/acorn-object-rest-spread-1.1.0.tgz#78699aefdd18ec3182caadadf52e2697c048f476"
+  dependencies:
+    acorn "^5.0.3"
+
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -60,6 +80,10 @@ acorn@^4.0.3, acorn@^4.0.4:
 acorn@^5.0.0, acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
+
+acorn@^5.0.3, acorn@^5.3.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 address@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Sucrase now uses object rest/spread in its compiled output, and ejected CRA apps
don't yet work in webpack 4, so I added the object rest/spread plugin to handle
it. Also, it was running out of memory in the production build (probably due to
monaco and babel-standalone both being huge), so I upped the memory to 8GB.