### PR TITLE
Fix coverage, update CI build in various ways

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,13 @@ matrix:
         - yarn run-examples tslint apollo-client
     - script:
         - yarn build
-        - 'yarn test && yarn coverage'
+        - yarn lint
+        - yarn test-with-coverage && yarn report-coverage
         - yarn run-examples decaffeinate decaffeinate-parser coffee-lex
     - node_js: '8'
       script:
         - yarn build
-        - yarn test
+        - yarn test-only
   # Exclude the default build; we only want to run explicitly-included builds.
   exclude:
     node_js: '10'

--- a/example-runner/example-runner.ts
+++ b/example-runner/example-runner.ts
@@ -112,4 +112,5 @@ async function runProject(project: string, shouldSave: boolean): Promise<boolean
 main().catch((e) => {
   console.error("Unhandled error:");
   console.error(e);
+  process.exitCode = 1;
 });

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "prepublishOnly": "yarn clean && yarn build",
     "release": "sucrase-node script/release.ts",
     "run-examples": "sucrase-node example-runner/example-runner.ts",
-    "test": "yarn lint && nyc yarn test-only",
+    "test": "yarn lint && yarn test-only",
     "test-only": "mocha './test/**/*.ts'",
-    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
+    "test-with-coverage": "nyc mocha './test/**/*.ts'",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "repository": {
     "type": "git",
@@ -64,7 +65,6 @@
     "mocha": "^3.5.3",
     "nyc": "^12.0.2",
     "prettier": "^1.12.1",
-    "source-map-support": "^0.5.9",
     "sucrase": "^3.6.0",
     "tslint": "^5.9.1",
     "tslint-language-service": "^0.9.9",

--- a/script/build.ts
+++ b/script/build.ts
@@ -77,4 +77,5 @@ async function buildIntegration(path: string): Promise<void> {
 main().catch((e) => {
   console.error("Unhandled error:");
   console.error(e);
+  process.exitCode = 1;
 });

--- a/script/release.ts
+++ b/script/release.ts
@@ -38,4 +38,5 @@ async function main(): Promise<void> {
 main().catch((e) => {
   console.error("Unhandled error:");
   console.error(e);
+  process.exitCode = 1;
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
 --require sucrase/register
---require source-map-support/register

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,6 @@
     "no-empty-interface": true,
     "no-floating-promises": true,
     "no-misused-new": true,
-    "no-unused-variable": true,
     "no-void-expression": true,
     "no-namespace": true,
     "no-internal-module": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,13 +2773,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -2794,7 +2787,7 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 


### PR DESCRIPTION
Fixes #329

* Rather than using `nyc` to wrap `yarn` to wrap `mocha`, we now just have `nyc`
  wrap `mocha` directly. This fixes a regression where a yarn upgrade broken
  coverage.
* We now run node 11 by default, with extra builds for node 8 and 10.
* source-map-support didn't seem to be doing anything, so I removed it.
* I made plain `yarn test` no longer run coverage. It's now opt-in as
  `yarn run-with-coverage`. This means that builds that run tests but don't
  report coverage won't be needlessly computing coverage.
* I got rid of the `no-unused-variable` TSLint rule, which has a deprecation
  warning now.

cc @raylu 