### PR TITLE
Fix syntax error line numbers, delay computation

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,6 @@
 import {Token} from "./tokenizer/index";
 import {Scope} from "./tokenizer/state";
-import {initParser} from "./traverser/base";
+import {augmentError, initParser} from "./traverser/base";
 import {parseFile} from "./traverser/index";
 
 export class File {
@@ -23,5 +23,9 @@ export function parse(
     throw new Error("Cannot combine flow and typescript plugins.");
   }
   initParser(input, isJSXEnabled, isTypeScriptEnabled, isFlowEnabled);
-  return parseFile();
+  try {
+    return parseFile();
+  } catch (e) {
+    throw augmentError(e);
+  }
 }

--- a/src/parser/traverser/base.ts
+++ b/src/parser/traverser/base.ts
@@ -18,13 +18,20 @@ export function getNextContextId(): number {
 // of the error message, and then raises a `SyntaxError` with that
 // message.
 export function raise(pos: number, message: string): never {
-  const loc = locationForIndex(pos);
-  message += ` (${loc.line}:${loc.column})`;
   // tslint:disable-next-line no-any
   const err: any = new SyntaxError(message);
   err.pos = pos;
-  err.loc = loc;
   throw err;
+}
+
+// tslint:disable-next-line no-any
+export function augmentError(error: any): any {
+  if ("pos" in error) {
+    const loc = locationForIndex(error.pos);
+    error.message += ` (${loc.line}:${loc.column})`;
+    error.loc = loc;
+  }
+  return error;
 }
 
 export class Loc {
@@ -40,7 +47,7 @@ export function locationForIndex(pos: number): Loc {
   let line = 1;
   let column = 1;
   for (let i = 0; i < pos; i++) {
-    if (input.charCodeAt(pos) === charCodes.lineFeed) {
+    if (input.charCodeAt(i) === charCodes.lineFeed) {
       line++;
       column = 1;
     } else {

--- a/test/errors-test.ts
+++ b/test/errors-test.ts
@@ -1,0 +1,11 @@
+import {throws} from "assert";
+import {transform} from "../src";
+
+describe("errors", () => {
+  it("gives proper line numbers in syntax errors", () => {
+    throws(
+      () => transform("const x = 1;\nconst y = )\n", {transforms: []}),
+      /SyntaxError: Unexpected token \(2:11\)/,
+    );
+  });
+});


### PR DESCRIPTION
We internally throw and catch syntax errors in a number of cases, and from some
profiling work, a lot of the time was spent generating the line number from the
source code offset, which the user will never see. Now, we only include the line
and column numbers when the exception is thrown from the top level of the
parser.

Also, the code to compute line numbers was completely broken anyway (everything
was showing up as on the first line), so this fixes it and adds a test.