### PR TITLE
Add support for dynamic import() syntax in TS types

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -145,7 +145,24 @@ function tsParseThisTypeNode(): void {
 
 function tsParseTypeQuery(): void {
   expect(tt._typeof);
-  tsParseEntityName();
+  if (match(tt._import)) {
+    tsParseImportType();
+  } else {
+    tsParseEntityName();
+  }
+}
+
+function tsParseImportType(): void {
+  expect(tt._import);
+  expect(tt.parenL);
+  expect(tt.string);
+  expect(tt.parenR);
+  if (eat(tt.dot)) {
+    tsParseEntityName();
+  }
+  if (match(tt.lessThan)) {
+    tsParseTypeArguments();
+  }
 }
 
 function tsParseTypeParameter(): void {
@@ -410,6 +427,9 @@ function tsParseNonArrayType(): void {
     }
     case tt._typeof:
       tsParseTypeQuery();
+      return;
+    case tt._import:
+      tsParseImportType();
       return;
     case tt.braceL:
       if (tsLookaheadIsStartOfMappedType()) {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1324,4 +1324,21 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("handles import() types", () => {
+    assertTypeScriptESMResult(
+      `
+      type T1 = import("./foo");
+      type T2 = typeof import("./bar");
+      type T3 = import("./bar").Point;
+      type T4 = import("./utils").HashTable<number>;
+    `,
+      `
+      
+
+
+
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Turns out this didn't work before, and I tried to use it when setting up code
splitting in the playground. This is mostly based on `parseImportType` from
the TypeScript codebase.