### PR TITLE
Port all babel-parser changes from 2018-04-20 to 2018-05-30

### DIFF
--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -22,9 +22,11 @@ import {
   flowParseArrow,
   flowParseFunctionBodyAndFinish,
   flowParseMaybeAssign,
+  flowParseSubscript,
   flowParseSubscripts,
   flowParseVariance,
   flowStartParseAsyncArrowFromCallExpression,
+  flowStartParseNewArguments,
   flowStartParseObjPropValue,
 } from "../plugins/flow";
 import {jsxParseElement} from "../plugins/jsx/index";
@@ -215,11 +217,6 @@ function parseExprOp(minPrec: number, noIn: boolean | null): void {
       const op = state.type;
       next();
 
-      if (op === tt.pipeline) {
-        // Support syntax such as 10 |> x => x + 1
-        state.potentialArrowAt = state.start;
-      }
-
       parseMaybeUnary();
       parseExprOp(op & TokenType.IS_RIGHT_ASSOCIATIVE ? prec - 1 : prec, noIn);
       parseExprOp(minPrec, noIn);
@@ -281,6 +278,8 @@ export function baseParseSubscripts(startPos: number, noCalls: boolean | null = 
 function parseSubscript(startPos: number, noCalls: boolean | null, stopState: StopState): void {
   if (isTypeScriptEnabled) {
     tsParseSubscript(startPos, noCalls, stopState);
+  } else if (isFlowEnabled) {
+    flowParseSubscript(startPos, noCalls, stopState);
   } else {
     baseParseSubscript(startPos, noCalls, stopState);
   }
@@ -662,6 +661,8 @@ function parseNew(): void {
 function parseNewArguments(): void {
   if (isTypeScriptEnabled) {
     tsStartParseNewArguments();
+  } else if (isFlowEnabled) {
+    flowStartParseNewArguments();
   }
   if (eat(tt.parenL)) {
     parseExprList(tt.parenR);

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -237,4 +237,50 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("handles internal slot syntax", () => {
+    assertFlowResult(
+      `
+      type T = { [[foo]]: X }
+    `,
+      `"use strict";
+      
+    `,
+    );
+  });
+
+  it("handles optional internal slot syntax", () => {
+    assertFlowResult(
+      `
+      type T = { [[foo]]?: X }
+    `,
+      `"use strict";
+      
+    `,
+    );
+  });
+
+  it("handles flow type arguments", () => {
+    assertFlowResult(
+      `
+      f<T>();
+      new C<T>();
+    `,
+      `"use strict";
+      f();
+      new C();
+    `,
+    );
+  });
+
+  it("handles flow inline interfaces", () => {
+    assertFlowResult(
+      `
+      type T = interface { p: string }
+    `,
+      `"use strict";
+      
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This is all of the remaining changes from when it was in the packages/babylon
directory. A future commit will port changes made since then in the
packages/babel-parser directory.

Changes in chronological order:

2afe9404f Use Object Spread Syntax (#7777)
🚫 Not relevant to current Sucrase code.

7142a79eb Bring `pipelineOperator` flag in line with minimal
✅ Removed potentialArrowAt assignment. Error strictness not relevant to Sucrase.

71fd37067 Avoid lookahead when parsing pipeline
🚫 Change in error handling code.

696f84468 Add test for params w/ parens around them
🚫 Test only.

4f312f573 Add syntax error test for arrow w/ paren'd args
🚫 Test only.

55ef39eb8 Correct typo [skip ci] (#7834)
🚫 Docs only.

65ca968f8 Allow static? as identifier in ObjectTypeProperty
✅ Made the question check, though I couldn't find a way for it to fail in
Sucrase.

0353ce9ed Disallow flow type parameter defaults in some cases
✅ Small perf refactor of conditional, everything else was error checking.

d60853571 Allow parsing of decorators with TypeScript abstract classes (#7850)
🚫 Just removes error which Sucrase had already removed.

84e76e2d4 TypeScript: Allow non-null and type assertions as lvalues. (Fixes #7638) (#7888)
🚫 None of the code is relevant in Sucrase. One case is error checking, one is
AST transformation.

70e3454d7 Fix a typo in a babylon flow plugin comment [skip ci] (#7898)
🚫 Comment removed fom Surase.

21b03c35d Fix lint and yarn.lock
🚫 Not relevant.

25c3f0d68 Rename decorators&decorators2 plugins to decorators-legacy&decorators. (#7821)
🚫 Plugin names were removed in Sucrase.

02c4a2860 Fix typescript decorator test (#7904)
🚫 Plugin names were removed in Sucrase.

f03adbadf (tag: v7.0.0-beta.47) v7.0.0-beta.47
🚫 Release only.

e45d5c3b6 Add an option to Babylon to have decorators before export (#7869)
🚫 Plugins aren't relevant to Sucrase. `@` was already allowed before exports,
the commit just made it more strict/precise, no need to port the new errors.

b396cdcbe Internal slot properties (#7947)
✅ Add a port of the internal slot parsing function, with test.

af7ab7148 Allow flow internal slot properties to be optional (#7959)
✅ Ported the fix and added a test.

a40f54f84 Add support for explicit type arguments in new and call expressions (#7934)
✅ Added tests and functions for the new syntax.

6baa36cdc Support Flow's inline interface syntax (#7973)
✅ Ported the new parsing method over, with a test.

70eb206c0 TypeScript: Fix TSInferType .typeParameter type. (#7967)
🚫 Change only affects AST.

daf0ca868 Rename "babylon" to "@babel/parser" (#7937) 🎉
🚫 Change not relevant for Sucrase.

c0013264b Add tests for interpreter directive with retainLines and sourcemaps.
🚫 Test only.

2058e0686 Add support for an InterpreterDirective AST node.
🚫 Test only.

c992f5b61 Remove duplicated test (in the old babylon folder)
🚫 Test only.

f0283572a Support Flow's proto modifier syntax for declared classes (#7978)
🚫 Test only.

d83d141e0 Move tests from babylon/ to babel-parserr/
🚫 Not relevant for Scurase.