### PR TITLE
Remove extension from "main" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Super-fast alternative to Babel for when you can target modern JS runtimes",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
Fixes #303

From my testing, this doesn't seem to break anything, and it makes it possible
to import sucrase with `--experimental-modules`. For now, I'm leaving the
`module` field as-is, since I think it's needed in some contexts.