### PR TITLE
Change class field implementation to use initializer methods

### DIFF
--- a/src/NameManager.ts
+++ b/src/NameManager.ts
@@ -3,6 +3,7 @@ import TokenProcessor from "./TokenProcessor";
 
 export default class NameManager {
   private readonly usedNames: Set<string> = new Set();
+  private symbolNames: Array<string> = [];
 
   constructor(readonly tokens: TokenProcessor) {}
 
@@ -29,5 +30,18 @@ export default class NameManager {
       suffixNum++;
     }
     return name + suffixNum;
+  }
+
+  /**
+   * Get an identifier such that the identifier will be a valid reference to a symbol after codegen.
+   */
+  claimSymbol(name: string): string {
+    const newName = this.claimFreeName(name);
+    this.symbolNames.push(newName);
+    return newName;
+  }
+
+  getInjectedSymbolCode(): string {
+    return this.symbolNames.map((name) => `const ${name} = Symbol();`).join("");
   }
 }

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -32,10 +32,6 @@ export default class TokenProcessor {
     return this.resultCode.length;
   }
 
-  getCodeInsertedSinceIndex(initialResultCodeIndex: number): string {
-    return this.resultCode.slice(initialResultCodeIndex);
-  }
-
   reset(): void {
     this.resultCode = "";
     this.tokenIndex = 0;
@@ -178,6 +174,16 @@ export default class TokenProcessor {
 
   copyToken(): void {
     this.resultCode += this.previousWhitespaceAndComments();
+    this.resultCode += this.code.slice(
+      this.tokens[this.tokenIndex].start,
+      this.tokens[this.tokenIndex].end,
+    );
+    this.tokenIndex++;
+  }
+
+  copyTokenWithPrefix(prefix: string): void {
+    this.resultCode += this.previousWhitespaceAndComments();
+    this.resultCode += prefix;
     this.resultCode += this.code.slice(
       this.tokens[this.tokenIndex].start,
       this.tokens[this.tokenIndex].end,

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -117,10 +117,10 @@ describe("type transforms", () => {
         y: {} = {};
       }
     `,
-      `"use strict";
-      class A {constructor() { this.x = 2;this.y = {}; }
-        
-        
+      `"use strict";const __init = Symbol();const __init2 = Symbol();
+      class A {constructor() { this[__init]();this[__init2](); }
+        [__init]() {this.x = 2}
+        [__init2]() {this.y = {}}
       }
     `,
     );

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -72,10 +72,10 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";const __init = Symbol();
       class A {
-        
-        constructor() {;this.x = 1;
+        [__init]() {this.x = 1}
+        constructor() {;this[__init]();
           this.y = 2;
         }
       }
@@ -93,11 +93,11 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";const __init = Symbol();
       class A extends B {
-        
+        [__init]() {this.x = 1}
         constructor(a) {
-          super(a);this.x = 1;;
+          super(a);this[__init]();;
         }
       }
     `,
@@ -111,9 +111,9 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `"use strict";
-      class A {constructor() { this.x = 1; }
-        
+      `"use strict";const __init = Symbol();
+      class A {constructor() { this[__init](); }
+        [__init]() {this.x = 1}
       }
     `,
     );
@@ -126,9 +126,9 @@ describe("typescript transform", () => {
         x = 1;
       }
     `,
-      `"use strict";
-      class A extends B {constructor(...args) { super(...args); this.x = 1; }
-        
+      `"use strict";const __init = Symbol();
+      class A extends B {constructor(...args) { super(...args); this[__init](); }
+        [__init]() {this.x = 1}
       }
     `,
     );
@@ -141,9 +141,9 @@ describe("typescript transform", () => {
         args = 1;
       }
     `,
-      `"use strict";
-      class A extends B {constructor(...args2) { super(...args2); this.args = 1; }
-        
+      `"use strict";const __init = Symbol();
+      class A extends B {constructor(...args2) { super(...args2); this[__init](); }
+        [__init]() {this.args = 1}
       }
     `,
     );
@@ -305,10 +305,10 @@ describe("typescript transform", () => {
         f: any = function() {};
       }
     `,
-      `"use strict";
-      class A {constructor() { this.f = function() {}; }
+      `"use strict";const __init = Symbol();
+      class A {constructor() { this[__init](); }
         
-        
+        [__init]() {this.f = function() {}}
       }
     `,
     );
@@ -360,11 +360,11 @@ describe("typescript transform", () => {
         "Hello, world" = 2;
       }
     `,
-      `"use strict";
-      class A {constructor() { this[a + b] = 3;this[0] = 1;this["Hello, world"] = 2; }
-        
-        
-        
+      `"use strict";const __init = Symbol();const __init2 = Symbol();const __init3 = Symbol();
+      class A {constructor() { this[__init]();this[__init2]();this[__init3](); }
+        [__init]() {this[a + b] = 3}
+        [__init2]() {this[0] = 1}
+        [__init3]() {this["Hello, world"] = 2}
       }
     `,
     );
@@ -696,10 +696,10 @@ describe("typescript transform", () => {
         }
       }
     `,
-      `"use strict";
+      `"use strict";const __init = Symbol();
       class A {
-        
-         constructor() {;this.x = 1;
+        [__init]() {this.x = 1}
+         constructor() {;this[__init]();
         }
       }
     `,
@@ -966,9 +966,9 @@ describe("typescript transform", () => {
         n?: number = 3;
       }
     `,
-      `"use strict";
-      class A {constructor() { this.n = 3; }
-        
+      `"use strict";const __init = Symbol();
+      class A {constructor() { this[__init](); }
+        [__init]() {this.n = 3}
       }
     `,
     );
@@ -1001,12 +1001,12 @@ describe("typescript transform", () => {
           x = 1;
       }
     `,
-      `"use strict";${ESMODULE_PREFIX}
-       class Foo {constructor() { this.x = 1; }
+      `"use strict";${ESMODULE_PREFIX}const __init = Symbol();
+       class Foo {constructor() { this[__init](); }
           f() {
           }
           
-          
+          [__init]() {this.x = 1}
       } exports.Foo = Foo;
     `,
     );


### PR DESCRIPTION
Fixes #311

Rather than moving the assignments to the constructor or after the class body,
we now wrap them in methods that assign to either the instance or class (both
via `this` assignments). The generated code in the constructor or after the
class just calls those methods.

This should make line numbers always line up and should make it possible to set
debugger breakpoints in bound callback methods. It's slightly less correct, but
hopefully that won't come up in practice.