### PR TITLE
Properly mark the `?` as a type token in `?:` class properties

### DIFF
--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -41,7 +41,9 @@ import {
   lookaheadTypeAndKeyword,
   match,
   next,
-} from "../tokenizer/index";
+  popTypeContext,
+  pushTypeContext,
+} from "../tokenizer";
 import {Scope} from "../tokenizer/state";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
 import {getNextContextId, isFlowEnabled, isTypeScriptEnabled, state} from "./base";
@@ -747,7 +749,9 @@ export function parseClassPropertyName(classContextId: number): void {
 
 export function parsePostMemberNameModifiers(): void {
   if (isTypeScriptEnabled) {
+    const oldIsType = pushTypeContext(0);
     eat(tt.question);
+    popTypeContext(oldIsType);
   }
 }
 

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -958,4 +958,19 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("properly handles optional class fields with default values", () => {
+    assertTypeScriptResult(
+      `
+      class A {
+        n?: number = 3;
+      }
+    `,
+      `"use strict";
+      class A {constructor() { this.n = 3; }
+        
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #252

The class field code was getting confused because it saw a non-type after the
field name.