### PR TITLE
Port all babel-parser changes from 2019-01-28 to 2019-03-26

### DIFF
--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -709,18 +709,13 @@ export function flowParseVariance(): void {
 // Overrides
 // ==================================
 
-export function flowParseFunctionBodyAndFinish(
-  functionStart: number,
-  isGenerator: boolean,
-  allowExpressionBody: boolean = false,
-  funcContextId: number,
-): void {
+export function flowParseFunctionBodyAndFinish(funcContextId: number): void {
   // For arrow functions, `parseArrow` handles the return type itself.
-  if (!allowExpressionBody && match(tt.colon)) {
+  if (match(tt.colon)) {
     flowParseTypeAndPredicateInitialiser();
   }
 
-  parseFunctionBody(functionStart, isGenerator, allowExpressionBody, funcContextId);
+  parseFunctionBody(false, funcContextId);
 }
 
 export function flowParseSubscript(startPos: number, noCalls: boolean, stopState: StopState): void {
@@ -1029,7 +1024,7 @@ export function flowParseSubscripts(startPos: number, noCalls: boolean = false):
     match(tt.lessThan)
   ) {
     const snapshot = state.snapshot();
-    const wasArrow = parseAsyncArrowWithTypeParameters(startPos);
+    const wasArrow = parseAsyncArrowWithTypeParameters();
     if (wasArrow && !state.error) {
       return;
     }
@@ -1040,13 +1035,13 @@ export function flowParseSubscripts(startPos: number, noCalls: boolean = false):
 }
 
 // Returns true if there was an arrow function here.
-function parseAsyncArrowWithTypeParameters(startPos: number): boolean {
+function parseAsyncArrowWithTypeParameters(): boolean {
   state.scopeDepth++;
   const startTokenIndex = state.tokens.length;
   parseFunctionParams();
   if (!parseArrow()) {
     return false;
   }
-  parseArrowExpression(startPos, startTokenIndex);
+  parseArrowExpression(startTokenIndex);
   return true;
 }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -797,4 +797,16 @@ describe("sucrase", () => {
       {transforms: []},
     );
   });
+
+  it("handles partial application syntax", () => {
+    assertResult(
+      `
+      foo(?)
+    `,
+      `
+      foo(?)
+    `,
+      {transforms: []},
+    );
+  });
 });

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -7,7 +7,7 @@ type SimpleToken = Token & {label?: string};
 type TokenExpectation = {[K in keyof SimpleToken]?: SimpleToken[K]};
 
 function assertTokens(code: string, expectedTokens: Array<TokenExpectation>): void {
-  const tokens: Array<SimpleToken> = parse(code, true, false, false).tokens;
+  const tokens: Array<SimpleToken> = parse(code, true, true, false).tokens;
   assert.strictEqual(tokens.length, expectedTokens.length);
   const projectedTokens = tokens.map((token, i) => {
     const result = {};
@@ -271,6 +271,34 @@ describe("tokens", () => {
         {type: tt.eq},
         {type: tt.preIncDec},
         {type: tt.name},
+        {type: tt.eof},
+      ],
+    );
+  });
+
+  it("properly parses keyword keys in TS class bodies", () => {
+    assertTokens(
+      `
+      class A {
+        abstract?: void;
+        readonly!: void;
+      }
+    `,
+      [
+        {type: tt._class},
+        {type: tt.name},
+        {type: tt.braceL},
+        {type: tt.name},
+        {type: tt.question},
+        {type: tt.colon},
+        {type: tt._void},
+        {type: tt.semi},
+        {type: tt.name},
+        {type: tt.bang},
+        {type: tt.colon},
+        {type: tt._void},
+        {type: tt.semi},
+        {type: tt.braceR},
         {type: tt.eof},
       ],
     );

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1710,4 +1710,39 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("handles const contexts", () => {
+    assertTypeScriptResult(
+      `
+      let x = 5 as const;
+    `,
+      `"use strict";
+      let x = 5 ;
+    `,
+    );
+  });
+
+  it("handles the readonly type modifier", () => {
+    assertTypeScriptResult(
+      `
+      let z: readonly number[];
+      let z1: readonly [number, number];
+    `,
+      `"use strict";
+      let z;
+      let z1;
+    `,
+    );
+  });
+
+  it("allows template literal syntax for type literals", () => {
+    assertTypeScriptResult(
+      `
+      let x: \`foo\`;
+    `,
+      `"use strict";
+      let x;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #437

Details:
828169e61 Fix line continuation with Unicode line terminators (#9403)
🚫 We don't do escape parsing anyway.

4c4c22a31 Run prettier
🚫 Tools only.

00c3e3c8e Fixed link to @babel/parser's issues in README (#9427)
🚫 Docs only.

9eb010da5 Unify reserved word checking and update error messages (#9402)
🚫 Error handling only.

344d35bbe Simplify await and yield tracking in params (#9405)
🚫 Error handling only.

d896ce2b5 v7.3.2
🚫 Release only.

e03e5ba01 Add TypeScript definitions for parser plugin options. (#9457)
🚫 Types only.

07b0f22a3 Fix range for TypeScript optional parameter in arrow function (#9463)
🚫 AST only.

d1514f57b Typescript function destructured params (#9431)
🚫 Already fixed in my code (with a fix that I think is better).

2817844e8 Fix regression with let (#9477)
🚫 This doesn't seem to affect Sucrase.

d349b74a4 Better error output in parser tests (#9491)
🚫 Test only.

4ba998c5d Add importKind to spec
🚫 Types only.

d1fe2d05f v7.3.3
🚫 Release only.

058f05742 Also check AssignmentPatterns for export name (#9521)
🚫 Error handling only.

a1ea765b9 Make tests spec compliant and avoid duplicate declarations in input files (#9522)
🚫 Test only.

dd8b700a2 Parenthesized expressions (#8025)
🚫 New feature that won't go into Sucrase.

9f3457797 Fix TypeScript parsers missing token check (#9571) (#9572)
✅ Added new check with test.

fc1ea7f49 Revert "Parenthesized expressions (#8025)"
🚫 New feature that won't go into Sucrase.

1f6454cc9 v7.3.4
🚫 Release only.

a7391144b Introduce scope tracking in the parser (#9493)
🚫 Looks like this is just for error handling.

e6c1065d1 Fix strict mode prescanning with EmptyStatement (#9585)
🚫 We don't detect strict mode.

d0e196d21 Treat for loop body as part of loop scope (#9586)
🚫 Scopes not tracked in Sucrase in the same way.

0345c1bc1 Use `for..of Object.keys` instead of `for..in` (#9518)
🚫 Not relevant for Sucrase.

244e4580e Remove always false param allowExpressionBody (#9591)
✅ Removed, plus removed some other unnecessary params.

a029071b8 [TS] Correctly forget `await`s after parsing async arrows with type args (#9593)
🚫 Doesn't come up in Sucrase.

e883ff295 Merge pull request #9597 from danez/Update-charcodes
🚫 Mostly just changes in types.

43eed1ac9 Check exported bindings are defined (#9589)
🚫 Error handling only.

5cb280f98 Fix scope check for 2nd+ lexical bindings (#9600)
🚫 Error handling only.

208195f42 Disallow duplicate params in methods (#9599)
🚫 Error handling only.

98ab1b642 Refactor parsing object members (#9607)
🚫 I won't try to port this refactor for now.

f13f4adcb [TS] Disallow type casts in arrow parameters (#9612)
🚫 Error handling only.

17f4195bc Allow any reserved word in `export {} from` specifiers (#9616)
🚫 Already works in Sucrase.

c60c4dd37 Partial Application Syntax: Stage 1 (#9343)
✅ Added basic parsing for ? expression.

d832c0f43 Add parser support for placeholders (#9364)
🚫 I won't include this feature in Sucrase.

54ba6d80c Update identifier parsing per Unicode v12 (#9637)
🚫 Sucrase doesn't need this validation.

29999007f Disallow escape sequences in contextual keywords (#9618)
🚫 We don't support identifier escape sequences in the first place.

fba5655a4 Parenthesized expressions (#8025)
🚫 I won't include this feature in Sucrase.

e53be4b38 [TS] Allow context type annotation on getters/setters (#9641)
🚫 Bug in validation that Sucrase doesn't do.

d8a532983 Reorganize token types and use a map for them (#9645)
🚫 Not really relevant for current Sucrase code.

cf4bd8bb8 Remove input and length from state (#9646)
🚫 Not relevant for Sucrase.

29cd27b54 Partial application plugin (#9474)
🚫 Tests only.

25a3825a1 TypeScript Constant contexts (#9534)
✅ Added test, already works from previous change to make it an identifier.

cc4560842 Add `readonly` to TypeScript type modifier (#9529)
✅ Added new case with test.

48d66eb64 Correctly parse TS TypeAssertions around arrow functions (#9699)
🚫 AST only, I think.

f1328fb91 v7.4.0
🚫 Release only.

ab41cb2cd Fix scope checks with enabled flow plugin (#9719)
🚫 Scope code doesn't exist in Sucrase.

2201fd839 Modules might be in loose mode when checking for undecl exports (#9725)
🚫 Sucrase always uses strict mode.

7dea0f23d v7.4.2
🚫 Release only.

ef0722b4b Fix compatibility between estree and TS plugin (#9700)
🚫 Sucrase doesn't support estree mode.

aaefc83a6 Allow HTML comments on first line (#9760)
🚫 Unclear what this is needed for, but doesn't seem important in Sucrase.

d720c6cff Explicit labels for tokenTypes (#9761)
🚫 Internal change.

444daf922 Optimize parseBindingAtom code to get better error messages (#9762)
🚫 Error checking only.

2867bbf19 [typescript] parsing template literal as type (#9748)
✅ Added new case with test.

7f4427432 Parse right-hand-side of for/of as an assignment expression (#9767)
🚫 Error checking only.

6bc9e7ebd Correctly check for-in and for-of loop for invalid left-hand side (#9768)
🚫 Error checking only.

60d7e940e Fix merge error
🚫 Not relevant to Sucrase.