### PR TITLE
Implement react-hot-loader transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ are four main transforms that you may want to enable:
   `const enum`s that need cross-file compilation.
 * **flow**:  Removes Flow type annotations. Does not check types.
 * **imports**: Transforms ES Modules (`import`/`export`) to CommonJS
-  (`require`/`module.exports`) using the same approach as Babel 6 and TypeScript
+  (`require`/`module.exports`) using the same approach as Babel and TypeScript
   with `--esModuleInterop`. Also includes dynamic `import`.
+* **react-hot-loader**: Performs the equivalent of the `react-hot-loader/babel`
+  transform in the [react-hot-loader](https://github.com/gaearon/react-hot-loader)
+  project. This enables advanced hot reloading use cases such as editing of
+  bound methods.
 
 The following proposed JS features are built-in and always transformed:
 * [Class fields](https://github.com/tc39/proposal-class-fields): `class C { x = 1; }`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import RootTransformer from "./transformers/RootTransformer";
 import formatTokens from "./util/formatTokens";
 import getTSImportedNames from "./util/getTSImportedNames";
 
-export type Transform = "jsx" | "typescript" | "flow" | "imports";
+export type Transform = "jsx" | "typescript" | "flow" | "imports" | "react-hot-loader";
 
 export interface SourceMapOptions {
   /**

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -34,6 +34,9 @@ export function parseBindingIdentifier(isBlockScope: boolean): void {
 }
 
 export function markPriorBindingIdentifier(isBlockScope: boolean): void {
+  if (state.isType) {
+    return;
+  }
   if (state.scopeDepth === 0) {
     state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.TopLevelDeclaration;
   } else {

--- a/src/transformers/ReactHotLoaderTransformer.ts
+++ b/src/transformers/ReactHotLoaderTransformer.ts
@@ -1,0 +1,66 @@
+import {IdentifierRole} from "../parser/tokenizer";
+import TokenProcessor from "../TokenProcessor";
+import Transformer from "./Transformer";
+
+export default class ReactHotLoaderTransformer extends Transformer {
+  private extractedDefaultExportName: string | null = null;
+
+  constructor(readonly tokens: TokenProcessor, readonly filePath: string) {
+    super();
+  }
+
+  setExtractedDefaultExportName(extractedDefaultExportName: string): void {
+    this.extractedDefaultExportName = extractedDefaultExportName;
+  }
+
+  getPrefixCode(): string {
+    return `
+      (function () {
+        var enterModule = require('react-hot-loader').enterModule;
+        enterModule && enterModule(module);
+      })();`
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  getSuffixCode(): string {
+    const topLevelNames = new Set();
+    for (const token of this.tokens.tokens) {
+      if (
+        token.identifierRole === IdentifierRole.TopLevelDeclaration ||
+        token.identifierRole === IdentifierRole.ObjectShorthandTopLevelDeclaration
+      ) {
+        topLevelNames.add(this.tokens.identifierNameForToken(token));
+      }
+    }
+    const namesToRegister = Array.from(topLevelNames).map((name) => ({
+      variableName: name,
+      uniqueLocalName: name,
+    }));
+    if (this.extractedDefaultExportName) {
+      namesToRegister.push({
+        variableName: this.extractedDefaultExportName,
+        uniqueLocalName: "default",
+      });
+    }
+    return `
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+  var leaveModule = require('react-hot-loader').leaveModule;
+  if (!reactHotLoader) {
+    return;
+  }
+${namesToRegister
+      .map(
+        ({variableName, uniqueLocalName}) =>
+          `  reactHotLoader.register(${variableName}, "${uniqueLocalName}", "${this.filePath}");`,
+      )
+      .join("\n")}
+  leaveModule(module);
+})();`;
+  }
+
+  process(): boolean {
+    return false;
+  }
+}

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -4,7 +4,7 @@ import {getFormattedTokens} from "../src";
 
 describe("getFormattedTokens", () => {
   it("formats a simple program", () => {
-    assert.equal(
+    assert.strictEqual(
       getFormattedTokens(
         `\
 if (foo) {

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -7,3 +7,6 @@ if (obj != null) { for (var key in obj) { \
 if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } \
 newObj.default = obj; return newObj; } }`;
 export const ESMODULE_PREFIX = 'Object.defineProperty(exports, "__esModule", {value: true});';
+export const RHL_PREFIX = `(function () { \
+var enterModule = require('react-hot-loader').enterModule; enterModule && enterModule(module); \
+})();`;

--- a/test/react-hot-loader-test.ts
+++ b/test/react-hot-loader-test.ts
@@ -1,0 +1,203 @@
+import {Transform} from "../src";
+import {ESMODULE_PREFIX, IMPORT_DEFAULT_PREFIX, RHL_PREFIX} from "./prefixes";
+import {assertResult} from "./util";
+
+function assertCJSResult(
+  code: string,
+  expectedResult: string,
+  extraTransforms: Array<Transform> = [],
+): void {
+  assertResult(code, expectedResult, {
+    transforms: ["jsx", "imports", "react-hot-loader", ...extraTransforms],
+    filePath: "sample.tsx",
+  });
+}
+
+function assertESMResult(
+  code: string,
+  expectedResult: string,
+  extraTransforms: Array<Transform> = [],
+): void {
+  assertResult(code, expectedResult, {
+    transforms: ["jsx", "react-hot-loader", ...extraTransforms],
+    filePath: "sample.tsx",
+  });
+}
+
+describe("transform react-hot-loader", () => {
+  it("transforms common cases in CJS mode", () => {
+    assertCJSResult(
+      `
+      import React from 'react';
+      
+      const x = 3;
+      
+      function blah() {
+      }
+      
+      class Foo extends React.Component {
+        _handleSomething = () => {
+          return 3;
+        };
+      
+        render() {
+          return <span onChange={this._handleSomething} />;
+        }
+      }
+      
+      class SomeOtherClass {
+        test() {}
+      }
+      
+      export default 12;
+    `,
+      `"use strict";const _jsxFileName = "sample.tsx";${RHL_PREFIX}${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
+      
+      const x = 3;
+      
+      function blah() {
+      }
+      
+      class Foo extends _react2.default.Component {__reactstandin__regenerateByEval(key, code) {this[key] = eval(code);}constructor(...args) { super(...args); Foo.prototype.__init.call(this); }
+        __init() {this._handleSomething = () => {
+          return 3;
+        }}
+      
+        render() {
+          return _react2.default.createElement('span', { onChange: this._handleSomething, __self: this, __source: {fileName: _jsxFileName, lineNumber: 15}} );
+        }
+      }
+      
+      class SomeOtherClass {__reactstandin__regenerateByEval(key, code) {this[key] = eval(code);}
+        test() {}
+      }
+      
+      let _default; exports. default = _default = 12;
+    
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+  var leaveModule = require('react-hot-loader').leaveModule;
+  if (!reactHotLoader) {
+    return;
+  }
+  reactHotLoader.register(x, "x", "sample.tsx");
+  reactHotLoader.register(blah, "blah", "sample.tsx");
+  reactHotLoader.register(Foo, "Foo", "sample.tsx");
+  reactHotLoader.register(SomeOtherClass, "SomeOtherClass", "sample.tsx");
+  reactHotLoader.register(_default, "default", "sample.tsx");
+  leaveModule(module);
+})();`,
+    );
+  });
+
+  it("transforms common cases in ESM mode", () => {
+    assertESMResult(
+      `
+      import React from 'react';
+      
+      const x = 3;
+      
+      function blah() {
+      }
+      
+      class Foo extends React.Component {
+        _handleSomething = () => {
+          return 3;
+        };
+      
+        render() {
+          return <span onChange={this._handleSomething} />;
+        }
+      }
+      
+      class SomeOtherClass {
+        test() {}
+      }
+      
+      export default 12;
+    `,
+      `const _jsxFileName = "sample.tsx";${RHL_PREFIX}
+      import React from 'react';
+      
+      const x = 3;
+      
+      function blah() {
+      }
+      
+      class Foo extends React.Component {__reactstandin__regenerateByEval(key, code) {this[key] = eval(code);}constructor(...args) { super(...args); Foo.prototype.__init.call(this); }
+        __init() {this._handleSomething = () => {
+          return 3;
+        }}
+      
+        render() {
+          return React.createElement('span', { onChange: this._handleSomething, __self: this, __source: {fileName: _jsxFileName, lineNumber: 15}} );
+        }
+      }
+      
+      class SomeOtherClass {__reactstandin__regenerateByEval(key, code) {this[key] = eval(code);}
+        test() {}
+      }
+      
+      let _default; export default _default = 12;
+    
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+  var leaveModule = require('react-hot-loader').leaveModule;
+  if (!reactHotLoader) {
+    return;
+  }
+  reactHotLoader.register(x, "x", "sample.tsx");
+  reactHotLoader.register(blah, "blah", "sample.tsx");
+  reactHotLoader.register(Foo, "Foo", "sample.tsx");
+  reactHotLoader.register(SomeOtherClass, "SomeOtherClass", "sample.tsx");
+  reactHotLoader.register(_default, "default", "sample.tsx");
+  leaveModule(module);
+})();`,
+    );
+  });
+
+  it("does not treat function type params as top-level declarations", () => {
+    assertESMResult(
+      `
+      type Reducer<T, U> = (u: U, t: T) => U;
+      const f = (x: number) => x + 1;
+    `,
+      `${RHL_PREFIX}
+      
+      const f = (x) => x + 1;
+    
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+  var leaveModule = require('react-hot-loader').leaveModule;
+  if (!reactHotLoader) {
+    return;
+  }
+  reactHotLoader.register(f, "f", "sample.tsx");
+  leaveModule(module);
+})();`,
+      ["typescript"],
+    );
+  });
+
+  it("does not extract default to a variable when it already has a name", () => {
+    assertESMResult(
+      `
+      export default function add() {}
+    `,
+      `${RHL_PREFIX}
+      export default function add() {}
+    
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+  var leaveModule = require('react-hot-loader').leaveModule;
+  if (!reactHotLoader) {
+    return;
+  }
+  reactHotLoader.register(add, "add", "sample.tsx");
+  leaveModule(module);
+})();`,
+      ["typescript"],
+    );
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,7 +7,7 @@ export function assertResult(
   expectedResult: string,
   options: Options = {transforms: ["jsx", "imports"]},
 ): void {
-  assert.equal(transform(code, options).code, expectedResult);
+  assert.strictEqual(transform(code, options).code, expectedResult);
 }
 
 export function devProps(lineNumber: number): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,6 @@
   ],
   "exclude": [
     "benchmark/sample",
+    "example-runner/example-repos"
   ]
 }


### PR DESCRIPTION
Fixes #228

Some details:
* An eval snippet needed to be added to each class, which I decided to do
  unconditionally for simplicity.
* A previous change already comptued the top-level declared variables, so I
  could just use those.
* There was a bug where parameters in arrow function types were seen as
  top-level variables, so I changed it so types are never considered variable
  declarations.
* In order to register the default export, we need to extract it to a variable,
  which required modifying both import transformers to handle that as a special
  case.
* The ReactHotLoaderTransformer doesn't actually participate in normal
  transform, it just adds the snippets to the start and end.

Cases not handled yet that could be handled in the future:
* Avoid treating `require` statements as top-level declarations.
* Skip react and react-hot-loader files themselves (Sucrase shouldn't be running
  on them anyway).

I tested this end-to-end on a small app to make sure hot reloading works,
including for bound methods.