### PR TITLE
Fix TS parsing bug when seeing a generics-like expression

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -1053,6 +1053,8 @@ export function tsParseSubscript(startPos: number, noCalls: boolean, stopState: 
     } else if (match(tt.backQuote)) {
       // Tagged template with a type argument.
       parseTemplate();
+    } else {
+      unexpected();
     }
 
     if (state.error) {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1451,6 +1451,17 @@ describe("typescript transform", () => {
     );
   });
 
+  it("properly handles comparison operators that look like JSX or generics (#408)", () => {
+    assertTypeScriptResult(
+      `
+      a < b > c
+    `,
+      `"use strict";
+      a < b > c
+    `,
+    );
+  });
+
   it("elides type-only exports", () => {
     assertTypeScriptImportResult(
       `


### PR DESCRIPTION
Fixes #408

If we see `a<b>`, we were already looking at the next token to see if it's an
open-paren (meaning this is a function call with a type argument) or a backtick
(meaning this is a tagged template literal with a type argument), but we weren't
properly bailing out if it was neither of those, which put the parser in a bad
state.