### PR TITLE
Overhaul error management to avoid the need for try/catch backtracking

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,6 @@
 import {Token} from "./tokenizer/index";
 import {Scope} from "./tokenizer/state";
-import {augmentError, initParser} from "./traverser/base";
+import {augmentError, initParser, state} from "./traverser/base";
 import {parseFile} from "./traverser/index";
 
 export class File {
@@ -23,9 +23,9 @@ export function parse(
     throw new Error("Cannot combine flow and typescript plugins.");
   }
   initParser(input, isJSXEnabled, isTypeScriptEnabled, isFlowEnabled);
-  try {
-    return parseFile();
-  } catch (e) {
-    throw augmentError(e);
+  const result = parseFile();
+  if (state.error) {
+    throw augmentError(state.error);
   }
+  return result;
 }

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 
-import {input, isFlowEnabled, raise, state} from "../traverser/base";
+import {input, isFlowEnabled, state} from "../traverser/base";
 import {unexpected} from "../traverser/util";
 import {charCodes} from "../util/charcodes";
 import {isIdentifierChar, isIdentifierStart} from "../util/identifier";
@@ -241,7 +241,9 @@ function readToken(code: number): void {
 
 function skipBlockComment(): void {
   const end = input.indexOf("*/", (state.pos += 2));
-  if (end === -1) raise(state.pos - 2, "Unterminated comment");
+  if (end === -1) {
+    unexpected(state.pos - 2, "Unterminated comment");
+  }
 
   state.pos = end + 2;
 }
@@ -666,7 +668,7 @@ export function getTokenFromCode(code: number): void {
       break;
   }
 
-  raise(state.pos, `Unexpected character '${String.fromCharCode(code)}'`);
+  unexpected(state.pos, `Unexpected character '${String.fromCharCode(code)}'`);
 }
 
 function finishOp(type: TokenType, size: number): void {
@@ -680,7 +682,8 @@ function readRegexp(): void {
   let inClass = false;
   for (;;) {
     if (state.pos >= input.length) {
-      raise(start, "Unterminated regular expression");
+      unexpected(start, "Unterminated regular expression");
+      return;
     }
     const ch = input.charAt(state.pos);
     if (escaped) {
@@ -781,7 +784,8 @@ function readString(quote: number): void {
   state.pos++;
   for (;;) {
     if (state.pos >= input.length) {
-      raise(state.start, "Unterminated string constant");
+      unexpected(state.start, "Unterminated string constant");
+      return;
     }
     const ch = input.charCodeAt(state.pos);
     if (ch === charCodes.backslash) {
@@ -799,7 +803,8 @@ function readString(quote: number): void {
 function readTmplToken(): void {
   for (;;) {
     if (state.pos >= input.length) {
-      raise(state.start, "Unterminated template");
+      unexpected(state.start, "Unterminated template");
+      return;
     }
     const ch = input.charCodeAt(state.pos);
     if (
@@ -839,7 +844,10 @@ export function skipWord(): void {
       // \u
       state.pos += 2;
       if (input.charCodeAt(state.pos) === charCodes.leftCurlyBrace) {
-        while (input.charCodeAt(state.pos) !== charCodes.leftCurlyBrace) {
+        while (
+          state.pos < input.length &&
+          input.charCodeAt(state.pos) !== charCodes.rightCurlyBrace
+        ) {
           state.pos++;
         }
         state.pos++;

--- a/src/parser/tokenizer/readWord.ts
+++ b/src/parser/tokenizer/readWord.ts
@@ -1027,7 +1027,10 @@ export default function readWord(): void {
       // \u
       state.pos += 2;
       if (input.charCodeAt(state.pos) === charCodes.leftCurlyBrace) {
-        while (input.charCodeAt(state.pos) !== charCodes.leftCurlyBrace) {
+        while (
+          state.pos < input.length &&
+          input.charCodeAt(state.pos) !== charCodes.rightCurlyBrace
+        ) {
           state.pos++;
         }
         state.pos++;

--- a/src/parser/traverser/base.ts
+++ b/src/parser/traverser/base.ts
@@ -12,18 +12,6 @@ export function getNextContextId(): number {
   return nextContextId++;
 }
 
-// This function is used to raise exceptions on parse errors. It
-// takes an offset integer (into the current `input`) to indicate
-// the location of the error, attaches the position to the end
-// of the error message, and then raises a `SyntaxError` with that
-// message.
-export function raise(pos: number, message: string): never {
-  // tslint:disable-next-line no-any
-  const err: any = new SyntaxError(message);
-  err.pos = pos;
-  throw err;
-}
-
 // tslint:disable-next-line no-any
 export function augmentError(error: any): any {
   if ("pos" in error) {

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -64,7 +64,7 @@ export function parseBindingAtom(isBlockScope: boolean): void {
       return;
 
     default:
-      throw unexpected();
+      unexpected();
   }
 }
 
@@ -79,7 +79,7 @@ export function parseBindingList(
   let hasRemovedComma = false;
   const firstItemTokenIndex = state.tokens.length;
 
-  while (!eat(close)) {
+  while (!eat(close) && !state.error) {
     if (first) {
       first = false;
     } else {

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -372,7 +372,7 @@ function parseSwitchStatement(): void {
   expect(tt.braceL);
 
   // Don't bother validation; just go through any sequence of cases, defaults, and statements.
-  while (!match(tt.braceR)) {
+  while (!match(tt.braceR) && !state.error) {
     if (match(tt._case) || match(tt._default)) {
       const isCase = match(tt._case);
       next();
@@ -479,7 +479,7 @@ export function parseBlock(
 }
 
 export function parseBlockBody(topLevel: boolean, end: TokenType): void {
-  while (!eat(end)) {
+  while (!eat(end) && !state.error) {
     parseStatement(true, topLevel);
   }
 }
@@ -526,7 +526,9 @@ function parseVar(isFor: boolean, kind: TokenType): void {
       parseMaybeAssign(isFor);
       state.tokens[eqIndex].rhsEndIndex = state.tokens.length;
     }
-    if (!eat(tt.comma)) break;
+    if (!eat(tt.comma)) {
+      break;
+    }
   }
 }
 
@@ -621,6 +623,9 @@ export function parseClass(isStatement: boolean, optionalId: boolean = false): v
   parseClassSuper();
   const openBraceIndex = state.tokens.length;
   parseClassBody(contextId);
+  if (state.error) {
+    return;
+  }
   state.tokens[openBraceIndex].contextId = contextId;
   state.tokens[state.tokens.length - 1].contextId = contextId;
   if (nameScopeStartTokenIndex !== null) {
@@ -640,7 +645,7 @@ function isClassMethod(): boolean {
 function parseClassBody(classContextId: number): void {
   expect(tt.braceL);
 
-  while (!eat(tt.braceR)) {
+  while (!eat(tt.braceR) && !state.error) {
     if (eat(tt.semi)) {
       continue;
     }
@@ -987,12 +992,14 @@ export function parseExportSpecifiers(): void {
   // export { x, y as z } [from '...']
   expect(tt.braceL);
 
-  while (!eat(tt.braceR)) {
+  while (!eat(tt.braceR) && !state.error) {
     if (first) {
       first = false;
     } else {
       expect(tt.comma);
-      if (eat(tt.braceR)) break;
+      if (eat(tt.braceR)) {
+        break;
+      }
     }
 
     parseIdentifier();
@@ -1055,7 +1062,7 @@ function parseImportSpecifiers(): void {
   }
 
   expect(tt.braceL);
-  while (!eat(tt.braceR)) {
+  while (!eat(tt.braceR) && !state.error) {
     if (first) {
       first = false;
     } else {
@@ -1068,7 +1075,9 @@ function parseImportSpecifiers(): void {
       }
 
       expect(tt.comma);
-      if (eat(tt.braceR)) break;
+      if (eat(tt.braceR)) {
+        break;
+      }
     }
 
     parseImportSpecifier();


### PR DESCRIPTION
There were 13 places in the code where a try/catch was used for backtracking,
i.e. to try parsing one approach (e.g. JSX vs generic arrow function), catch
SyntaxError if there was a problem, then try the other approach. To some extent,
this parser complexity is needed due to the inherent difficulty in parsing
JS+JSX+TS (and Flow), particularly arrow functions and the many uses of `<`.
It also doesn't have a clear alternative, since any lookahead approach would
basically need to be a full parser to get all the details right.

try/catch is problematic not just for performance reasons but also because
exceptions aren't available in WebAssembly or Rust, both of which I want to
explore, so this change gets rid of all usages of try/catch.

Rather than changing every function in the parser to return an optional error
and propagate errors from its child calls (which would be a huge change and
likely hurt perf), this change swaps out `unexpected` so that rather than
throwing, it saves an error in `State` that can be accessed later. At that
point, code continues executing with the token state stuck in "EOF", and all
parsing operations are effectively no-ops. This is fragile because it means
that every function in the parser needs to be able to keep running in the
face of failure so that we can wind up the stack through normal function
completion. As part of this change, I audited all unbounded loops and made sure
they all break when in an error state. We still throw the saved error at the
top level, so the stack trace and error message is the same as before.