### PR TITLE
Don't crash on class bodies with an index signature

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -305,6 +305,8 @@ function tsTryParseIndexSignature(): boolean {
     return false;
   }
 
+  const oldIsType = pushTypeContext(0);
+
   expect(tt.bracketL);
   parseIdentifier();
   tsParseTypeAnnotation();
@@ -312,6 +314,8 @@ function tsTryParseIndexSignature(): boolean {
 
   tsTryParseTypeAnnotation();
   tsParseTypeMemberSemicolon();
+
+  popTypeContext(oldIsType);
   return true;
 }
 

--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -52,6 +52,8 @@ export default function getClassInfo(
       ({constructorInitializers, constructorInsertPos} = processConstructor(tokens));
     } else if (tokens.matches1(tt.semi)) {
       tokens.nextToken();
+    } else if (tokens.currentToken().isType) {
+      tokens.nextToken();
     } else {
       // Either a method or a field. Skip to the identifier part.
       const statementStartIndex = tokens.currentIndex();

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -990,4 +990,25 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows index signatures in classes", () => {
+    assertTypeScriptResult(
+      `
+      export class Foo {
+          f() {
+          }
+          [name: string]: any;
+          x = 1;
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+       class Foo {constructor() { this.x = 1; }
+          f() {
+          }
+          
+          ;
+      } exports.Foo = Foo;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #250

We should skip all type-only lines when processing a class body, and also mark
index signatures as entirely types.