### PR TITLE
Fix hasShadowedGlobals check to properly ignore top-level declarations

### DIFF
--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -1,7 +1,7 @@
 import {
   isBlockScopedDeclaration,
-  isDeclaration,
   isFunctionScopedDeclaration,
+  isNonTopLevelDeclaration,
 } from "./parser/tokenizer";
 import {Scope} from "./parser/tokenizer/state";
 import {TokenType as tt} from "./parser/tokenizer/types";
@@ -26,11 +26,12 @@ export default function identifyShadowedGlobals(
  * We can do a fast up-front check to see if there are any declarations to global names. If not,
  * then there's no point in computing scope assignments.
  */
-function hasShadowedGlobals(tokens: TokenProcessor, globalNames: Set<string>): boolean {
+// Exported for testing.
+export function hasShadowedGlobals(tokens: TokenProcessor, globalNames: Set<string>): boolean {
   for (const token of tokens.tokens) {
     if (
       token.type === tt.name &&
-      isDeclaration(token) &&
+      isNonTopLevelDeclaration(token) &&
       globalNames.has(tokens.identifierNameForToken(token))
     ) {
       return true;

--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -1037,6 +1037,7 @@ export function flowParseSubscripts(startPos: number, noCalls: boolean = false):
 
 // Returns true if there was an arrow function here.
 function parseAsyncArrowWithTypeParameters(startPos: number): boolean {
+  state.scopeDepth++;
   const startTokenIndex = state.tokens.length;
   parseFunctionParams();
   if (!parseArrow()) {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -12,8 +12,10 @@ import {TokenType, TokenType as tt} from "./types";
 export const enum IdentifierRole {
   Access,
   ExportAccess,
+  TopLevelDeclaration,
   FunctionScopedDeclaration,
   BlockScopedDeclaration,
+  ObjectShorthandTopLevelDeclaration,
   ObjectShorthandFunctionScopedDeclaration,
   ObjectShorthandBlockScopedDeclaration,
   ObjectShorthand,
@@ -21,6 +23,18 @@ export const enum IdentifierRole {
 }
 
 export function isDeclaration(token: Token): boolean {
+  const role = token.identifierRole;
+  return (
+    role === IdentifierRole.TopLevelDeclaration ||
+    role === IdentifierRole.FunctionScopedDeclaration ||
+    role === IdentifierRole.BlockScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandTopLevelDeclaration ||
+    role === IdentifierRole.ObjectShorthandFunctionScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandBlockScopedDeclaration
+  );
+}
+
+export function isNonTopLevelDeclaration(token: Token): boolean {
   const role = token.identifierRole;
   return (
     role === IdentifierRole.FunctionScopedDeclaration ||
@@ -32,8 +46,11 @@ export function isDeclaration(token: Token): boolean {
 
 export function isBlockScopedDeclaration(token: Token): boolean {
   const role = token.identifierRole;
+  // Treat top-level declarations as block scope since the distinction doesn't matter here.
   return (
+    role === IdentifierRole.TopLevelDeclaration ||
     role === IdentifierRole.BlockScopedDeclaration ||
+    role === IdentifierRole.ObjectShorthandTopLevelDeclaration ||
     role === IdentifierRole.ObjectShorthandBlockScopedDeclaration
   );
 }
@@ -43,6 +60,14 @@ export function isFunctionScopedDeclaration(token: Token): boolean {
   return (
     role === IdentifierRole.FunctionScopedDeclaration ||
     role === IdentifierRole.ObjectShorthandFunctionScopedDeclaration
+  );
+}
+
+export function isObjectShorthandDeclaration(token: Token): boolean {
+  return (
+    token.identifierRole === IdentifierRole.ObjectShorthandTopLevelDeclaration ||
+    token.identifierRole === IdentifierRole.ObjectShorthandBlockScopedDeclaration ||
+    token.identifierRole === IdentifierRole.ObjectShorthandFunctionScopedDeclaration
   );
 }
 

--- a/src/parser/tokenizer/state.ts
+++ b/src/parser/tokenizer/state.ts
@@ -26,6 +26,7 @@ export class StateSnapshot {
     readonly start: number,
     readonly end: number,
     readonly isType: boolean,
+    readonly scopeDepth: number,
     readonly error: Error | null,
   ) {}
 }
@@ -53,6 +54,7 @@ export default class State {
   end: number = 0;
 
   isType: boolean = false;
+  scopeDepth: number = 0;
 
   /**
    * If the parser is in an error state, then the token is always tt.eof and all functions can
@@ -76,6 +78,7 @@ export default class State {
       this.start,
       this.end,
       this.isType,
+      this.scopeDepth,
       this.error,
     );
   }
@@ -91,6 +94,7 @@ export default class State {
     this.start = snapshot.start;
     this.end = snapshot.end;
     this.isType = snapshot.isType;
+    this.scopeDepth = snapshot.scopeDepth;
     this.error = snapshot.error;
   }
 }

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -34,9 +34,13 @@ export function parseBindingIdentifier(isBlockScope: boolean): void {
 }
 
 export function markPriorBindingIdentifier(isBlockScope: boolean): void {
-  state.tokens[state.tokens.length - 1].identifierRole = isBlockScope
-    ? IdentifierRole.BlockScopedDeclaration
-    : IdentifierRole.FunctionScopedDeclaration;
+  if (state.scopeDepth === 0) {
+    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.TopLevelDeclaration;
+  } else {
+    state.tokens[state.tokens.length - 1].identifierRole = isBlockScope
+      ? IdentifierRole.BlockScopedDeclaration
+      : IdentifierRole.FunctionScopedDeclaration;
+  }
 }
 
 // Parses lvalue (assignable) atom.

--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -1,5 +1,5 @@
 import CJSImportProcessor from "../CJSImportProcessor";
-import {IdentifierRole, isDeclaration} from "../parser/tokenizer";
+import {IdentifierRole, isDeclaration, isObjectShorthandDeclaration} from "../parser/tokenizer";
 import {ContextualKeyword} from "../parser/tokenizer/keywords";
 import {TokenType as tt} from "../parser/tokenizer/types";
 import TokenProcessor from "../TokenProcessor";
@@ -444,10 +444,7 @@ export default class CJSImportTransformer extends Transformer {
           if (replacement === null) {
             throw new Error(`Expected a replacement for ${name} in \`export var\` syntax.`);
           }
-          if (
-            token.identifierRole === IdentifierRole.ObjectShorthandBlockScopedDeclaration ||
-            token.identifierRole === IdentifierRole.ObjectShorthandFunctionScopedDeclaration
-          ) {
+          if (isObjectShorthandDeclaration(token)) {
             replacement = `${name}: ${replacement}`;
           }
           this.tokens.replaceToken(replacement);

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -1,0 +1,45 @@
+import * as assert from "assert";
+import CJSImportProcessor from "../src/CJSImportProcessor";
+import {hasShadowedGlobals} from "../src/identifyShadowedGlobals";
+import NameManager from "../src/NameManager";
+import {parse} from "../src/parser";
+import TokenProcessor from "../src/TokenProcessor";
+
+function assertHasShadowedGlobals(code: string, expected: boolean): void {
+  const file = parse(code, false, false, false);
+  const tokenProcessor = new TokenProcessor(code, file.tokens, false);
+  const nameManager = new NameManager(tokenProcessor);
+  nameManager.preprocessNames();
+  const importProcessor = new CJSImportProcessor(nameManager, tokenProcessor, false);
+  importProcessor.preprocessTokens();
+  assert.strictEqual(
+    hasShadowedGlobals(tokenProcessor, importProcessor.getGlobalNames()),
+    expected,
+  );
+}
+
+describe("identifyShadowedGlobals", () => {
+  it("properly does an up-front that there are any shadowed globals", () => {
+    assertHasShadowedGlobals(
+      `
+      import a from 'a';
+      function foo() {
+        const a = 3;
+        console.log(a);
+      }
+    `,
+      true,
+    );
+  });
+
+  it("properly detects when there are no shadowed globals", () => {
+    assertHasShadowedGlobals(
+      `
+      import a from 'a';
+      
+      export const b = 3;
+    `,
+      false,
+    );
+  });
+});


### PR DESCRIPTION
We'll want top-level declaration detection for #228 anyway, and
hasShadowedGlobals was buggy because it was treating export declarations as
shadowing themselves, so this adds some bookkeeping so we know when a
declaration is top-level or not.

This doesn't affect correctness, it was just an optimization that wasn't kicking
in when it was supposed to.

Tracking scope depth throughout the parser is a little scary and adds another
field to the state, so there may be a way to improve it in the future, but it
certainly should work for now.