### PR TITLE
Fix implementation of JSX spread children

### DIFF
--- a/src/parser/plugins/jsx/index.ts
+++ b/src/parser/plugins/jsx/index.ts
@@ -139,11 +139,11 @@ function jsxParseEmptyExpression(): void {
 }
 
 // Parse JSX spread child
+// Does not parse the last token.
 function jsxParseSpreadChild(): void {
   expect(tt.braceL);
   expect(tt.ellipsis);
   parseExpression();
-  expect(tt.braceR);
 }
 
 // Parses JSX expression enclosed into curly brackets.
@@ -233,6 +233,7 @@ function jsxParseElementAt(): void {
         case tt.braceL:
           if (lookaheadType() === tt.ellipsis) {
             jsxParseSpreadChild();
+            nextJSXExprToken();
           } else {
             jsxParseExpressionContainer();
             nextJSXExprToken();

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -499,6 +499,17 @@ describe("transform JSX", () => {
     throws(() => transform("const x = <", {transforms: ["jsx"]}));
   });
 
+  it("handles spread children", () => {
+    assertResult(
+      `
+      const e = <A>{...b}</A>;
+    `,
+      `${JSX_PREFIX}
+      const e = React.createElement(A, {${devProps(2)}}, ...b);
+    `,
+    );
+  });
+
   describe("with production true", () => {
     it("handles no props", () => {
       assertResult(


### PR DESCRIPTION
Fixes #420

This was actually already handled by the parser carried over from Babel, but
there was a bug in the tokenization, since Sucrase always skips the last token
so we can get the proper token type for the next one. After fixing that bug,
everything seems to work; no transformer changes are needed because argument
spread syntax is the same as JSX child spread syntax.

As mentioned in #420, Babel disallows this syntax with React and TypeScript
seems to give the wrong result, but this change like a good idea regardless
since it's just a bug fix.