### PR TITLE
Treat reserved words as invalid identifiers when handling enums

### DIFF
--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -81,19 +81,17 @@ export default class TypeScriptTransformer extends Transformer {
       }
       const nameToken = this.tokens.currentToken();
       let name;
-      let isValidIdentifier;
       let nameStringCode;
       if (nameToken.type === tt.name) {
         name = this.tokens.identifierNameForToken(nameToken);
-        isValidIdentifier = true;
         nameStringCode = `"${name}"`;
       } else if (nameToken.type === tt.string) {
         name = this.tokens.stringValueForToken(nameToken);
-        isValidIdentifier = isIdentifier(name);
         nameStringCode = this.tokens.code.slice(nameToken.start, nameToken.end);
       } else {
         throw new Error("Expected name or string at beginning of enum element.");
       }
+      const isValidIdentifier = isIdentifier(name);
       this.tokens.removeInitialToken();
 
       let valueIsString;

--- a/src/util/isIdentifier.ts
+++ b/src/util/isIdentifier.ts
@@ -1,5 +1,59 @@
 import {IS_IDENTIFIER_CHAR, IS_IDENTIFIER_START} from "../parser/util/identifier";
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
+// Hard-code a list of reserved words rather than trying to use keywords or contextual keywords
+// from the parser, since currently there are various exceptions, like `package` being reserved
+// but unused and various contextual keywords being reserved. Note that we assume that all code
+// compiled by Sucrase is in a module, so strict mode words and await are all considered reserved
+// here.
+const RESERVED_WORDS = new Set([
+  // Reserved keywords as of ECMAScript 2015
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+  // Future reserved keywords
+  "enum",
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "await",
+]);
+
 export default function isIdentifier(name: string): boolean {
   if (name.length === 0) {
     return false;
@@ -12,5 +66,5 @@ export default function isIdentifier(name: string): boolean {
       return false;
     }
   }
-  return true;
+  return !RESERVED_WORDS.has(name);
 }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -536,6 +536,8 @@ describe("typescript transform", () => {
         "",
         "D" = "foo".length,
         E = D / D,
+        "debugger" = 4,
+        default = 7,
         "!" = E << E,
         "\\n",
         ",",
@@ -549,6 +551,8 @@ describe("typescript transform", () => {
         Foo[Foo[""] = (A / 2) + 1] = "";
         const D = "foo".length; Foo[Foo["D"] = D] = "D";
         const E = D / D; Foo[Foo["E"] = E] = "E";
+        Foo[Foo["debugger"] = 4] = "debugger";
+        Foo[Foo["default"] = 7] = "default";
         Foo[Foo["!"] = E << E] = "!";
         Foo[Foo["\\n"] = (E << E) + 1] = "\\n";
         Foo[Foo[","] = ((E << E) + 1) + 1] = ",";


### PR DESCRIPTION
Fixes #392

There was already a code path for keys that couldn't be treated as regular
identifiers; with those, the variable declaration is omitted and we create a
special expression if necessary to add 1 to the previous value. Now, even for
regular identifiers, we see if the resulting identifier would be a JS reserve
word and treat it as a non-identifier if so. I had a few ideas on how to
reliably get a list of reserved words, but decided to just reference MDN since
there were enough edge cases with trying to modify the parser code.