### PR TITLE
Move close-paren to before arrow when removing arrow return types

### DIFF
--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -8,6 +8,9 @@ export default class FlowTransformer extends Transformer {
   }
 
   process(): boolean {
-    return this.rootTransformer.processPossibleTypeRange();
+    return (
+      this.rootTransformer.processPossibleArrowParamEnd() ||
+      this.rootTransformer.processPossibleTypeRange()
+    );
   }
 }

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -14,8 +14,10 @@ export default class TypeScriptTransformer extends Transformer {
   }
 
   process(): boolean {
-    const processedType = this.rootTransformer.processPossibleTypeRange();
-    if (processedType) {
+    if (
+      this.rootTransformer.processPossibleArrowParamEnd() ||
+      this.rootTransformer.processPossibleTypeRange()
+    ) {
       return true;
     }
     if (

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -1,5 +1,10 @@
 import {ESMODULE_PREFIX} from "./prefixes";
-import {assertResult} from "./util";
+import {assertExpectations, assertResult, Expectations} from "./util";
+
+function assertTypeScriptAndFlowExpectations(code: string, expectations: Expectations): void {
+  assertExpectations(code, expectations, {transforms: ["jsx", "imports", "typescript"]});
+  assertExpectations(code, expectations, {transforms: ["jsx", "imports", "flow"]});
+}
 
 function assertTypeScriptAndFlowResult(code: string, expectedResult: string): void {
   assertResult(code, expectedResult, {transforms: ["jsx", "imports", "typescript"]});
@@ -485,6 +490,20 @@ describe("type transforms", () => {
         return a;
       }
     `,
+    );
+  });
+
+  it("does not produce code with a syntax error on multiline return types", () => {
+    assertTypeScriptAndFlowExpectations(
+      `
+      const multiLineReturn = (
+        x: number
+      ): {
+        value: number;
+      } => ({value: x}); 
+      setOutput(multiLineReturn(5).value)
+    `,
+      {expectedOutput: 5},
     );
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,13 +1,36 @@
 import * as assert from "assert";
+import vm from "vm";
 
 import {Options, transform} from "../src";
+
+export interface Expectations {
+  expectedResult?: string;
+  expectedOutput?: unknown;
+}
+
+export function assertExpectations(
+  code: string,
+  expectations: Expectations,
+  options: Options,
+): void {
+  const resultCode = transform(code, options).code;
+  if ("expectedResult" in expectations) {
+    assert.strictEqual(resultCode, expectations.expectedResult);
+  }
+  if ("expectedOutput" in expectations) {
+    const outputs: Array<unknown> = [];
+    vm.runInNewContext(resultCode, {setOutput: (value: unknown) => outputs.push(value)});
+    assert.strictEqual(outputs.length, 1, "setOutput should be called exactly once");
+    assert.deepStrictEqual(outputs[0], expectations.expectedOutput);
+  }
+}
 
 export function assertResult(
   code: string,
   expectedResult: string,
   options: Options = {transforms: ["jsx", "imports"]},
 ): void {
-  assert.strictEqual(transform(code, options).code, expectedResult);
+  assertExpectations(code, {expectedResult}, options);
 }
 
 export function devProps(lineNumber: number): string {


### PR DESCRIPTION
Fixes #391

It's a bit ugly, but we now do a lookahead whenever we see a `):` with the `:`
as a type token. If the next non-type is an arrow, we move the `)` to just
before the arrow. This seems to work and seems to agree with
`processBalancedCode`.

I also added a new type of test that actually executes the resulting code and
asserts the output value from the code, which will probably be useful in the
future as well.