### PR TITLE
Fix incorrect type state when processing TS "declare global"

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -892,7 +892,6 @@ function tsTryParseDeclare(): boolean {
       if (contextualKeyword === ContextualKeyword._global) {
         tsParseAmbientExternalModuleDeclaration();
         matched = true;
-        return true;
       } else {
         matched = tsParseDeclaration(contextualKeyword, /* isBeforeToken */ true);
       }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -594,6 +594,19 @@ describe("typescript transform", () => {
     );
   });
 
+  it("handles and removes `declare global` syntax", () => {
+    assertTypeScriptResult(
+      `
+      declare global {
+      }
+    `,
+      `"use strict";
+      
+
+    `,
+    );
+  });
+
   it("handles and removes `export declare class` syntax", () => {
     assertTypeScriptResult(
       `


### PR DESCRIPTION
Fixes #336

It wasn't cleaning up the type context, so all tokens from there to the end of
the file were incorrectly treated as a type, including the EOF.