### PR TITLE
Change param order in unexpected to better handle defaults

### DIFF
--- a/src/parser/plugins/jsx/index.ts
+++ b/src/parser/plugins/jsx/index.ts
@@ -21,7 +21,7 @@ import {tsTryParseJSXTypeArgument} from "../typescript";
 function jsxReadToken(): void {
   for (;;) {
     if (state.pos >= input.length) {
-      unexpected(state.start, "Unterminated JSX contents");
+      unexpected("Unterminated JSX contents");
       return;
     }
 
@@ -52,7 +52,7 @@ function jsxReadString(quote: number): void {
   state.pos++;
   for (;;) {
     if (state.pos >= input.length) {
-      unexpected(state.start, "Unterminated string constant");
+      unexpected("Unterminated string constant");
       return;
     }
 
@@ -77,7 +77,7 @@ function jsxReadWord(): void {
   let ch: number;
   do {
     if (state.pos > input.length) {
-      unexpected(null, "Unexpectedly reached the end of input.");
+      unexpected("Unexpectedly reached the end of input.");
       return;
     }
     ch = input.charCodeAt(++state.pos);
@@ -130,7 +130,7 @@ function jsxParseAttributeValue(): void {
       return;
 
     default:
-      unexpected(state.start, "JSX value should be either an expression or a quoted JSX text");
+      unexpected("JSX value should be either an expression or a quoted JSX text");
   }
 }
 

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -209,7 +209,7 @@ export function nextToken(): void {
       tokens[tokens.length - 1].start >= input.length &&
       tokens[tokens.length - 2].start >= input.length
     ) {
-      unexpected(null, "Unexpectedly reached the end of input.");
+      unexpected("Unexpectedly reached the end of input.");
     }
     finishToken(tt.eof);
     return;
@@ -234,7 +234,7 @@ function readToken(code: number): void {
 function skipBlockComment(): void {
   const end = input.indexOf("*/", (state.pos += 2));
   if (end === -1) {
-    unexpected(state.pos - 2, "Unterminated comment");
+    unexpected("Unterminated comment", state.pos - 2);
   }
 
   state.pos = end + 2;
@@ -660,7 +660,7 @@ export function getTokenFromCode(code: number): void {
       break;
   }
 
-  unexpected(state.pos, `Unexpected character '${String.fromCharCode(code)}'`);
+  unexpected(`Unexpected character '${String.fromCharCode(code)}'`, state.pos);
 }
 
 function finishOp(type: TokenType, size: number): void {
@@ -674,7 +674,7 @@ function readRegexp(): void {
   let inClass = false;
   for (;;) {
     if (state.pos >= input.length) {
-      unexpected(start, "Unterminated regular expression");
+      unexpected("Unterminated regular expression", start);
       return;
     }
     const ch = input.charAt(state.pos);
@@ -776,7 +776,7 @@ function readString(quote: number): void {
   state.pos++;
   for (;;) {
     if (state.pos >= input.length) {
-      unexpected(state.start, "Unterminated string constant");
+      unexpected("Unterminated string constant");
       return;
     }
     const ch = input.charCodeAt(state.pos);
@@ -795,7 +795,7 @@ function readString(quote: number): void {
 function readTmplToken(): void {
   for (;;) {
     if (state.pos >= input.length) {
-      unexpected(state.start, "Unterminated template");
+      unexpected("Unterminated template");
       return;
     }
     const ch = input.charCodeAt(state.pos);

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -1069,7 +1069,6 @@ function parseImportSpecifiers(): void {
       // Detect an attempt to deep destructure
       if (eat(tt.colon)) {
         unexpected(
-          null,
           "ES2015 named imports do not destructure. Use another statement for destructuring after the import.",
         );
       }

--- a/src/parser/traverser/util.ts
+++ b/src/parser/traverser/util.ts
@@ -29,7 +29,7 @@ export function eatContextual(contextualKeyword: ContextualKeyword): boolean {
 // Asserts that following token is given contextual keyword.
 export function expectContextual(contextualKeyword: ContextualKeyword): void {
   if (!eatContextual(contextualKeyword)) {
-    unexpected(null);
+    unexpected();
   }
 }
 
@@ -62,15 +62,17 @@ export function isLineTerminator(): boolean {
 // Consume a semicolon, or, failing that, see if we are allowed to
 // pretend that there is a semicolon at this position.
 export function semicolon(): void {
-  if (!isLineTerminator()) unexpected(null, 'Unexpected token, expected";"');
+  if (!isLineTerminator()) {
+    unexpected('Unexpected token, expected ";"');
+  }
 }
 
 // Expect a token of a given type. If found, consume it, otherwise,
 // raise an unexpected token error at given pos.
-export function expect(type: TokenType, pos?: number | null): void {
+export function expect(type: TokenType): void {
   const matched = eat(type);
   if (!matched) {
-    unexpected(pos, `Unexpected token, expected "${formatTokenType(type)}"`);
+    unexpected(`Unexpected token, expected "${formatTokenType(type)}"`);
   }
 }
 
@@ -78,13 +80,13 @@ export function expect(type: TokenType, pos?: number | null): void {
  * Transition the parser to an error state. All code needs to be written to naturally unwind in this
  * state, which allows us to backtrack without exceptions and without error plumbing everywhere.
  */
-export function unexpected(pos: number | null = null, message: string = "Unexpected token"): void {
+export function unexpected(message: string = "Unexpected token", pos: number = state.start): void {
   if (state.error) {
     return;
   }
   // tslint:disable-next-line no-any
   const err: any = new SyntaxError(message);
-  err.pos = pos != null ? pos : state.start;
+  err.pos = pos;
   state.error = err;
   state.pos = input.length;
   finishToken(tt.eof);


### PR DESCRIPTION
Specifying a custom string was common, and specifying a custom index was rare,
so it makes more sense for the index to be the second param.