### PR TITLE
Change source map config to an object type

### DIFF
--- a/src/computeSourceMap.ts
+++ b/src/computeSourceMap.ts
@@ -1,10 +1,15 @@
 import sourceMap, {RawSourceMap} from "source-map";
+import {SourceMapOptions} from "./index";
 
 /**
  * Generate a simple source map indicating that each line maps directly to the original line.
  */
-export default function computeSourceMap(code: string, filePath: string): RawSourceMap {
-  const mapGenerator = new sourceMap.SourceMapGenerator({file: filePath});
+export default function computeSourceMap(
+  code: string,
+  filePath: string,
+  {compiledFilename}: SourceMapOptions,
+): RawSourceMap {
+  const mapGenerator = new sourceMap.SourceMapGenerator({file: compiledFilename});
   let numLines = 1;
   for (let i = 0; i < code.length; i++) {
     if (code[i] === "\n") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,14 @@ import formatTokens from "./util/formatTokens";
 
 export type Transform = "jsx" | "typescript" | "flow" | "imports";
 
+export interface SourceMapOptions {
+  /**
+   * The name to use in the "file" field of the source map. This should be the name of the compiled
+   * file.
+   */
+  compiledFilename: string;
+}
+
 export interface Options {
   transforms: Array<Transform>;
   /**
@@ -30,11 +38,11 @@ export interface Options {
    */
   enableLegacyBabel5ModuleInterop?: boolean;
   /**
-   * If true, we also return a RawSourceMap object alongside the code. Currently, source maps simply
-   * map each line to the original line without any mappings within lines, since Sucrase preserves
-   * line numbers. filePath must be specified if this option is enabled.
+   * If specified, we also return a RawSourceMap object alongside the code. Currently, source maps
+   * simply map each line to the original line without any mappings within lines, since Sucrase
+   * preserves line numbers. filePath must be specified if this option is enabled.
    */
-  computeSourceMap?: boolean;
+  sourceMapOptions?: SourceMapOptions;
   /**
    * File path to use in error messages, React display names, and source maps.
    */
@@ -68,11 +76,14 @@ export function transform(code: string, options: Options): TransformResult {
       options,
     );
     let result: TransformResult = {code: transformer.transform()};
-    if (options.computeSourceMap) {
+    if (options.sourceMapOptions) {
       if (!options.filePath) {
         throw new Error("filePath must be specified when generating a source map.");
       }
-      result = {...result, sourceMap: computeSourceMap(result.code, options.filePath)};
+      result = {
+        ...result,
+        sourceMap: computeSourceMap(result.code, options.filePath, options.sourceMapOptions),
+      };
     }
     return result;
   } catch (e) {

--- a/src/register.ts
+++ b/src/register.ts
@@ -8,7 +8,7 @@ export function addHook(extension: string, options: Options): void {
     (code: string, filePath: string): string => {
       const {code: transformedCode, sourceMap} = transform(code, {
         ...options,
-        computeSourceMap: true,
+        sourceMapOptions: {compiledFilename: filePath},
         filePath,
       });
       const mapBase64 = Buffer.from(JSON.stringify(sourceMap)).toString("base64");

--- a/test/source-maps-test.ts
+++ b/test/source-maps-test.ts
@@ -9,14 +9,18 @@ describe("source maps", () => {
       const x: number = 1;
       console.log(x + 1);
     `,
-      {transforms: ["imports", "typescript"], computeSourceMap: true, filePath: "test.ts"},
+      {
+        transforms: ["imports", "typescript"],
+        sourceMapOptions: {compiledFilename: "test.js"},
+        filePath: "test.ts",
+      },
     );
     assert.deepEqual(result.sourceMap, {
       version: 3,
       sources: ["test.ts"],
       names: [],
       mappings: "AAAA;AACA;AACA;AACA",
-      file: "test.ts",
+      file: "test.js",
     });
   });
 });


### PR DESCRIPTION
Progress toward #223.

This should make it more easily extensible in the future. We also now accept a
`compiledFilename` option for the filename to go in the source map.