### PR TITLE
Properly handle async arrow functions with multiline type parameters

### DIFF
--- a/src/transformers/FlowTransformer.ts
+++ b/src/transformers/FlowTransformer.ts
@@ -10,6 +10,7 @@ export default class FlowTransformer extends Transformer {
   process(): boolean {
     return (
       this.rootTransformer.processPossibleArrowParamEnd() ||
+      this.rootTransformer.processPossibleAsyncArrowWithTypeParams() ||
       this.rootTransformer.processPossibleTypeRange()
     );
   }

--- a/src/transformers/TypeScriptTransformer.ts
+++ b/src/transformers/TypeScriptTransformer.ts
@@ -16,6 +16,7 @@ export default class TypeScriptTransformer extends Transformer {
   process(): boolean {
     if (
       this.rootTransformer.processPossibleArrowParamEnd() ||
+      this.rootTransformer.processPossibleAsyncArrowWithTypeParams() ||
       this.rootTransformer.processPossibleTypeRange()
     ) {
       return true;

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -471,7 +471,7 @@ describe("type transforms", () => {
       async <T>(1, 2, 3);
     `,
       `"use strict";
-      async (1, 2, 3);
+      async ( 1, 2, 3);
     `,
     );
   });
@@ -502,6 +502,20 @@ describe("type transforms", () => {
         value: number;
       } => ({value: x}); 
       setOutput(multiLineReturn(5).value)
+    `,
+      {expectedOutput: 5},
+    );
+  });
+
+  it("properly handles multiline type parameters in an async arrow function", () => {
+    assertTypeScriptAndFlowExpectations(
+      `
+      const multilineGenerics = async <
+        A
+      >(x) => {
+        setOutput(5);
+      };
+      multilineGenerics();
     `,
       {expectedOutput: 5},
     );


### PR DESCRIPTION
Fixes #396

This is similar to another case: we detect it as a special case, then move the (
to right after the async, so that all newlines will be in parens so it won't be
detected as the end of a statement by the parser.