### PR TITLE
Remove @flow directives from comments when the flow transform is enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
   const tokens = file.tokens;
   const scopes = file.scopes;
 
-  const tokenProcessor = new TokenProcessor(code, tokens);
+  const tokenProcessor = new TokenProcessor(code, tokens, isFlowEnabled);
   const nameManager = new NameManager(tokenProcessor);
   nameManager.preprocessNames();
   const enableLegacyTypeScriptModuleInterop = Boolean(options.enableLegacyTypeScriptModuleInterop);

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -216,4 +216,25 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("removes @flow directives", () => {
+    assertFlowResult(
+      `
+      /* Hello @flow */
+      // World @flow
+      function foo(): number {
+        return 3;
+      }
+      // @flow
+    `,
+      `"use strict";
+      /* Hello  */
+      // World 
+      function foo() {
+        return 3;
+      }
+      // 
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #246

Comments aren't tokens, and making them tokens would cause all sorts of other
issues, so trying to use the normal plugin-style approach here wouldn't really
work. Instead, I added a custom line of code to TokenProcessor and only run it
when the flow transform is enabled.