### PR TITLE
Avoid false positive when detecting if a class has a superclass

### DIFF
--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -172,7 +172,11 @@ function processClassHeader(tokens: TokenProcessor): ClassHeaderInfo {
     className = tokens.identifierName();
   }
   while (!tokens.matchesContextIdAndLabel(tt.braceL, contextId)) {
-    if (tokens.matches1(tt._extends)) {
+    // If this has a superclass, there will always be an `extends` token. If it doesn't have a
+    // superclass, only type parameters and `implements` clauses can show up here, all of which
+    // consist only of type tokens. A declaration like `class A<B extends C> {` should *not* count
+    // as having a superclass.
+    if (tokens.matches1(tt._extends) && !tokens.currentToken().isType) {
       hasSuperclass = true;
     }
     tokens.nextToken();

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1341,4 +1341,19 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("properly compiles class fields with extends in a type parameter", () => {
+    assertTypeScriptESMResult(
+      `
+      class A<B extends C> {
+        x = 1;
+      }
+    `,
+      `
+      class A {constructor() { A.prototype.__init.call(this); }
+        __init() {this.x = 1}
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #397

I'm fairly sure that all false positives are type tokens, so we can just make
sure that we only look for non-type `extends` tokens.