### PR TITLE
More AssemblyScript-related simplifications

### DIFF
--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -971,30 +971,21 @@ export function flowStartParseAsyncArrowFromCallExpression(): void {
 //    parse the rest, make sure the rest is an arrow function, and go from
 //    there
 // 3. This is neither. Just call the super method
-export function flowParseMaybeAssign(noIn: boolean = false, isWithinParens: boolean): boolean {
-  let jsxError = null;
+export function flowParseMaybeAssign(noIn: boolean, isWithinParens: boolean): boolean {
   if (match(tt.lessThan)) {
     const snapshot = state.snapshot();
-    const wasArrow = baseParseMaybeAssign(noIn, isWithinParens);
+    let wasArrow = baseParseMaybeAssign(noIn, isWithinParens);
     if (state.error) {
-      jsxError = state.error;
       state.restoreFromSnapshot(snapshot);
       state.type = tt.typeParameterStart;
     } else {
       return wasArrow;
     }
-  }
 
-  if (jsxError != null || match(tt.lessThan)) {
     const oldIsType = pushTypeContext(0);
     flowParseTypeParameterDeclaration();
     popTypeContext(oldIsType);
-    const wasArrow = baseParseMaybeAssign(noIn, isWithinParens);
-
-    if (state.error) {
-      state.error = jsxError;
-    }
-
+    wasArrow = baseParseMaybeAssign(noIn, isWithinParens);
     if (wasArrow) {
       return true;
     }
@@ -1032,23 +1023,11 @@ export function flowParseSubscripts(startPos: number, noCalls: boolean = false):
     match(tt.lessThan)
   ) {
     const snapshot = state.snapshot();
-    let error;
-
     const wasArrow = parseAsyncArrowWithTypeParameters(startPos);
-    if (wasArrow) {
+    if (wasArrow && !state.error) {
       return;
     }
-    if (state.error) {
-      error = state.error;
-    }
-
     state.restoreFromSnapshot(snapshot);
-
-    baseParseSubscripts(startPos, noCalls);
-    if (state.error) {
-      state.error = error || state.error;
-    }
-    return;
   }
 
   baseParseSubscripts(startPos, noCalls);

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -448,4 +448,26 @@ describe("type transforms", () => {
     `,
     );
   });
+
+  it("handles a function call where the function is named 'async'", () => {
+    assertTypeScriptAndFlowResult(
+      `
+      async (1, 2, 3);
+    `,
+      `"use strict";
+      async (1, 2, 3);
+    `,
+    );
+  });
+
+  it("handles a function call with a type argument where the function is named 'async'", () => {
+    assertTypeScriptAndFlowResult(
+      `
+      async <T>(1, 2, 3);
+    `,
+      `"use strict";
+      async (1, 2, 3);
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This weakens some error reporting around JSX vs arrow function with type
parameter vs type assertion, but that seemed pretty insignificant anyway and
it's nice to keep the implementation simple. I also split out various code paths
into explicit separate cases rather than trying to handle multiple cases at
once, which at least here should avoid the need for typechecking escape hatches
and make each piece a bit easier to think about.