### PR TITLE
Implement destructuring in export declarations

### DIFF
--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -1,4 +1,8 @@
-import {IdentifierRole} from "./parser/tokenizer";
+import {
+  isBlockScopedDeclaration,
+  isDeclaration,
+  isFunctionScopedDeclaration,
+} from "./parser/tokenizer";
 import {Scope} from "./parser/tokenizer/state";
 import {TokenType as tt} from "./parser/tokenizer/types";
 import TokenProcessor from "./TokenProcessor";
@@ -26,8 +30,7 @@ function hasShadowedGlobals(tokens: TokenProcessor, globalNames: Set<string>): b
   for (const token of tokens.tokens) {
     if (
       token.type === tt.name &&
-      (token.identifierRole === IdentifierRole.FunctionScopedDeclaration ||
-        token.identifierRole === IdentifierRole.BlockScopedDeclaration) &&
+      isDeclaration(token) &&
       globalNames.has(tokens.identifierNameForToken(token))
     ) {
       return true;
@@ -61,9 +64,9 @@ function markShadowedGlobals(
     const token = tokens.tokens[i];
     const name = tokens.identifierNameForToken(token);
     if (scopeStack.length > 1 && token.type === tt.name && globalNames.has(name)) {
-      if (token.identifierRole === IdentifierRole.BlockScopedDeclaration) {
+      if (isBlockScopedDeclaration(token)) {
         markShadowedForScope(scopeStack[scopeStack.length - 1], tokens, name);
-      } else if (token.identifierRole === IdentifierRole.FunctionScopedDeclaration) {
+      } else if (isFunctionScopedDeclaration(token)) {
         let stackIndex = scopeStack.length - 1;
         while (stackIndex > 0 && !scopeStack[stackIndex].isFunctionScope) {
           stackIndex--;

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -13,8 +13,36 @@ export enum IdentifierRole {
   ExportAccess,
   FunctionScopedDeclaration,
   BlockScopedDeclaration,
+  ObjectShorthandFunctionScopedDeclaration,
+  ObjectShorthandBlockScopedDeclaration,
   ObjectShorthand,
   ObjectKey,
+}
+
+export function isDeclaration(token: Token): boolean {
+  const role = token.identifierRole;
+  return (
+    role === IdentifierRole.FunctionScopedDeclaration ||
+    role === IdentifierRole.BlockScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandFunctionScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandBlockScopedDeclaration
+  );
+}
+
+export function isBlockScopedDeclaration(token: Token): boolean {
+  const role = token.identifierRole;
+  return (
+    role === IdentifierRole.BlockScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandBlockScopedDeclaration
+  );
+}
+
+export function isFunctionScopedDeclaration(token: Token): boolean {
+  const role = token.identifierRole;
+  return (
+    role === IdentifierRole.FunctionScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandFunctionScopedDeclaration
+  );
 }
 
 export const enum ContextualKeyword {

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -135,5 +135,7 @@ export function parseMaybeDefault(isBlockScope: boolean, leftAlreadyParsed: bool
   if (!eat(tt.eq)) {
     return;
   }
+  const eqIndex = state.tokens.length - 1;
   parseMaybeAssign();
+  state.tokens[eqIndex].rhsEndIndex = state.tokens.length;
 }

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -509,7 +509,9 @@ function parseVar(isFor: boolean, kind: TokenType): void {
     const isBlockScope = kind === tt._const || kind === tt._let;
     parseVarHead(isBlockScope);
     if (eat(tt.eq)) {
+      const eqIndex = state.tokens.length - 1;
       parseMaybeAssign(isFor);
+      state.tokens[eqIndex].rhsEndIndex = state.tokens.length;
     }
     if (!eat(tt.comma)) break;
   }

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -1005,4 +1005,28 @@ module.exports = exports.default;
     `,
     );
   });
+
+  it("allows exported destructure operations", () => {
+    assertResult(
+      `
+      export let {a = 2, b: [c, d], ...e} = f;
+      export var [g = 3, ...h] = i;
+      export const {j} = k;
+      export let {l = () => {const m = 3;}} = {};
+      export let x;
+      x = 2;
+      export let {y}: Foo = z;
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      ( {a: exports.a = 2, b: [exports.c, exports.d], ...exports.e} = f);
+       [exports.g = 3, ...exports.h] = i;
+      ( {j: exports.j} = k);
+      ( {l: exports.l = () => {const m = 3;}} = {});
+       exports.x;
+      exports.x = 2;
+      ( {y: exports.y} = z);
+    `,
+      {transforms: ["imports", "typescript"]},
+    );
+  });
 });


### PR DESCRIPTION
Fixes #297

The export transformation process now finds any declaration on the LHS,
excluding declarations within default values, and modifies them to use `exports`
syntax. In addition, for object destructures, we need to surround the entire
assignment with parens so that it's treated as a proper assignment. This
required some additional parser information: annotating the end index of an `=`
token in more cases, as well as identifying object shorthand declarations.