### PR TITLE
Fix infinite loop when a file ends with a short identifier

### DIFF
--- a/src/parser/tokenizer/readWord.ts
+++ b/src/parser/tokenizer/readWord.ts
@@ -13,9 +13,9 @@ import {TokenType as tt} from "./types";
  */
 export default function readWord(): void {
   let treePos = 0;
-  let code;
+  let code = 0;
   let pos = state.pos;
-  while (true) {
+  while (pos < input.length) {
     code = input.charCodeAt(pos);
     if (code < charCodes.lowercaseA || code > charCodes.lowercaseZ) {
       break;

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -723,4 +723,8 @@ describe("sucrase", () => {
       {transforms: ["typescript"]},
     );
   });
+
+  it("handles a file with only a single identifier", () => {
+    assertResult("a", "a", {transforms: []});
+  });
 });


### PR DESCRIPTION
We weren't properly checking for end-of-file when going through the readWord
tree.