### PR TITLE
Don't treat `/*/` as an entire block comment

### DIFF
--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -265,6 +265,7 @@ export function skipSpace(): void {
       case charCodes.slash:
         switch (input.charCodeAt(state.pos + 1)) {
           case charCodes.asterisk:
+            state.pos += 2;
             skipBlockComment();
             break;
 

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -747,4 +747,28 @@ describe("sucrase", () => {
   it("handles a file with only an assignment", () => {
     assertResult("a = 1", '"use strict";a = 1', {transforms: ["imports"]});
   });
+
+  it("handles a standalone comment that looks like it could be a regex", () => {
+    assertResult(
+      `
+      /*/*/;
+    `,
+      `
+      /*/*/;
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("handles a comment that looks like it could be a regex after a string", () => {
+    assertResult(
+      `
+      let thing = "sup" /*/*/;
+    `,
+      `
+      let thing = "sup" /*/*/;
+    `,
+      {transforms: []},
+    );
+  });
 });


### PR DESCRIPTION
Fixes #428

After seeing a `/*`, we were searching for a `*/`, but really we needed to
search starting at two past the start of the comment.