### PR TITLE
Fix TS import elision for JSX fragments and custom pragmas

### DIFF
--- a/src/CJSImportProcessor.ts
+++ b/src/CJSImportProcessor.ts
@@ -1,3 +1,4 @@
+import {Options} from "./index";
 import NameManager from "./NameManager";
 import {isDeclaration} from "./parser/tokenizer";
 import {ContextualKeyword} from "./parser/tokenizer/keywords";
@@ -40,6 +41,7 @@ export default class CJSImportProcessor {
     readonly nameManager: NameManager,
     readonly tokens: TokenProcessor,
     readonly enableLegacyTypeScriptModuleInterop: boolean,
+    readonly options: Options,
   ) {}
 
   getPrefixCode(): string {
@@ -97,7 +99,7 @@ export default class CJSImportProcessor {
    * bare imports.
    */
   pruneTypeOnlyImports(): void {
-    const nonTypeIdentifiers = getNonTypeIdentifiers(this.tokens);
+    const nonTypeIdentifiers = getNonTypeIdentifiers(this.tokens, this.options);
     for (const [path, importInfo] of this.importInfoByPath.entries()) {
       if (
         importInfo.hasBareImport ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
       nameManager,
       tokenProcessor,
       enableLegacyTypeScriptModuleInterop,
+      options,
     );
     importProcessor.preprocessTokens();
     // We need to mark shadowed globals after processing imports so we know that the globals are,

--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -1,3 +1,4 @@
+import {Options} from "../index";
 import NameManager from "../NameManager";
 import {ContextualKeyword} from "../parser/tokenizer/keywords";
 import {TokenType as tt} from "../parser/tokenizer/types";
@@ -18,10 +19,11 @@ export default class ESMImportTransformer extends Transformer {
     readonly nameManager: NameManager,
     readonly reactHotLoaderTransformer: ReactHotLoaderTransformer | null,
     readonly isTypeScriptTransformEnabled: boolean,
+    options: Options,
   ) {
     super();
     this.nonTypeIdentifiers = isTypeScriptTransformEnabled
-      ? getNonTypeIdentifiers(tokens)
+      ? getNonTypeIdentifiers(tokens, options)
       : new Set();
   }
 

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -78,6 +78,7 @@ export default class RootTransformer {
           this.nameManager,
           reactHotLoaderTransformer,
           transforms.includes("typescript"),
+          options,
         ),
       );
     }

--- a/src/util/getJSXPragmaInfo.ts
+++ b/src/util/getJSXPragmaInfo.ts
@@ -1,0 +1,22 @@
+import {Options} from "../index";
+
+export interface JSXPragmaInfo {
+  base: string;
+  suffix: string;
+  fragmentBase: string;
+  fragmentSuffix: string;
+}
+
+export default function getJSXPragmaInfo(options: Options): JSXPragmaInfo {
+  const [base, suffix] = splitPragma(options.jsxPragma || "React.createElement");
+  const [fragmentBase, fragmentSuffix] = splitPragma(options.jsxFragmentPragma || "React.Fragment");
+  return {base, suffix, fragmentBase, fragmentSuffix};
+}
+
+function splitPragma(pragma: string): [string, string] {
+  let dotIndex = pragma.indexOf(".");
+  if (dotIndex === -1) {
+    dotIndex = pragma.length;
+  }
+  return [pragma.slice(0, dotIndex), pragma.slice(dotIndex)];
+}

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -10,7 +10,9 @@ function assertHasShadowedGlobals(code: string, expected: boolean): void {
   const tokenProcessor = new TokenProcessor(code, file.tokens, false);
   const nameManager = new NameManager(tokenProcessor);
   nameManager.preprocessNames();
-  const importProcessor = new CJSImportProcessor(nameManager, tokenProcessor, false);
+  const importProcessor = new CJSImportProcessor(nameManager, tokenProcessor, false, {
+    transforms: [],
+  });
   importProcessor.preprocessTokens();
   assert.strictEqual(
     hasShadowedGlobals(tokenProcessor, importProcessor.getGlobalNames()),


### PR DESCRIPTION
Fixes #395

Previously, we added the `React` identifier as non-type identifier when seeing
any JSX name, but this meant that fragment syntax didn't keep that import. We
also shouldn't hard-code React, and instead use whatever the pragma base values
are.