### PR TITLE
Fix two usability bugs with website

### DIFF
--- a/website/src/EditorWrapper.tsx
+++ b/website/src/EditorWrapper.tsx
@@ -29,7 +29,7 @@ export default class EditorWrapper extends Component<EditorWrapperProps, State> 
   editor: Editor | null = null;
 
   async componentDidUpdate(prevProps: EditorWrapperProps): Promise<void> {
-    if (prevProps.babelLoaded !== this.props.babelLoaded) {
+    if (this.props.babelLoaded && !this.state.MonacoEditor) {
       this.setState({MonacoEditor: (await import("react-monaco-editor")).default});
     }
   }

--- a/website/src/URLHashState.ts
+++ b/website/src/URLHashState.ts
@@ -90,7 +90,7 @@ export function loadHashState(): Partial<BaseHashState> | null {
       }
     }
     // Deleting code and refreshing should give the default state again.
-    if (!result.code) {
+    if (result.code === "") {
       return null;
     }
     return result;


### PR DESCRIPTION
* We always want to load Monaco once Babel is loaded. Previously we were only
  doing it as a transition, which missed cases where we added an editor after
  initial pageload.
* Clearing the code should give it a fresh start, but leaving the code
  unspecified shouldn't. For example, it should be possible to link to the
  default code with TypeScript enabled instead of Babel.