### PR TITLE
Change prepublish to prepublishOnly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "script/sucrase-node script/lint.ts",
     "profile": "node --inspect-brk script/sucrase-node ./benchmark/profile",
     "profile-react": "node --inspect-brk script/sucrase-node ./benchmark/profile-react.js",
-    "prepublish": "yarn clean && yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "run-examples": "script/sucrase-node example-runner/example-runner.ts",
     "test": "yarn lint && yarn test-only",
     "test-only": "mocha './test/**/*.ts'"


### PR DESCRIPTION
Some discussion here:
https://github.com/yarnpkg/yarn/issues/3209

The long-term behavior of `publish` is to eventually only run on actual publish,
but for now, it runs on publish or install, which isn't what we want.
`prepublishOnly` is a transitionary hook that unambiguously gets the behavior I
want.