### PR TITLE
Optimize hasPrecedingLineBreak

### DIFF
--- a/benchmark/microbenchmark.ts
+++ b/benchmark/microbenchmark.ts
@@ -1,6 +1,9 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
 import * as fs from "fs";
+import {next} from "../src/parser/tokenizer";
+import {initParser} from "../src/parser/traverser/base";
+import {hasPrecedingLineBreak} from "../src/parser/traverser/util";
 import {isWhitespace} from "../src/parser/util/whitespace";
 import runBenchmark from "./runBenchmark";
 
@@ -27,6 +30,23 @@ function main(): void {
         }
       },
       1000,
+    );
+  }
+  if (benchmark === "all" || benchmark === "hasPredecingLineBreak") {
+    initParser("let x\nx++;", false, false, false);
+    next();
+    next();
+    next();
+    runBenchmark(
+      "hasPredecingLineBreak",
+      () => {
+        hasPrecedingLineBreak();
+        hasPrecedingLineBreak();
+        hasPrecedingLineBreak();
+        hasPrecedingLineBreak();
+        hasPrecedingLineBreak();
+      },
+      1000000,
     );
   }
 }

--- a/src/parser/traverser/util.ts
+++ b/src/parser/traverser/util.ts
@@ -1,6 +1,6 @@
 import {ContextualKeyword, eat, lookaheadTypeAndKeyword, match} from "../tokenizer/index";
 import {formatTokenType, TokenType, TokenType as tt} from "../tokenizer/types";
-import {lineBreak} from "../util/whitespace";
+import {charCodes} from "../util/charcodes";
 import {input, raise, state} from "./base";
 
 // ## Parser utilities
@@ -35,7 +35,18 @@ export function canInsertSemicolon(): boolean {
 export function hasPrecedingLineBreak(): boolean {
   const prevToken = state.tokens[state.tokens.length - 1];
   const lastTokEnd = prevToken ? prevToken.end : 0;
-  return lineBreak.test(input.slice(lastTokEnd, state.start));
+  for (let i = lastTokEnd; i < state.start; i++) {
+    const code = input.charCodeAt(i);
+    if (
+      code === charCodes.lineFeed ||
+      code === charCodes.carriageReturn ||
+      code === 0x2028 ||
+      code === 0x2029
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function isLineTerminator(): boolean {

--- a/src/parser/util/whitespace.ts
+++ b/src/parser/util/whitespace.ts
@@ -1,20 +1,16 @@
-// Matches a whole line break (where CRLF is considered a single
-// line break). Used to count lines.
 import {charCodes} from "./charcodes";
 
-export const lineBreak = /\r\n?|\n|\u2028|\u2029/;
-
-const WHITESPACE = new Uint8Array(128);
-WHITESPACE[0x0009] = 1;
-WHITESPACE[0x000b] = 1;
-WHITESPACE[0x000c] = 1;
-WHITESPACE[charCodes.space] = 1;
+const WHITESPACE_TABLE = new Uint8Array(128);
+WHITESPACE_TABLE[0x0009] = 1;
+WHITESPACE_TABLE[0x000b] = 1;
+WHITESPACE_TABLE[0x000c] = 1;
+WHITESPACE_TABLE[charCodes.space] = 1;
 
 // https://tc39.github.io/ecma262/#sec-white-space
 export function isWhitespace(code: number): number {
   // Fast path for ASCII using a pre-computed table.
   if (!(code >>> 7)) {
-    return WHITESPACE[code];
+    return WHITESPACE_TABLE[code];
   }
   switch (code) {
     case 0x0009: // CHARACTER TABULATION


### PR DESCRIPTION
This wasn't very commonly used, but was an example of a regex that's nice to get
rid of, and removing the regex did bring the running time down from about 170ms
to about 50ms.