### PR TITLE
Add microbenchmark, optimize isWhitespace

### DIFF
--- a/benchmark/benchmark-project.ts
+++ b/benchmark/benchmark-project.ts
@@ -2,8 +2,7 @@
 /* eslint-disable no-console */
 import parseArgs from "yargs-parser";
 
-// @ts-ignore: May not be built, just ignore for now.
-import * as sucrase from "../dist/index"; // eslint-disable-line import/no-unresolved
+import * as sucrase from "../src/index";
 import {FileInfo, loadProjectFiles} from "./loadProjectFiles";
 
 async function main(): Promise<void> {

--- a/benchmark/benchmark-react.ts
+++ b/benchmark/benchmark-react.ts
@@ -3,8 +3,7 @@
 // @ts-ignore: new babel-core package missing types.
 import * as babel from "@babel/core";
 
-// @ts-ignore: May not be built, just ignore for now.
-import * as sucrase from "../dist/index"; // eslint-disable-line import/no-unresolved
+import * as sucrase from "../src/index";
 import {loadProjectFiles} from "./loadProjectFiles";
 
 async function main(): Promise<void> {

--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -4,8 +4,8 @@
 import * as babel from "@babel/core";
 import * as fs from "fs";
 import * as TypeScript from "typescript";
-// @ts-ignore: May not be built, just ignore for now.
-import * as sucrase from "../dist/index"; // eslint-disable-line import/no-unresolved
+import * as sucrase from "../src/index";
+import runBenchmark from "./runBenchmark";
 
 function main(): void {
   const sampleFile = process.argv[2] || "sample.tsx";
@@ -32,17 +32,6 @@ function main(): void {
       plugins: ["@babel/plugin-transform-modules-commonjs"],
     }),
   );
-}
-
-function runBenchmark(name: string, runTrial: () => void): void {
-  // Run twice before starting the clock to warm up the JIT, caches, etc.
-  runTrial();
-  runTrial();
-  console.time(name);
-  for (let i = 0; i < 100; i++) {
-    runTrial();
-  }
-  console.timeEnd(name);
 }
 
 main();

--- a/benchmark/microbenchmark.ts
+++ b/benchmark/microbenchmark.ts
@@ -1,0 +1,34 @@
+#!./node_modules/.bin/sucrase-node
+/* eslint-disable no-console */
+import * as fs from "fs";
+import {isWhitespace} from "../src/parser/util/whitespace";
+import runBenchmark from "./runBenchmark";
+
+function main(): void {
+  const benchmark = process.argv[2] || "all";
+  console.log(`Running microbenchmark ${benchmark}`);
+  const code = fs.readFileSync(`./benchmark/sample/sample.tsx`).toString();
+  if (benchmark === "all" || benchmark === "isWhitespace") {
+    runBenchmark(
+      "isWhitespace",
+      () => {
+        for (let i = 0; i < code.length; i++) {
+          const char = code.charCodeAt(i);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+          isWhitespace(char);
+        }
+      },
+      1000,
+    );
+  }
+}
+
+main();

--- a/benchmark/profile.ts
+++ b/benchmark/profile.ts
@@ -2,8 +2,7 @@
 /* eslint-disable no-console */
 import * as fs from "fs";
 
-// @ts-ignore: May not be built, just ignore for now.
-import * as sucrase from "../dist/index"; // eslint-disable-line import/no-unresolved
+import * as sucrase from "../src/index";
 
 function main(): void {
   const sampleFile = process.argv[2] || "sample.tsx";

--- a/benchmark/runBenchmark.ts
+++ b/benchmark/runBenchmark.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+
+export default function runBenchmark(
+  name: string,
+  runTrial: () => void,
+  times: number = 100,
+): void {
+  // Run twice before starting the clock to warm up the JIT, caches, etc.
+  runTrial();
+  runTrial();
+  console.time(name);
+  for (let i = 0; i < times; i++) {
+    runTrial();
+  }
+  console.timeEnd(name);
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf ./build ./dist ./dist-self-build ./example-runner/example-repos",
     "generate": "sucrase-node generator/generate.ts",
     "benchmark": "sucrase-node benchmark/benchmark.ts",
+    "microbenchmark": "sucrase-node benchmark/microbenchmark.ts",
     "benchmark-react": "sucrase-node benchmark/benchmark-react.ts",
     "benchmark-project": "sucrase-node benchmark/benchmark-project.ts",
     "lint": "sucrase-node script/lint.ts",

--- a/src/parser/tokenizer/state.ts
+++ b/src/parser/tokenizer/state.ts
@@ -51,7 +51,7 @@ export class StateSnapshot {
 }
 
 export default class State {
-  init(): void {
+  constructor() {
     this.potentialArrowAt = -1;
     this.noAnonFunctionType = false;
     this.tokens = [];

--- a/src/parser/traverser/base.ts
+++ b/src/parser/traverser/base.ts
@@ -65,7 +65,6 @@ export function initParser(
 ): void {
   input = inputCode;
   state = new State();
-  state.init();
   nextContextId = 1;
   isJSXEnabled = isJSXEnabledArg;
   isTypeScriptEnabled = isTypeScriptEnabledArg;

--- a/src/parser/util/whitespace.ts
+++ b/src/parser/util/whitespace.ts
@@ -4,8 +4,18 @@ import {charCodes} from "./charcodes";
 
 export const lineBreak = /\r\n?|\n|\u2028|\u2029/;
 
+const WHITESPACE = new Uint8Array(128);
+WHITESPACE[0x0009] = 1;
+WHITESPACE[0x000b] = 1;
+WHITESPACE[0x000c] = 1;
+WHITESPACE[charCodes.space] = 1;
+
 // https://tc39.github.io/ecma262/#sec-white-space
-export function isWhitespace(code: number): boolean {
+export function isWhitespace(code: number): number {
+  // Fast path for ASCII using a pre-computed table.
+  if (!(code >>> 7)) {
+    return WHITESPACE[code];
+  }
   switch (code) {
     case 0x0009: // CHARACTER TABULATION
     case 0x000b: // LINE TABULATION
@@ -28,9 +38,9 @@ export function isWhitespace(code: number): boolean {
     case 0x205f: // MEDIUM MATHEMATICAL SPACE
     case 0x3000: // IDEOGRAPHIC SPACE
     case 0xfeff: // ZERO WIDTH NO-BREAK SPACE
-      return true;
+      return 1;
 
     default:
-      return false;
+      return 0;
   }
 }


### PR DESCRIPTION
From some trial and error and printing out the generated machine code with
`node --print-opt-code`, it looks like switches aren't actually compiled all
that well and a lookup table performs a lot better, especially for the common
case of non-whitespace chars.

This optimization brings the microbenchmark running time from about 2 seconds to
about 1.2 seconds. With the function always returning true, it was 0.8 seconds,
so by that measure it's a 3x speedup.

I also changed benchmarks to compile on-the-fly since it doesn't seem to
actually affect perf much and it's nice to avoid the build step when iterating
on perf. I also simplified State construction a little.