### PR TITLE
Fix build process to produce types in the right place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 dist
 dist-self-build
+dist-types
 example-runner/example-repos
 integrations/gulp-plugin/dist
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "sucrase-node script/build.ts",
     "fast-build": "sucrase-node script/build.ts --fast",
-    "clean": "rm -rf ./build ./dist ./dist-self-build ./example-runner/example-repos",
+    "clean": "rm -rf ./build ./dist ./dist-self-build ./dist-types ./example-runner/example-repos",
     "generate": "sucrase-node generator/generate.ts",
     "benchmark": "sucrase-node benchmark/benchmark.ts",
     "microbenchmark": "sucrase-node benchmark/microbenchmark.ts",

--- a/script/build.ts
+++ b/script/build.ts
@@ -1,5 +1,6 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
+import mergeDirectoryContents from "./mergeDirectoryContents";
 import run from "./run";
 
 const SUCRASE = "./node_modules/.bin/sucrase";
@@ -34,6 +35,7 @@ async function buildSucrase(): Promise<void> {
   await run(`${SUCRASE} ./src -d ./dist --transforms imports,typescript -q`);
   if (!fast) {
     await run(`rm -rf ./dist-self-build`);
+    await run(`rm -rf ./dist-types`);
     // The installed Sucrase version is always the previous version, but released versions of
     // Sucrase should be self-compiled, so we do a multi-phase compilation. We compile Sucrase with
     // the previous version, then use it to compile the current code, then use that to compile the
@@ -51,7 +53,8 @@ async function buildSucrase(): Promise<void> {
     );
     await run("diff -r ./dist ./dist-self-build");
     // Also add in .d.ts files from tsc, which only need to be compiled once.
-    await run(`${TSC} --emitDeclarationOnly --project ./src --outDir ./dist`);
+    await run(`${TSC} --emitDeclarationOnly --project ./src --outDir ./dist-types`);
+    await mergeDirectoryContents("./dist-types/src", "./dist");
     // Link all integrations to Sucrase so that all building/linting/testing is up to date.
     await run("yarn link");
   }

--- a/script/mergeDirectoryContents.ts
+++ b/script/mergeDirectoryContents.ts
@@ -1,0 +1,20 @@
+import {copyFile, exists, mkdir, readdir, stat} from "mz/fs";
+import {join} from "path";
+
+export default async function mergeDirectoryContents(
+  srcDirPath: string,
+  destDirPath: string,
+): Promise<void> {
+  if (!(await exists(destDirPath))) {
+    await mkdir(destDirPath);
+  }
+  for (const child of await readdir(srcDirPath)) {
+    const srcChildPath = join(srcDirPath, child);
+    const destChildPath = join(destDirPath, child);
+    if ((await stat(srcChildPath)).isDirectory()) {
+      await mergeDirectoryContents(srcChildPath, destChildPath);
+    } else {
+      await copyFile(srcChildPath, destChildPath);
+    }
+  }
+}

--- a/script/mz.d.ts
+++ b/script/mz.d.ts
@@ -1,0 +1,6 @@
+import "mz/fs";
+
+declare module "mz/fs" {
+  // copyFile isn't in the typedefs yet, so add it manually.
+  export function copyFile(oldPath: string, newPath: string): Promise<void>;
+}


### PR DESCRIPTION
PR #372 changed the tsconfig to use `include`, which changed the way that type
generation deals with directories. Now, we can't use the automatic directory
merging, so we need to output code to another directory and then merge it with a
custom function.