### PR TITLE
Allow TS type parameters on object member methods

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -1258,9 +1258,7 @@ export function tsAfterParseClassSuper(hasSuper: boolean): void {
 }
 
 export function tsStartParseObjPropValue(): void {
-  if (match(tt.lessThan)) {
-    throw new Error("TODO");
-  }
+  tsTryParseTypeParameters();
 }
 
 export function tsStartParseFunctionParams(): void {

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -141,7 +141,7 @@ describe("type transforms", () => {
     );
   });
 
-  it.skip("removes function type parameters", () => {
+  it("removes function type parameters", () => {
     assertTypeScriptAndFlowResult(
       `
       function f<T>(t: T): void {


### PR DESCRIPTION
Fixes #251

The Babel code had a TODO, but at least in our case, it seems as easy as
optionally calling the existing type parameter parsing code.