### PR TITLE
Fix ugly emitted comments when removing code between tokens

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -138,7 +138,7 @@ export default class TokenProcessor {
     return this.matches1(type) && this.currentToken().contextId === contextId;
   }
 
-  previousWhitespace(): string {
+  previousWhitespaceAndComments(): string {
     let whitespaceAndComments = this.code.slice(
       this.tokenIndex > 0 ? this.tokens[this.tokenIndex - 1].end : 0,
       this.tokenIndex < this.tokens.length ? this.tokens[this.tokenIndex].start : this.code.length,
@@ -150,13 +150,13 @@ export default class TokenProcessor {
   }
 
   replaceToken(newCode: string): void {
-    this.resultCode += this.previousWhitespace();
+    this.resultCode += this.previousWhitespaceAndComments();
     this.resultCode += newCode;
     this.tokenIndex++;
   }
 
   replaceTokenTrimmingLeftWhitespace(newCode: string): void {
-    this.resultCode += this.previousWhitespace().replace(/[\t ]/g, "");
+    this.resultCode += this.previousWhitespaceAndComments().replace(/[^\r\n]/g, "");
     this.resultCode += newCode;
     this.tokenIndex++;
   }
@@ -177,7 +177,7 @@ export default class TokenProcessor {
   }
 
   copyToken(): void {
-    this.resultCode += this.previousWhitespace();
+    this.resultCode += this.previousWhitespaceAndComments();
     this.resultCode += this.code.slice(
       this.tokens[this.tokenIndex].start,
       this.tokens[this.tokenIndex].end,
@@ -225,7 +225,7 @@ export default class TokenProcessor {
     if (this.tokenIndex !== this.tokens.length) {
       throw new Error("Tried to finish processing tokens before reaching the end.");
     }
-    this.resultCode += this.previousWhitespace();
+    this.resultCode += this.previousWhitespaceAndComments();
     return this.resultCode;
   }
 

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -567,4 +567,20 @@ describe("sucrase", () => {
       {transforms: ["imports", "typescript"]},
     );
   });
+
+  it("removes comments within removed ranges rather than removing all whitespace", () => {
+    assertResult(
+      `
+      interface A {
+        // This is a comment.
+      }
+    `,
+      `"use strict";
+      
+
+
+    `,
+      {transforms: ["imports", "typescript"]},
+    );
+  });
 });


### PR DESCRIPTION
Fixes #281

Previously, it seemed best to remove all whitespace, but that makes comments
look really weird, since all spaces are removed in the comment. Instead, for
now, we remove whitespace and comments in their entirety (except newlines).