### PR TITLE
Allow trailing commas after rest elements

### DIFF
--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -715,8 +715,6 @@ export function parseObj(isPattern: boolean, isBlockScope: boolean): void {
           unexpected(firstRestLocation, "Cannot have multiple rest elements when destructuring");
         } else if (eat(tt.braceR)) {
           break;
-        } else if (match(tt.comma) && lookaheadType() === tt.braceR) {
-          unexpected(position, "A trailing comma is not permitted after the rest element");
         } else {
           firstRestLocation = position;
           continue;

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -98,6 +98,8 @@ export function parseBindingList(
     } else if (match(tt.ellipsis)) {
       parseRest(isBlockScope);
       parseAssignableListItemTypes();
+      // Support rest element trailing commas allowed by TypeScript <2.9.
+      eat(TokenType.comma);
       expect(close);
       break;
     } else {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -973,4 +973,21 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  // TODO: TypeScript 2.9 makes this required, so we can drop support for this syntax when we don't
+  // need to support older versions of TypeScript.
+  it("allows trailing commas after rest elements", () => {
+    assertTypeScriptResult(
+      `
+      function foo(a, ...b,) {}
+      const {a, ...b,} = c;
+      const [a, ...b,] = c;
+    `,
+      `"use strict";
+      function foo(a, ...b,) {}
+      const {a, ...b,} = c;
+      const [a, ...b,] = c;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #249

Nothing stops us from allowing it at parse time, and it's allowed in TS <2.9, so
we support it for now.