### PR TITLE
Remove React-related contextual keywords

### DIFF
--- a/generator/generateReadWord.ts
+++ b/generator/generateReadWord.ts
@@ -71,11 +71,6 @@ const CONTEXTUAL_KEYWORDS = [
   "static",
   "type",
   "unique",
-  // Custom identifiers we want to match.
-  "React",
-  "createClass",
-  "createReactClass",
-  "displayName",
 ];
 
 const CODE = `\
@@ -104,7 +99,10 @@ export default function readWord(): void {
       // \\u
       state.pos += 2;
       if (input.charCodeAt(state.pos) === charCodes.leftCurlyBrace) {
-        while (input.charCodeAt(state.pos) !== charCodes.leftCurlyBrace) {
+        while (
+          state.pos < input.length &&
+          input.charCodeAt(state.pos) !== charCodes.rightCurlyBrace
+        ) {
           state.pos++;
         }
         state.pos++;

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -79,11 +79,6 @@ export const enum ContextualKeyword {
   _static,
   _type,
   _unique,
-  // Also throw in some identifiers we know we'll need to match on.
-  _React,
-  _createClass,
-  _createReactClass,
-  _displayName,
 }
 
 // Object type used to represent tokens. Note that normally, tokens

--- a/src/parser/tokenizer/readWord.ts
+++ b/src/parser/tokenizer/readWord.ts
@@ -14,19 +14,6 @@ import {TokenType as tt} from "./types";
  */
 export default function readWord(): void {
   switch (input.charCodeAt(state.pos++)) {
-    case charCodes.uppercaseR:
-      if (
-        input.charCodeAt(state.pos++) === charCodes.lowercaseE &&
-        input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-        input.charCodeAt(state.pos++) === charCodes.lowercaseC &&
-        input.charCodeAt(state.pos++) === charCodes.lowercaseT &&
-        !isIdentifierChar(input.charCodeAt(state.pos)) &&
-        input.charCodeAt(state.pos) !== charCodes.backslash
-      ) {
-        finishToken(tt.name, ContextualKeyword._React);
-        return;
-      }
-      break;
     case charCodes.lowercaseA:
       switch (input.charCodeAt(state.pos++)) {
         case charCodes.lowercaseB:
@@ -185,49 +172,6 @@ export default function readWord(): void {
             }
           }
           break;
-        case charCodes.lowercaseR:
-          if (input.charCodeAt(state.pos++) === charCodes.lowercaseE) {
-            if (input.charCodeAt(state.pos++) === charCodes.lowercaseA) {
-              if (input.charCodeAt(state.pos++) === charCodes.lowercaseT) {
-                if (input.charCodeAt(state.pos++) === charCodes.lowercaseE) {
-                  switch (input.charCodeAt(state.pos++)) {
-                    case charCodes.uppercaseC:
-                      if (
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseL &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseS &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseS &&
-                        !isIdentifierChar(input.charCodeAt(state.pos)) &&
-                        input.charCodeAt(state.pos) !== charCodes.backslash
-                      ) {
-                        finishToken(tt.name, ContextualKeyword._createClass);
-                        return;
-                      }
-                      break;
-                    case charCodes.uppercaseR:
-                      if (
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseE &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseC &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseT &&
-                        input.charCodeAt(state.pos++) === charCodes.uppercaseC &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseL &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseS &&
-                        input.charCodeAt(state.pos++) === charCodes.lowercaseS &&
-                        !isIdentifierChar(input.charCodeAt(state.pos)) &&
-                        input.charCodeAt(state.pos) !== charCodes.backslash
-                      ) {
-                        finishToken(tt.name, ContextualKeyword._createReactClass);
-                        return;
-                      }
-                      break;
-                  }
-                }
-              }
-            }
-          }
-          break;
       }
       break;
     case charCodes.lowercaseD:
@@ -286,24 +230,6 @@ export default function readWord(): void {
                 return;
               }
               break;
-          }
-          break;
-        case charCodes.lowercaseI:
-          if (
-            input.charCodeAt(state.pos++) === charCodes.lowercaseS &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseP &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseL &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseY &&
-            input.charCodeAt(state.pos++) === charCodes.uppercaseN &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseA &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseM &&
-            input.charCodeAt(state.pos++) === charCodes.lowercaseE &&
-            !isIdentifierChar(input.charCodeAt(state.pos)) &&
-            input.charCodeAt(state.pos) !== charCodes.backslash
-          ) {
-            finishToken(tt.name, ContextualKeyword._displayName);
-            return;
           }
           break;
         case charCodes.lowercaseO:

--- a/src/transformers/ReactDisplayNameTransformer.ts
+++ b/src/transformers/ReactDisplayNameTransformer.ts
@@ -1,6 +1,6 @@
 import CJSImportProcessor from "../CJSImportProcessor";
 import {Options} from "../index";
-import {ContextualKeyword, IdentifierRole} from "../parser/tokenizer";
+import {IdentifierRole} from "../parser/tokenizer";
 import {TokenType as tt} from "../parser/tokenizer/types";
 import TokenProcessor from "../TokenProcessor";
 import RootTransformer from "./RootTransformer";
@@ -22,7 +22,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
 
   process(): boolean {
     const startIndex = this.tokens.currentIndex();
-    if (this.tokens.matchesContextual(ContextualKeyword._createReactClass)) {
+    if (this.tokens.identifierName() === "createReactClass") {
       const newName =
         this.importProcessor && this.importProcessor.getIdentifierReplacement("createReactClass");
       if (newName) {
@@ -35,11 +35,8 @@ export default class ReactDisplayNameTransformer extends Transformer {
     }
     if (
       this.tokens.matches3(tt.name, tt.dot, tt.name) &&
-      this.tokens.matchesContextual(ContextualKeyword._React) &&
-      this.tokens.matchesContextualAtIndex(
-        this.tokens.currentIndex() + 2,
-        ContextualKeyword._createClass,
-      )
+      this.tokens.identifierName() === "React" &&
+      this.tokens.identifierNameAtIndex(this.tokens.currentIndex() + 2) === "createClass"
     ) {
       const newName = this.importProcessor
         ? this.importProcessor.getIdentifierReplacement("React") || "React"
@@ -137,7 +134,7 @@ export default class ReactDisplayNameTransformer extends Transformer {
       }
 
       if (
-        this.tokens.matchesContextualAtIndex(index, ContextualKeyword._displayName) &&
+        this.tokens.identifierNameAtIndex(index) === "displayName" &&
         this.tokens.tokens[index].identifierRole === IdentifierRole.ObjectKey &&
         token.contextId === objectContextId
       ) {


### PR DESCRIPTION
This makes it so all keywords only consist of lowercase letters, which should
make it easier to use a lookup table approach.