### PR TITLE
Elide import = statements that are only used as a type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
       tokenProcessor,
       enableLegacyTypeScriptModuleInterop,
       options,
+      options.transforms.includes("typescript"),
     );
     importProcessor.preprocessTokens();
     // We need to mark shadowed globals after processing imports so we know that the globals are,

--- a/src/util/elideImportEquals.ts
+++ b/src/util/elideImportEquals.ts
@@ -1,0 +1,29 @@
+import {TokenType as tt} from "../parser/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+
+export default function elideImportEquals(tokens: TokenProcessor): void {
+  // import
+  tokens.removeInitialToken();
+  // name
+  tokens.removeToken();
+  // =
+  tokens.removeToken();
+  // name or require
+  tokens.removeToken();
+  // Handle either `import A = require('A')` or `import A = B.C.D`.
+  if (tokens.matches1(tt.parenL)) {
+    // (
+    tokens.removeToken();
+    // path string
+    tokens.removeToken();
+    // )
+    tokens.removeToken();
+  } else {
+    while (tokens.matches1(tt.dot)) {
+      // .
+      tokens.removeToken();
+      // name
+      tokens.removeToken();
+    }
+  }
+}

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -10,9 +10,15 @@ function assertHasShadowedGlobals(code: string, expected: boolean): void {
   const tokenProcessor = new TokenProcessor(code, file.tokens, false);
   const nameManager = new NameManager(tokenProcessor);
   nameManager.preprocessNames();
-  const importProcessor = new CJSImportProcessor(nameManager, tokenProcessor, false, {
-    transforms: [],
-  });
+  const importProcessor = new CJSImportProcessor(
+    nameManager,
+    tokenProcessor,
+    false,
+    {
+      transforms: [],
+    },
+    false,
+  );
   importProcessor.preprocessTokens();
   assert.strictEqual(
     hasShadowedGlobals(tokenProcessor, importProcessor.getGlobalNames()),


### PR DESCRIPTION
Fixes #422

In both CJS and ESM, we now look at the identifier in `import A =` and decide
whether to elide the entire statement in a similar way to normal TS import
elision. Since there are only two forms that these statements can have, I just
special cased the two when deleting statements.

Technically to implement this totally correctly, I'd need something like a graph
traversal: in an `import A = B.C;` statement, `B` is referenced as a value if
`A` is ever referenced as a value, so deciding if an import should be elided
requires following an arbitrary number of import statements. In practice, I
think this syntax is only ever used to pull in types (for values, you can just
use `const`, and the syntax is obscure anyway), so I treat it as a type
statement that gets elided.