### PR TITLE
Elide type-only exports when the TS transform is enabled

### DIFF
--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -19,7 +19,12 @@ export enum IdentifierRole {
   ObjectShorthandFunctionScopedDeclaration,
   ObjectShorthandBlockScopedDeclaration,
   ObjectShorthand,
+  // Any identifier bound in an import statement, e.g. both A and b from
+  // `import A, * as b from 'A';`
+  ImportDeclaration,
   ObjectKey,
+  // The `foo` in `import {foo as bar} from "./abc";`.
+  ImportAccess,
 }
 
 export function isDeclaration(token: Token): boolean {
@@ -41,6 +46,15 @@ export function isNonTopLevelDeclaration(token: Token): boolean {
     role === IdentifierRole.BlockScopedDeclaration ||
     role === IdentifierRole.ObjectShorthandFunctionScopedDeclaration ||
     role === IdentifierRole.ObjectShorthandBlockScopedDeclaration
+  );
+}
+
+export function isTopLevelDeclaration(token: Token): boolean {
+  const role = token.identifierRole;
+  return (
+    role === IdentifierRole.TopLevelDeclaration ||
+    role === IdentifierRole.ObjectShorthandTopLevelDeclaration ||
+    role === IdentifierRole.ImportDeclaration
   );
 }
 
@@ -98,6 +112,7 @@ export class Token {
   // analysis.
   shadowsGlobal: boolean;
   contextId: number | null;
+  // For assignments, the index of the RHS. For export tokens, the end of the export.
   rhsEndIndex: number | null;
   // For class tokens, records if the class is a class expression or a class statement.
   isExpression: boolean;

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -33,10 +33,12 @@ export function parseBindingIdentifier(isBlockScope: boolean): void {
   markPriorBindingIdentifier(isBlockScope);
 }
 
+export function parseImportedIdentifier(): void {
+  parseIdentifier();
+  state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ImportDeclaration;
+}
+
 export function markPriorBindingIdentifier(isBlockScope: boolean): void {
-  if (state.isType) {
-    return;
-  }
   if (state.scopeDepth === 0) {
     state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.TopLevelDeclaration;
   } else {

--- a/src/transformers/ReactHotLoaderTransformer.ts
+++ b/src/transformers/ReactHotLoaderTransformer.ts
@@ -1,4 +1,4 @@
-import {IdentifierRole} from "../parser/tokenizer";
+import {IdentifierRole, isTopLevelDeclaration} from "../parser/tokenizer";
 import TokenProcessor from "../TokenProcessor";
 import Transformer from "./Transformer";
 
@@ -27,8 +27,9 @@ export default class ReactHotLoaderTransformer extends Transformer {
     const topLevelNames = new Set();
     for (const token of this.tokens.tokens) {
       if (
-        token.identifierRole === IdentifierRole.TopLevelDeclaration ||
-        token.identifierRole === IdentifierRole.ObjectShorthandTopLevelDeclaration
+        !token.isType &&
+        isTopLevelDeclaration(token) &&
+        token.identifierRole !== IdentifierRole.ImportDeclaration
       ) {
         topLevelNames.add(this.tokens.identifierNameForToken(token));
       }

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -69,6 +69,7 @@ export default class RootTransformer {
           this.nameManager,
           reactHotLoaderTransformer,
           enableLegacyBabel5ModuleInterop,
+          transforms.includes("typescript"),
         ),
       );
     } else {

--- a/src/util/getDeclarationInfo.ts
+++ b/src/util/getDeclarationInfo.ts
@@ -1,0 +1,40 @@
+import {isTopLevelDeclaration} from "../parser/tokenizer";
+import {TokenType as tt} from "../parser/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+
+export interface DeclarationInfo {
+  typeDeclarations: Set<string>;
+  valueDeclarations: Set<string>;
+}
+
+export const EMPTY_DECLARATION_INFO: DeclarationInfo = {
+  typeDeclarations: new Set(),
+  valueDeclarations: new Set(),
+};
+
+/**
+ * Get all top-level identifiers that should be preserved when exported in TypeScript.
+ *
+ * Examples:
+ * - If an identifier is declared as `const x`, then `export {x}` should be preserved.
+ * - If it's declared as `type x`, then `export {x}` should be removed.
+ * - If it's declared as both `const x` and `type x`, then the export should be preserved.
+ * - Classes and enums should be preserved (even though they also introduce types).
+ * - Imported identifiers should be preserved since we don't have enough information to
+ *   rule them out. --isolatedModules disallows re-exports, which catches errors here.
+ */
+export default function getDeclarationInfo(tokens: TokenProcessor): DeclarationInfo {
+  const typeDeclarations: Set<string> = new Set();
+  const valueDeclarations: Set<string> = new Set();
+  for (let i = 0; i < tokens.tokens.length; i++) {
+    const token = tokens.tokens[i];
+    if (token.type === tt.name && isTopLevelDeclaration(token)) {
+      if (token.isType) {
+        typeDeclarations.add(tokens.identifierNameForToken(token));
+      } else {
+        valueDeclarations.add(tokens.identifierNameForToken(token));
+      }
+    }
+  }
+  return {typeDeclarations, valueDeclarations};
+}

--- a/src/util/shouldElideDefaultExport.ts
+++ b/src/util/shouldElideDefaultExport.ts
@@ -1,0 +1,37 @@
+import {TokenType as tt} from "../parser/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+import {DeclarationInfo} from "./getDeclarationInfo";
+
+/**
+ * Common method sharing code between CJS and ESM cases, since they're the same here.
+ */
+export default function shouldElideDefaultExport(
+  isTypeScriptTransformEnabled: boolean,
+  tokens: TokenProcessor,
+  declarationInfo: DeclarationInfo,
+): boolean {
+  if (!isTypeScriptTransformEnabled) {
+    return false;
+  }
+  const exportToken = tokens.currentToken();
+  if (exportToken.rhsEndIndex == null) {
+    throw new Error("Expected non-null rhsEndIndex on export token.");
+  }
+  // The export must be of the form `export default a` or `export default a;`.
+  const numTokens = exportToken.rhsEndIndex - tokens.currentIndex();
+  if (
+    numTokens !== 3 &&
+    !(numTokens === 4 && tokens.matches1AtIndex(exportToken.rhsEndIndex - 1, tt.semi))
+  ) {
+    return false;
+  }
+  const identifierToken = tokens.tokenAtRelativeIndex(2);
+  if (identifierToken.type !== tt.name) {
+    return false;
+  }
+  const exportedName = tokens.identifierNameForToken(identifierToken);
+  return (
+    declarationInfo.typeDeclarations.has(exportedName) &&
+    !declarationInfo.valueDeclarations.has(exportedName)
+  );
+}

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -266,9 +266,11 @@ describe("sucrase", () => {
   it("allows using the import keyword as an export", () => {
     assertResult(
       `
+      const Import = null;
       export {Import as import};
     `,
       `"use strict";${ESMODULE_PREFIX}
+      const Import = null;
       exports.import = Import;
     `,
       {transforms: ["jsx", "imports", "typescript"]},


### PR DESCRIPTION
Fixes #398

This ended up having a *lot* of cases and complexity. We actually care about the
known type declarations and the known value declarations.
* In ESM mode, only elide exports that are known to be a type and not known to
  be a value. This is true both for named export syntax and default export.
* In CJS mode, elide named exports that are either completely unknown or known
  to be a type. For default exports, it's the same logic as ESM: we only elide
  if we know it as a type and not as a value.

This required going through all declarations (at least in TS parsing mode) and
making sure we add the right identifier info to each of them, which in turn had
consequences on the react-hot-loader transform, so that had to be fixed.

One challenge is that default exports should be elided only when they export a
single identifier, which we can't know statically. Instead, we now use the
`rhsEndIndex` field on the `export` token to know when the export statement
actually ends, and use that to determine if the export is just an identifier.