### PR TITLE
Fix playground hot reloading, simplify more webpack dev config

### DIFF
--- a/website/config/webpack.config.dev.js
+++ b/website/config/webpack.config.dev.js
@@ -30,22 +30,9 @@ module.exports = {
   // readable anyway.
   devtool: "eval",
   entry: [
-    // Include an alternative client for WebpackDevServer. A client's job is to
-    // connect to WebpackDevServer by a socket and get notified about changes.
-    // When you save a file, the client will either apply hot updates (in case
-    // of CSS changes), or refresh the page (in case of JS changes). When you
-    // make a syntax error, this client will display a syntax error overlay.
-    // Note: instead of the default WebpackDevServer client, we use a custom one
-    // to bring better experience for Create React App users. You can replace
-    // the line below with these two lines if you prefer the stock client:
-    // require.resolve('webpack-dev-server/client') + '?/',
-    // require.resolve('webpack/hot/dev-server'),
-    require.resolve("react-dev-utils/webpackHotDevClient"),
-    // Finally, this is your app's code:
+    `${require.resolve("webpack-dev-server/client")}?/`,
+    require.resolve("webpack/hot/only-dev-server"),
     paths.appIndexJs,
-    // We include the app code last so that if there is a runtime error during
-    // initialization, it doesn't blow up the WebpackDevServer client, and
-    // changing JS code would still trigger a refresh.
   ],
   output: {
     // Next line is not used in dev but WebpackDevServer crashes without it:

--- a/website/config/webpackDevServer.config.js
+++ b/website/config/webpackDevServer.config.js
@@ -41,9 +41,6 @@ module.exports = function(proxy, allowedHost) {
     // It is important to tell WebpackDevServer to use the same "root" path
     // as we specified in the config. In development, we always serve from /.
     publicPath: config.output.publicPath,
-    // WebpackDevServer is noisy by default so we emit custom message instead
-    // by listening to the compiler events with `compiler.plugin` calls above.
-    quiet: true,
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
     watchOptions: {
@@ -63,12 +60,6 @@ module.exports = function(proxy, allowedHost) {
     setup(app) {
       // This lets us open files from the runtime error overlay.
       app.use(errorOverlayMiddleware());
-      // This service worker file is effectively a 'no-op' that will reset any
-      // previous service worker registered for the same host:port combination.
-      // We do this in development to avoid hitting the production cache if
-      // it used the same host and port.
-      // https://github.com/facebookincubator/create-react-app/issues/2272#issuecomment-302832432
-      app.use(noopServiceWorkerMiddleware());
     },
   };
 };

--- a/website/scripts/start.js
+++ b/website/scripts/start.js
@@ -17,14 +17,8 @@ const fs = require("fs");
 const chalk = require("chalk");
 const webpack = require("webpack");
 const WebpackDevServer = require("webpack-dev-server");
-const clearConsole = require("react-dev-utils/clearConsole");
 const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
-const {
-  choosePort,
-  createCompiler,
-  prepareProxy,
-  prepareUrls,
-} = require("react-dev-utils/WebpackDevServerUtils");
+const {choosePort, prepareProxy, prepareUrls} = require("react-dev-utils/WebpackDevServerUtils");
 const openBrowser = require("react-dev-utils/openBrowser");
 const paths = require("../config/paths");
 const config = require("../config/webpack.config.dev");
@@ -51,10 +45,8 @@ choosePort(HOST, DEFAULT_PORT)
       return;
     }
     const protocol = process.env.HTTPS === "true" ? "https" : "http";
-    const appName = require(paths.appPackageJson).name;
     const urls = prepareUrls(protocol, HOST, port);
-    // Create a webpack compiler that is configured with custom messages.
-    const compiler = createCompiler(webpack, config, appName, urls, useYarn);
+    const compiler = webpack(config);
     // Load proxy config
     const proxySetting = require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(proxySetting, paths.appPublic);
@@ -65,9 +57,6 @@ choosePort(HOST, DEFAULT_PORT)
     devServer.listen(port, HOST, (err) => {
       if (err) {
         return console.log(err);
-      }
-      if (isInteractive) {
-        clearConsole();
       }
       console.log(chalk.cyan("Starting the development server...\n"));
       openBrowser(urls.localUrlForBrowser);


### PR DESCRIPTION
worker-plugin seems to cause an edit to its generated JS file on any edit to any
file, and it's never accepted as a hot module update, so webpack was refreshing
the page every time. To fix, I switched to use only-dev-server, so it still
shows a warning but doesn't refresh the page. Ideally it wouldn't be an edit or
would be accepted as a hot update, but this fixes things in practice.

I also got rid of some code that regularly clears the console, which makes it
easier to add console.logs to see what's happening within webpack.