### PR TITLE
Optimize initial JS load for playground

### DIFF
--- a/website/config/env.js
+++ b/website/config/env.js
@@ -18,6 +18,8 @@ function getClientEnvironment(publicUrl) {
     // This should only be used as an escape hatch. Normally you would put
     // images into the `src` and `import` them in code to get their paths.
     PUBLIC_URL: publicUrl,
+    // eslint-disable-next-line global-require
+    SUCRASE_VERSION: require("sucrase").getVersion(),
   };
   // Stringify all values so we can feed into Webpack DefinePlugin
   const stringified = {

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,7 +1,6 @@
 import {css, StyleSheet} from "aphrodite";
 import React, {Component} from "react";
 import {hot} from "react-hot-loader";
-import {getVersion} from "sucrase";
 
 import {
   DEFAULT_COMPARE_WITH_BABEL,
@@ -11,7 +10,7 @@ import {
   INITIAL_CODE,
   TRANSFORMS,
 } from "./Constants";
-import Editor from "./Editor";
+import EditorWrapper from "./EditorWrapper";
 import OptionBox from "./OptionBox";
 import {loadHashState, saveHashState} from "./URLHashState";
 import * as WorkerClient from "./WorkerClient";
@@ -33,8 +32,6 @@ interface State {
 }
 
 class App extends Component<{}, State> {
-  editors: {[editorName: string]: Editor | null};
-
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -67,8 +64,6 @@ class App extends Component<{}, State> {
     ) {
       this.state = {...this.state, showMore: true};
     }
-
-    this.editors = {};
   }
 
   componentDidMount(): void {
@@ -209,22 +204,19 @@ class App extends Component<{}, State> {
         </div>
 
         <div className={css(styles.editors)}>
-          <Editor
-            ref={(e) => (this.editors["input"] = e)}
+          <EditorWrapper
             label="Your code"
             code={this.state.code}
             onChange={this._handleCodeChange}
           />
-          <Editor
-            ref={(e) => (this.editors["sucrase"] = e)}
+          <EditorWrapper
             label="Transformed with Sucrase"
             code={sucraseCode}
             timeMs={sucraseTimeMs}
             isReadOnly={true}
           />
           {this.state.compareWithBabel && (
-            <Editor
-              ref={(e) => (this.editors["babel"] = e)}
+            <EditorWrapper
               label="Transformed with Babel"
               code={babelCode}
               timeMs={babelTimeMs}
@@ -232,8 +224,7 @@ class App extends Component<{}, State> {
             />
           )}
           {this.state.compareWithTypeScript && (
-            <Editor
-              ref={(e) => (this.editors["typescript"] = e)}
+            <EditorWrapper
               label="Transformed with TypeScript"
               code={typeScriptCode}
               timeMs={typeScriptTimeMs}
@@ -241,8 +232,7 @@ class App extends Component<{}, State> {
             />
           )}
           {this.state.showTokens && (
-            <Editor
-              ref={(e) => (this.editors["tokens"] = e)}
+            <EditorWrapper
               label="Tokens"
               code={tokensStr}
               isReadOnly={true}
@@ -257,7 +247,7 @@ class App extends Component<{}, State> {
           <a className={css(styles.link)} href="https://www.npmjs.com/package/sucrase">
             sucrase
           </a>{" "}
-          {getVersion()}
+          {process.env.SUCRASE_VERSION}
         </span>
       </div>
     );

--- a/website/src/Editor.tsx
+++ b/website/src/Editor.tsx
@@ -1,23 +1,22 @@
-import {css, StyleSheet} from "aphrodite";
 import {editor} from "monaco-editor";
 import React, {Component} from "react";
-import MonacoEditor, {EditorDidMount} from "react-monaco-editor";
-import {AutoSizer} from "react-virtualized";
+import {EditorDidMount} from "react-monaco-editor";
 
 interface EditorProps {
-  label: string;
+  MonacoEditor: typeof import("react-monaco-editor").default;
   code: string;
-  timeMs?: number | "LOADING" | null;
   onChange?: (code: string) => void;
   isReadOnly?: boolean;
   isPlaintext?: boolean;
   options?: editor.IEditorConstructionOptions;
+  width: number;
+  height: number;
 }
 
 export default class Editor extends Component<EditorProps> {
   editor: editor.IStandaloneCodeEditor | null = null;
 
-  componentDidMount(): void {
+  async componentDidMount(): Promise<void> {
     setTimeout(this.invalidate, 0);
   }
 
@@ -36,68 +35,32 @@ export default class Editor extends Component<EditorProps> {
     }
   };
 
-  _formatTime(): string {
-    const {timeMs} = this.props;
-    if (timeMs == null) {
-      return "";
-    } else if (timeMs === "LOADING") {
-      return " (...)";
-    } else {
-      return ` (${Math.round(timeMs * 100) / 100}ms)`;
-    }
-  }
-
   render(): JSX.Element {
-    const {label, code, onChange, isReadOnly, isPlaintext, options} = this.props;
+    const {
+      MonacoEditor,
+      code,
+      onChange,
+      isReadOnly,
+      isPlaintext,
+      options,
+      width,
+      height,
+    } = this.props;
     return (
-      <div className={css(styles.editor)}>
-        <span className={css(styles.label)}>
-          {label}
-          {this._formatTime()}
-        </span>
-        <span className={css(styles.container)}>
-          <AutoSizer onResize={this.invalidate} defaultWidth={300} defaultHeight={300}>
-            {({width, height}) => (
-              <MonacoEditor
-                editorDidMount={this._editorDidMount}
-                width={width}
-                height={height - 30}
-                language={isPlaintext ? undefined : "typescript"}
-                theme="vs-dark"
-                value={code}
-                onChange={onChange}
-                options={{
-                  minimap: {enabled: false},
-                  readOnly: isReadOnly,
-                  ...options,
-                }}
-              />
-            )}
-          </AutoSizer>
-        </span>
-      </div>
+      <MonacoEditor
+        editorDidMount={this._editorDidMount}
+        width={width}
+        height={height}
+        language={isPlaintext ? undefined : "typescript"}
+        theme="vs-dark"
+        value={code}
+        onChange={onChange}
+        options={{
+          minimap: {enabled: false},
+          readOnly: isReadOnly,
+          ...options,
+        }}
+      />
     );
   }
 }
-
-const styles = StyleSheet.create({
-  editor: {
-    display: "flex",
-    flexDirection: "column",
-    minWidth: 300,
-    height: "100%",
-    flex: 1,
-    // When adding a third editor, we need the container size to shrink so that
-    // the Monaco layout code will adjust to the container size.
-    overflowX: "hidden",
-    margin: 8,
-  },
-  label: {
-    color: "white",
-    lineHeight: '30px',
-    padding: 8,
-  },
-  container: {
-    height: "100%",
-  },
-});

--- a/website/src/EditorWrapper.tsx
+++ b/website/src/EditorWrapper.tsx
@@ -1,0 +1,114 @@
+import {css, StyleSheet} from "aphrodite";
+import {editor} from "monaco-editor";
+import React, {Component} from "react";
+import {AutoSizer} from "react-virtualized/dist/es/AutoSizer";
+
+import Editor from "./Editor";
+import FallbackEditor from "./FallbackEditor";
+
+interface EditorWrapperProps {
+  label: string;
+  timeMs?: number | "LOADING" | null;
+  code: string;
+  onChange?: (code: string) => void;
+  isReadOnly?: boolean;
+  isPlaintext?: boolean;
+  options?: editor.IEditorConstructionOptions;
+}
+
+interface State {
+  MonacoEditor: typeof import("react-monaco-editor").default | null;
+}
+
+export default class EditorWrapper extends Component<EditorWrapperProps, State> {
+  state: State = {
+    MonacoEditor: null,
+  };
+
+  editor: Editor | null = null;
+
+  async componentDidMount(): Promise<void> {
+    this.setState({MonacoEditor: (await import("react-monaco-editor")).default});
+  }
+
+  invalidate = () => {
+    if (this.editor) {
+      this.editor.invalidate();
+    }
+  };
+
+  _formatTime(): string {
+    const {timeMs} = this.props;
+    if (timeMs == null) {
+      return "";
+    } else if (timeMs === "LOADING") {
+      return " (...)";
+    } else {
+      return ` (${Math.round(timeMs * 100) / 100}ms)`;
+    }
+  }
+
+  render(): JSX.Element {
+    const {MonacoEditor} = this.state;
+    const {label, code, onChange, isReadOnly, isPlaintext, options} = this.props;
+    return (
+      <div className={css(styles.editor)}>
+        <span className={css(styles.label)}>
+          {label}
+          {this._formatTime()}
+        </span>
+        <span className={css(styles.container)}>
+          <AutoSizer onResize={this.invalidate} defaultWidth={300} defaultHeight={300}>
+            {({width, height}) =>
+              MonacoEditor ? (
+                <Editor
+                  ref={(e) => {
+                    this.editor = e;
+                  }}
+                  MonacoEditor={MonacoEditor}
+                  width={width}
+                  height={height - 30}
+                  code={code}
+                  onChange={onChange}
+                  isPlaintext={isPlaintext}
+                  isReadOnly={isReadOnly}
+                  options={options}
+                />
+              ) : (
+                <FallbackEditor
+                  width={width}
+                  height={height - 30}
+                  code={code}
+                  onChange={onChange}
+                  isReadOnly={isReadOnly}
+                />
+              )
+            }
+          </AutoSizer>
+        </span>
+      </div>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  editor: {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: 300,
+    height: "100%",
+    flex: 1,
+    // When adding a third editor, we need the container size to shrink so that
+    // the Monaco layout code will adjust to the container size.
+    overflowX: "hidden",
+    margin: 8,
+  },
+  label: {
+    color: "white",
+    lineHeight: "30px",
+    padding: 8,
+  },
+  container: {
+    height: "100%",
+  },
+});

--- a/website/src/FallbackEditor.tsx
+++ b/website/src/FallbackEditor.tsx
@@ -1,0 +1,56 @@
+import {css, StyleSheet} from "aphrodite";
+import React from "react";
+
+interface FallbackEditorProps {
+  width: number;
+  height: number;
+  code: string;
+  onChange?: (code: string) => void;
+  isReadOnly?: boolean;
+}
+
+/**
+ * Clone of the default styles in the Monaco editor to get something as close as possible
+ * while the real editor is loading. Ideally, all text is positioned exactly the same when
+ * the editor loads, and line numbers, syntax highlighting, etc appear to enhance the
+ * existing text rather than replacing it.
+ */
+export default function FallbackEditor({
+  width,
+  height,
+  code,
+  onChange,
+  isReadOnly,
+}: FallbackEditorProps): JSX.Element {
+  return (
+    <textarea
+      className={css(styles.editor)}
+      style={{width, height}}
+      value={code}
+      onChange={
+        onChange &&
+        ((e) => {
+          onChange(e.target.value);
+        })
+      }
+      spellCheck={false}
+      readOnly={isReadOnly}
+      wrap="off"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  editor: {
+    border: 0,
+    color: "#d4d4d4",
+    backgroundColor: "#1e1e1e",
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    fontSize: 12,
+    resize: "none",
+    outline: 0,
+    padding: 0,
+    paddingLeft: 62,
+    lineHeight: "18px",
+  },
+});


### PR DESCRIPTION
* Instead of loading monaco as part of the initial JS load, we now async-load it
  and show in its place a textarea component with the same styles.
* Instead of loading all of Sucrase just to get its version during render, we
  now compute the version at build time and inject it into the JS.
* Instead of loading all of react-virtualized just for AutoSizer, we just load
  that one part.

These changes bring the uncompressed JS size down from 2.6MB to 191KB.