### PR TITLE
Add production option and use it for JSX

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,7 @@ export interface Options {
    */
   filePath?: string;
   /**
-   * If specified, we generate a few less things (for example the jsx
-   * transformer does not add debug props).
+   * If specified, omit any development-specific code in the output.
    */
   production?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,11 @@ export interface Options {
    * File path to use in error messages, React display names, and source maps.
    */
   filePath?: string;
+  /**
+   * If specified, we generate a few less things (for example the jsx
+   * transformer does not add debug props).
+   */
+  production?: boolean;
 }
 
 export interface TransformResult {

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -83,14 +83,28 @@ export default class JSXTransformer extends Transformer {
 
   processProps(firstTokenStart: number): void {
     const lineNumber = this.getLineNumberForIndex(firstTokenStart);
-    const devProps = `__self: this, __source: {fileName: ${this.getFilenameVarName()}, lineNumber: ${lineNumber}}`;
+    const devProps = this.options.production
+      ? ""
+      : `__self: this, __source: {fileName: ${this.getFilenameVarName()}, lineNumber: ${lineNumber}}`;
     if (!this.tokens.matches1(tt.jsxName) && !this.tokens.matches1(tt.braceL)) {
-      this.tokens.appendCode(`, {${devProps}}`);
+      if (devProps) {
+        this.tokens.appendCode(`, {${devProps}}`);
+      } else {
+        this.tokens.appendCode(`, null`);
+      }
       return;
     }
     this.tokens.appendCode(`, {`);
+    let firstProperty = true;
+    const appendComma = () => {
+      if (!firstProperty) {
+        this.tokens.appendCode(",");
+      }
+      firstProperty = false;
+    };
     while (true) {
       if (this.tokens.matches2(tt.jsxName, tt.eq)) {
+        appendComma();
         const keyName = this.tokens.identifierName();
         if (keyName.includes("-")) {
           this.tokens.replaceToken(`'${keyName}'`);
@@ -108,18 +122,24 @@ export default class JSXTransformer extends Transformer {
           this.processStringPropValue();
         }
       } else if (this.tokens.matches1(tt.jsxName)) {
+        appendComma();
         this.tokens.copyToken();
         this.tokens.appendCode(": true");
       } else if (this.tokens.matches1(tt.braceL)) {
+        appendComma();
         this.tokens.replaceToken("");
         this.rootTransformer.processBalancedCode();
         this.tokens.replaceToken("");
       } else {
         break;
       }
-      this.tokens.appendCode(",");
     }
-    this.tokens.appendCode(` ${devProps}}`);
+    if (devProps) {
+      appendComma();
+      this.tokens.appendCode(` ${devProps}}`);
+    } else {
+      this.tokens.appendCode("}");
+    }
   }
 
   processStringPropValue(): void {

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -95,16 +95,8 @@ export default class JSXTransformer extends Transformer {
       return;
     }
     this.tokens.appendCode(`, {`);
-    let firstProperty = true;
-    const appendComma = () => {
-      if (!firstProperty) {
-        this.tokens.appendCode(",");
-      }
-      firstProperty = false;
-    };
     while (true) {
       if (this.tokens.matches2(tt.jsxName, tt.eq)) {
-        appendComma();
         const keyName = this.tokens.identifierName();
         if (keyName.includes("-")) {
           this.tokens.replaceToken(`'${keyName}'`);
@@ -122,20 +114,18 @@ export default class JSXTransformer extends Transformer {
           this.processStringPropValue();
         }
       } else if (this.tokens.matches1(tt.jsxName)) {
-        appendComma();
         this.tokens.copyToken();
         this.tokens.appendCode(": true");
       } else if (this.tokens.matches1(tt.braceL)) {
-        appendComma();
         this.tokens.replaceToken("");
         this.rootTransformer.processBalancedCode();
         this.tokens.replaceToken("");
       } else {
         break;
       }
+      this.tokens.appendCode(",");
     }
     if (devProps) {
-      appendComma();
       this.tokens.appendCode(` ${devProps}}`);
     } else {
       this.tokens.appendCode("}");

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -11,10 +11,16 @@ function assertResult(
     extraTransforms,
     jsxPragma,
     jsxFragmentPragma,
-  }: {extraTransforms?: Array<Transform>; jsxPragma?: string; jsxFragmentPragma?: string} = {},
+    production,
+  }: {
+    extraTransforms?: Array<Transform>;
+    jsxPragma?: string;
+    jsxFragmentPragma?: string;
+    production?: boolean;
+  } = {},
 ): void {
   const transforms: Array<Transform> = ["jsx", ...(extraTransforms || [])];
-  util.assertResult(code, expectedResult, {transforms, jsxPragma, jsxFragmentPragma});
+  util.assertResult(code, expectedResult, {transforms, jsxPragma, jsxFragmentPragma, production});
 }
 
 describe("transform JSX", () => {
@@ -412,5 +418,67 @@ describe("transform JSX", () => {
     `,
       {extraTransforms: ["imports"], jsxPragma: "h", jsxFragmentPragma: "Fragment"},
     );
+  });
+
+  describe("with production true", () => {
+    it("handles no props", () => {
+      assertResult(
+        `
+      <A />
+    `,
+        `
+      React.createElement(A, null )
+    `,
+        {production: true},
+      );
+    });
+
+    it("handles props", () => {
+      assertResult(
+        `
+      <A a="b" />
+    `,
+        `
+      React.createElement(A, { a: "b"} )
+    `,
+        {production: true},
+      );
+    });
+
+    it("handles bool props", () => {
+      assertResult(
+        `
+      <A a />
+    `,
+        `
+      React.createElement(A, { a: true} )
+    `,
+        {production: true},
+      );
+    });
+
+    it("handles spread props", () => {
+      assertResult(
+        `
+        <A {...obj} />
+    `,
+        `
+        React.createElement(A, { ...obj} )
+    `,
+        {production: true},
+      );
+    });
+
+    it("handles fragment", () => {
+      assertResult(
+        `
+      <>Hi</>
+    `,
+        `
+      React.createElement(React.Fragment, null, "Hi")
+    `,
+        {production: true},
+      );
+    });
   });
 });

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -439,7 +439,7 @@ describe("transform JSX", () => {
       <A a="b" />
     `,
         `
-      React.createElement(A, { a: "b"} )
+      React.createElement(A, { a: "b",} )
     `,
         {production: true},
       );
@@ -451,7 +451,7 @@ describe("transform JSX", () => {
       <A a />
     `,
         `
-      React.createElement(A, { a: true} )
+      React.createElement(A, { a: true,} )
     `,
         {production: true},
       );
@@ -463,7 +463,7 @@ describe("transform JSX", () => {
         <A {...obj} />
     `,
         `
-        React.createElement(A, { ...obj} )
+        React.createElement(A, { ...obj,} )
     `,
         {production: true},
       );


### PR DESCRIPTION
When production is true (default is false) we do not include debug
info (such as `__self` and `__source`) in the output of the jsx
transformer.