### PR TITLE
Update build script so released Sucrase versions compile themselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
-build
-self-build
 dist
+dist-self-build
 example-runner/example-repos
 integrations/gulp-plugin/dist
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "script/sucrase-node script/build.ts",
     "fast-build": "script/sucrase-node script/build.ts --fast",
-    "clean": "rm -rf ./build ./dist ./example-runner/example-repos",
+    "clean": "rm -rf ./build ./dist ./dist-self-build ./example-runner/example-repos",
     "generate": "script/sucrase-node generator/generate.ts",
     "benchmark": "script/sucrase-node benchmark/benchmark.ts",
     "benchmark-react": "script/sucrase-node benchmark/benchmark-react.ts",


### PR DESCRIPTION
This should make issues like #280 easier to detect in the future, and should
make it possible to fix with just one release.