### PR TITLE
Fix RHL transform to always use dev version, use new RHL API for website

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,6 +1,6 @@
 import {css, StyleSheet} from "aphrodite";
 import React, {Component} from "react";
-import {hot} from "react-hot-loader";
+import {hot} from "react-hot-loader/root";
 
 import {
   DEFAULT_COMPARE_WITH_BABEL,
@@ -265,7 +265,7 @@ class App extends Component<{}, State> {
   }
 }
 
-export default hot(module)(App);
+export default hot(App);
 
 const styles = StyleSheet.create({
   app: {

--- a/website/src/Babel.ts
+++ b/website/src/Babel.ts
@@ -10,7 +10,7 @@ import NumericSeparatorPlugin from "@babel/plugin-proposal-numeric-separator";
 // @ts-ignore
 import DynamicImportPlugin from "babel-plugin-dynamic-import-node";
 // @ts-ignore
-import ReactHotLoaderPlugin from "react-hot-loader/babel";
+import ReactHotLoaderPlugin from "react-hot-loader/dist/babel.development";
 
 registerPlugin("proposal-numeric-separator", NumericSeparatorPlugin);
 registerPlugin("dynamic-import-node", DynamicImportPlugin);


### PR DESCRIPTION
This fixes an issue where sucrase.io wasn't applying the transform right within
Babel because its environment was set to production.

Also switch website RHL usage to the new API that apparently works better.