### PR TITLE
Simplify identity source map generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "commander": "^2.12.2",
     "lines-and-columns": "^1.1.6",
     "mz": "^2.7.0",
-    "pirates": "^3.0.2",
-    "source-map": "^0.7.3"
+    "pirates": "^3.0.2"
   },
   "engines": {
     "node": ">=8"

--- a/src/computeSourceMap.ts
+++ b/src/computeSourceMap.ts
@@ -1,5 +1,14 @@
-import sourceMap, {RawSourceMap} from "source-map";
 import {SourceMapOptions} from "./index";
+
+export interface RawSourceMap {
+  version: number;
+  file: string;
+  sources: Array<string>;
+  sourceRoot?: string;
+  sourcesContent?: Array<string>;
+  mappings: string;
+  names: Array<string>;
+}
 
 /**
  * Generate a simple source map indicating that each line maps directly to the original line.
@@ -9,19 +18,17 @@ export default function computeSourceMap(
   filePath: string,
   {compiledFilename}: SourceMapOptions,
 ): RawSourceMap {
-  const mapGenerator = new sourceMap.SourceMapGenerator({file: compiledFilename});
-  let numLines = 1;
+  let mappings = "AAAA";
   for (let i = 0; i < code.length; i++) {
     if (code[i] === "\n") {
-      numLines++;
+      mappings += ";AACA";
     }
   }
-  for (let line = 1; line <= numLines; line++) {
-    mapGenerator.addMapping({
-      source: filePath,
-      generated: {line, column: 0},
-      original: {line, column: 0},
-    });
-  }
-  return mapGenerator.toJSON();
+  return {
+    version: 3,
+    file: compiledFilename || "",
+    sources: [filePath],
+    mappings,
+    names: [],
+  };
 }

--- a/src/computeSourceMap.ts
+++ b/src/computeSourceMap.ts
@@ -1,4 +1,5 @@
 import {SourceMapOptions} from "./index";
+import {charCodes} from "./parser/util/charcodes";
 
 export interface RawSourceMap {
   version: number;
@@ -20,7 +21,7 @@ export default function computeSourceMap(
 ): RawSourceMap {
   let mappings = "AAAA";
   for (let i = 0; i < code.length; i++) {
-    if (code[i] === "\n") {
+    if (code.charCodeAt(i) === charCodes.lineFeed) {
       mappings += ";AACA";
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import {RawSourceMap} from "source-map";
 import CJSImportProcessor from "./CJSImportProcessor";
-import computeSourceMap from "./computeSourceMap";
+import computeSourceMap, {RawSourceMap} from "./computeSourceMap";
 import identifyShadowedGlobals from "./identifyShadowedGlobals";
 import NameManager from "./NameManager";
 import {parse} from "./parser";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,10 +2665,6 @@ source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-
 spawn-wrap@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"


### PR DESCRIPTION
This should be a lot faster than using the `source-map` library, since all we're doing is generating an identity line map.