### PR TITLE
Fix crash with TypeScript overloaded constructors

### DIFF
--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -66,7 +66,7 @@ export default function getClassInfo(
 
   tokens.nextToken();
   while (!tokens.matchesContextIdAndLabel(tt.braceR, classContextId)) {
-    if (tokens.matchesContextual(ContextualKeyword._constructor)) {
+    if (tokens.matchesContextual(ContextualKeyword._constructor) && !tokens.currentToken().isType) {
       ({constructorInitializers, constructorInsertPos} = processConstructor(tokens));
     } else if (tokens.matches1(tt.semi)) {
       rangesToRemove.push({start: tokens.currentIndex(), end: tokens.currentIndex() + 1});
@@ -83,7 +83,10 @@ export default function getClassInfo(
         }
         tokens.nextToken();
       }
-      if (tokens.matchesContextual(ContextualKeyword._constructor)) {
+      if (
+        tokens.matchesContextual(ContextualKeyword._constructor) &&
+        !tokens.currentToken().isType
+      ) {
         ({constructorInitializers, constructorInsertPos} = processConstructor(tokens));
         continue;
       }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1251,4 +1251,23 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("allows overloads for constructors", () => {
+    assertTypeScriptResult(
+      `
+      class A {
+        constructor(s: string)
+        constructor(n: number)
+        constructor(sn: string | number) {}
+      }
+    `,
+      `"use strict";
+      class A {
+        
+
+        constructor(sn) {}
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #334

Constructors without bodies were correctly being marked as type tokens, but the
class transformation code (to implement class fields and TS fields defined in
constructor params) was incorrectly viewing it as a real constructor. Now, when
checking if something matches the constructor keyword, we also make sure it's
not a type token.