### PR TITLE
Use async loading for worker chunks

### DIFF
--- a/website/config/webpack.config.dev.js
+++ b/website/config/webpack.config.dev.js
@@ -7,6 +7,7 @@ const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const CaseSensitivePathsPlugin = require("case-sensitive-paths-webpack-plugin");
 const InterpolateHtmlPlugin = require("react-dev-utils/InterpolateHtmlPlugin");
 const WatchMissingNodeModulesPlugin = require("react-dev-utils/WatchMissingNodeModulesPlugin");
+const WorkerPlugin = require("worker-plugin");
 const getClientEnvironment = require("./env");
 const paths = require("./paths");
 
@@ -54,9 +55,9 @@ module.exports = {
     // This does not produce a real file. It's just the virtual path that is
     // served by WebpackDevServer in development. This is the JS bundle
     // containing code from all our entry points, and the Webpack runtime.
-    filename: "static/js/bundle.js",
+    filename: "bundle.js",
     // There are also additional JS chunk files if you use code splitting.
-    chunkFilename: "static/js/[name].chunk.js",
+    chunkFilename: "[name].chunk.js",
     // This is the URL that app is served from. We use "/" in development.
     publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
@@ -77,10 +78,6 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       {parser: {requireEnsure: false}},
-      {
-        test: /\.worker\.ts$/,
-        use: {loader: "worker-loader"},
-      },
       {
         type: "javascript/auto",
         test: /\.mjs$/,
@@ -169,6 +166,7 @@ module.exports = {
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new MonacoWebpackPlugin({languages: ["typescript"]}),
+    new WorkerPlugin(),
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/website/config/webpack.config.prod.js
+++ b/website/config/webpack.config.prod.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const InterpolateHtmlPlugin = require("react-dev-utils/InterpolateHtmlPlugin");
+const WorkerPlugin = require("worker-plugin");
 const paths = require("./paths");
 const getClientEnvironment = require("./env");
 
@@ -44,8 +45,8 @@ module.exports = {
     // Generated JS file names (with nested folders).
     // There will be one main bundle, and one file per asynchronous chunk.
     // We don't currently advertise code splitting but Webpack supports it.
-    filename: "static/js/[name].[chunkhash:8].js",
-    chunkFilename: "static/js/[name].[chunkhash:8].chunk.js",
+    filename: "[name].[hash:8].js",
+    chunkFilename: "[name].[hash:8].chunk.js",
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
@@ -66,10 +67,6 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       {parser: {requireEnsure: false}},
-      {
-        test: /\.worker\.ts$/,
-        use: {loader: "worker-loader"},
-      },
       {
         type: "javascript/auto",
         test: /\.mjs$/,
@@ -158,13 +155,8 @@ module.exports = {
     new ManifestPlugin({
       fileName: "asset-manifest.json",
     }),
-    // Moment.js is an extremely popular library that bundles large locale files
-    // by default due to how Webpack interprets its code. This is a practical
-    // solution that requires the user to opt into importing specific locales.
-    // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-    // You can remove this if you don't use Moment.js:
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new MonacoWebpackPlugin({languages: ["typescript"]}),
+    new WorkerPlugin(),
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
     "webpack": "^4.28.2",
     "webpack-dev-server": "2.8.2",
     "webpack-manifest-plugin": "^2.0.4",
-    "worker-loader": "^2.0.0"
+    "worker-plugin": "^3.0.0"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -29,6 +29,8 @@ interface State {
   typeScriptTimeMs: number | null | "LOADING";
   tokensStr: string;
   showMore: boolean;
+  babelLoaded: boolean;
+  typeScriptLoaded: boolean;
 }
 
 class App extends Component<{}, State> {
@@ -49,6 +51,8 @@ class App extends Component<{}, State> {
       typeScriptTimeMs: null,
       tokensStr: "",
       showMore: false,
+      babelLoaded: false,
+      typeScriptLoaded: false,
     };
     const hashState = loadHashState();
     if (hashState) {
@@ -91,7 +95,9 @@ class App extends Component<{}, State> {
       this.state.selectedTransforms !== prevState.selectedTransforms ||
       this.state.compareWithBabel !== prevState.compareWithBabel ||
       this.state.compareWithTypeScript !== prevState.compareWithTypeScript ||
-      this.state.showTokens !== prevState.showTokens
+      this.state.showTokens !== prevState.showTokens ||
+      this.state.babelLoaded !== prevState.babelLoaded ||
+      this.state.typeScriptLoaded !== prevState.typeScriptLoaded
     ) {
       this.postConfigToWorker();
     }
@@ -208,12 +214,14 @@ class App extends Component<{}, State> {
             label="Your code"
             code={this.state.code}
             onChange={this._handleCodeChange}
+            babelLoaded={this.state.babelLoaded}
           />
           <EditorWrapper
             label="Transformed with Sucrase"
             code={sucraseCode}
             timeMs={sucraseTimeMs}
             isReadOnly={true}
+            babelLoaded={this.state.babelLoaded}
           />
           {this.state.compareWithBabel && (
             <EditorWrapper
@@ -221,6 +229,7 @@ class App extends Component<{}, State> {
               code={babelCode}
               timeMs={babelTimeMs}
               isReadOnly={true}
+              babelLoaded={this.state.babelLoaded}
             />
           )}
           {this.state.compareWithTypeScript && (
@@ -229,6 +238,7 @@ class App extends Component<{}, State> {
               code={typeScriptCode}
               timeMs={typeScriptTimeMs}
               isReadOnly={true}
+              babelLoaded={this.state.babelLoaded}
             />
           )}
           {this.state.showTokens && (
@@ -240,6 +250,7 @@ class App extends Component<{}, State> {
               options={{
                 lineNumbers: (n) => (n > 1 ? String(n - 2) : ""),
               }}
+              babelLoaded={this.state.babelLoaded}
             />
           )}
         </div>

--- a/website/src/Babel.ts
+++ b/website/src/Babel.ts
@@ -1,0 +1,19 @@
+/**
+ * Single file expressing all Babel dependencies and applying all plugins so that they will be
+ * in a single webpack chunk.
+ */
+// @ts-ignore
+import {registerPlugin, transform} from "@babel/standalone";
+
+// @ts-ignore
+import NumericSeparatorPlugin from "@babel/plugin-proposal-numeric-separator";
+// @ts-ignore
+import DynamicImportPlugin from "babel-plugin-dynamic-import-node";
+// @ts-ignore
+import ReactHotLoaderPlugin from "react-hot-loader/babel";
+
+registerPlugin("proposal-numeric-separator", NumericSeparatorPlugin);
+registerPlugin("dynamic-import-node", DynamicImportPlugin);
+registerPlugin("react-hot-loader", ReactHotLoaderPlugin);
+
+export {transform};

--- a/website/src/EditorWrapper.tsx
+++ b/website/src/EditorWrapper.tsx
@@ -14,6 +14,7 @@ interface EditorWrapperProps {
   isReadOnly?: boolean;
   isPlaintext?: boolean;
   options?: editor.IEditorConstructionOptions;
+  babelLoaded: boolean;
 }
 
 interface State {
@@ -27,8 +28,10 @@ export default class EditorWrapper extends Component<EditorWrapperProps, State> 
 
   editor: Editor | null = null;
 
-  async componentDidMount(): Promise<void> {
-    this.setState({MonacoEditor: (await import("react-monaco-editor")).default});
+  async componentDidUpdate(prevProps: EditorWrapperProps): Promise<void> {
+    if (prevProps.babelLoaded !== this.props.babelLoaded) {
+      this.setState({MonacoEditor: (await import("react-monaco-editor")).default});
+    }
   }
 
   invalidate = () => {

--- a/website/src/WorkerProtocol.ts
+++ b/website/src/WorkerProtocol.ts
@@ -9,6 +9,11 @@ export type Message =
   | {type: "PROFILE_BABEL"}
   | {type: "PROFILE_TYPESCRIPT"};
 
+export type WorkerMessage =
+  | {type: "RESPONSE"; response: unknown}
+  | {type: "BABEL_LOADED"}
+  | {type: "TYPESCRIPT_LOADED"};
+
 export interface WorkerConfig {
   compareWithBabel: boolean;
   compareWithTypeScript: boolean;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3869,7 +3869,7 @@ loader-runner@^2.3.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.1.tgz#026f12fe7c3115992896ac02ba022ba92971b979"
   integrity sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==
 
-loader-utils@1.1.0, loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   integrity sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=
@@ -5508,7 +5508,7 @@ scheduler@^0.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.0, schema-utils@^0.4.4:
+schema-utils@^0.4.4:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -6674,13 +6674,12 @@ worker-farm@^1.3.1, worker-farm@^1.5.2:
   dependencies:
     errno "~0.1.7"
 
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+worker-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/worker-plugin/-/worker-plugin-3.0.0.tgz#70a64e732b3bf575ad5981071bc5f010dadd6f95"
+  integrity sha512-iLcZBwR3TZO2A8s4S+VNzvuCvAHeZx84IR/zE8O89E+VBTTdn73cwDaUoCroftwtW1Qo0mMxYkJqwf0hyFwmeA==
   dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
+    loader-utils "^1.1.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
The big challenge here was that webpack currently uses `importScripts` to load
chunks in a worker, which means it blocks the worker from operating while the
chunk is loading. Getting this working required a few details:

* Change the worker setup from worker-loader to worker-plugin. This changes the
  naming of chunks to be more predictable so they can be inferred from the JS
  side.
* In addition to delay-loading Babel and TypeScript, we call `fetch` on the
  chunk files in advance so that the `importScripts` call will pull from cache
  when it runs. In practice, this means that you can immediately see the Sucrase
  output and make changes to the code to get immediate results, even if Babel
  loading takes a very long time.
* Make a new file for all of the Babel dependencies in one so it doesn't get
  split into a separate chunk per plugin.
* When Babel and TypeScript finish loading, we need to inform the main thread so
  that it can try the computation again. This required generalizing the messages
  that the worker can send back to the main thread.
* For the initial user experience, getting Babel loaded is the highest priority,
  more important than monaco, so we use a prop to intentionally delay the
  beginning of monaco loading until Babel is done.