### PR TITLE
Fix off-by-one error in parsing JSX fragments

### DIFF
--- a/src/parser/plugins/jsx/index.ts
+++ b/src/parser/plugins/jsx/index.ts
@@ -171,7 +171,6 @@ function jsxParseAttribute(): void {
 // Does not parse the last token.
 function jsxParseOpeningElement(): boolean {
   if (match(tt.jsxTagEnd)) {
-    nextJSXExprToken();
     // This is an open-fragment.
     return false;
   }

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -420,6 +420,30 @@ describe("transform JSX", () => {
     );
   });
 
+  it("allows empty fragments", () => {
+    assertResult(
+      `
+      const c = <></>;
+    `,
+      `
+      const c = React.createElement(React.Fragment, null);
+    `,
+    );
+  });
+
+  it("allows fragments without whitespace", () => {
+    assertResult(
+      `
+      const c = <><a/></>;
+    `,
+      `${JSX_PREFIX}
+      const c = React.createElement(React.Fragment, null, React.createElement('a', {${devProps(
+        2,
+      )}}));
+    `,
+    );
+  });
+
   describe("with production true", () => {
     it("handles no props", () => {
       assertResult(


### PR DESCRIPTION
Fixes #254

`jsxParseOpeningElement` isn't supposed to parse the last token, but was doing
so, and it happened to work in the existing test cases.