### PR TITLE
Properly handle function name inference in named exports

### DIFF
--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -78,9 +78,9 @@ describe("transform imports", () => {
       export const z = 3;
     `,
       `"use strict";${ESMODULE_PREFIX}
-       exports.x = 1;
-       exports.y = 2;
-       exports.z = 3;
+       var x = 1; exports.x = x;
+       let y = 2; exports.y = y;
+       const z = 3; exports.z = z;
     `,
     );
   });
@@ -623,7 +623,7 @@ module.exports = exports.default;
       export default 4;
     `,
       `"use strict";${ESMODULE_PREFIX}
-       exports.x = 1;
+       const x = 1; exports.x = x;
       exports. default = 4;
     `,
       {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
@@ -981,7 +981,7 @@ module.exports = exports.default;
       console.log(a);
     `,
       `"use strict";${ESMODULE_PREFIX}
-       exports.a = 1;
+       let a = 1; exports.a = a;
       ({a: exports.a} = 2);
       exports.a = 3;
       console.log(exports.a);
@@ -1025,6 +1025,20 @@ module.exports = exports.default;
        exports.x;
       exports.x = 2;
       ( {y: exports.y} = z);
+    `,
+      {transforms: ["imports", "typescript"]},
+    );
+  });
+
+  it("allows function name inference for direct named exports", () => {
+    assertResult(
+      `
+      export let f = () => {};
+      export const g = () => {};
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+       let f = () => {}; exports.f = f;
+       const g = () => {}; exports.g = g;
     `,
       {transforms: ["imports", "typescript"]},
     );

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -49,7 +49,7 @@ describe("sucrase", () => {
       };
     `,
       `"use strict";${ESMODULE_PREFIX}
-       exports.keywords = {
+       const keywords = {
         break: new KeywordTokenType("break"),
         case: new KeywordTokenType("case", { beforeExpr }),
         catch: new KeywordTokenType("catch"),
@@ -87,7 +87,7 @@ describe("sucrase", () => {
         typeof: new KeywordTokenType("typeof", { beforeExpr, prefix, startsExpr }),
         void: new KeywordTokenType("void", { beforeExpr, prefix, startsExpr }),
         delete: new KeywordTokenType("delete", { beforeExpr, prefix, startsExpr }),
-      };
+      }; exports.keywords = keywords;
     `,
     );
   });

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -208,7 +208,7 @@ describe("type transforms", () => {
     `,
       `"use strict";${ESMODULE_PREFIX}
       
-       exports.x = 1;
+       const x = 1; exports.x = x;
     `,
     );
   });


### PR DESCRIPTION
Fixes #307

Instead of writing `exports.f = () => {};`, we write
`const f = () => {}; exports.f = f;` and still use `exports.f` for all writes
and reads. This is a little odd in that the variable is never used, but it makes
sure the export works fine. In the future, we possibly could refine it to only
do a special case when the RHS is an unnamed function, but that's a bit harder
to detect.