### PR TITLE
First pass at implementation of nullish coalescing

### DIFF
--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -45,6 +45,15 @@ const HELPERS = {
         });
     }
   `,
+  nullishCoalesce: `
+    function nullishCoalesce(lhs, rhsFn) {
+      if (lhs != null) {
+        return lhs;
+      } else {
+        return rhsFn();
+      }
+    }
+  `,
 };
 
 export class HelperManager {

--- a/src/NameManager.ts
+++ b/src/NameManager.ts
@@ -1,17 +1,11 @@
-import {TokenType as tt} from "./parser/tokenizer/types";
-import TokenProcessor from "./TokenProcessor";
+import {Token} from "./parser/tokenizer";
+import getIdentifierNames from "./util/getIdentifierNames";
 
 export default class NameManager {
   private readonly usedNames: Set<string> = new Set();
 
-  constructor(readonly tokens: TokenProcessor) {}
-
-  preprocessNames(): void {
-    for (let i = 0; i < this.tokens.tokens.length; i++) {
-      if (this.tokens.matches1AtIndex(i, tt.name)) {
-        this.usedNames.add(this.tokens.identifierNameAtIndex(i));
-      }
-    }
+  constructor(code: string, tokens: Array<Token>) {
+    this.usedNames = new Set(getIdentifierNames(code, tokens));
   }
 
   claimFreeName(name: string): string {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -100,6 +100,8 @@ export class Token {
     this.contextId = null;
     this.rhsEndIndex = null;
     this.isExpression = false;
+    this.numNullishCoalesceStarts = 0;
+    this.numNullishCoalesceEnds = 0;
   }
 
   type: TokenType;
@@ -116,6 +118,10 @@ export class Token {
   rhsEndIndex: number | null;
   // For class tokens, records if the class is a class expression or a class statement.
   isExpression: boolean;
+  // Number of times to insert a `nullishCoalesce(` snippet before this token.
+  numNullishCoalesceStarts: number;
+  // Number of times to insert a `)` snippet after this token.
+  numNullishCoalesceEnds: number;
 }
 
 // ## Tokenizer

--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -39,7 +39,7 @@ export default class CJSImportTransformer extends Transformer {
   }
 
   getPrefixCode(): string {
-    let prefix = this.importProcessor.getPrefixCode();
+    let prefix = "";
     if (this.hadExport) {
       prefix += 'Object.defineProperty(exports, "__esModule", {value: true});';
     }

--- a/src/util/getIdentifierNames.ts
+++ b/src/util/getIdentifierNames.ts
@@ -1,0 +1,15 @@
+import {Token} from "../parser/tokenizer";
+import {TokenType as tt} from "../parser/tokenizer/types";
+
+/**
+ * Get all identifier names in the code, in order, including duplicates.
+ */
+export default function getIdentifierNames(code: string, tokens: Array<Token>): Array<string> {
+  const names = [];
+  for (const token of tokens) {
+    if (token.type === tt.name) {
+      names.push(code.slice(token.start, token.end));
+    }
+  }
+  return names;
+}

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import CJSImportProcessor from "../src/CJSImportProcessor";
+import {HelperManager} from "../src/HelperManager";
 import {hasShadowedGlobals} from "../src/identifyShadowedGlobals";
 import NameManager from "../src/NameManager";
 import {parse} from "../src/parser";
@@ -7,9 +8,9 @@ import TokenProcessor from "../src/TokenProcessor";
 
 function assertHasShadowedGlobals(code: string, expected: boolean): void {
   const file = parse(code, false, false, false);
-  const tokenProcessor = new TokenProcessor(code, file.tokens, false);
-  const nameManager = new NameManager(tokenProcessor);
-  nameManager.preprocessNames();
+  const nameManager = new NameManager(code, file.tokens);
+  const helperManager = new HelperManager(nameManager);
+  const tokenProcessor = new TokenProcessor(code, file.tokens, false, helperManager);
   const importProcessor = new CJSImportProcessor(
     nameManager,
     tokenProcessor,
@@ -18,6 +19,7 @@ function assertHasShadowedGlobals(code: string, expected: boolean): void {
       transforms: [],
     },
     false,
+    helperManager,
   );
   importProcessor.preprocessTokens();
   assert.strictEqual(

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -596,7 +596,7 @@ var _moduleName = require('moduleName');
       export class Subclass extends Superclass {
       }
     `,
-      `"use strict";${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _superclass = require('./superclass'); var _superclass2 = _interopRequireDefault(_superclass);
       
        class Subclass extends _superclass2.default {
@@ -794,7 +794,7 @@ module.exports = exports.default;
       export {x} from './MyVars';
       export {a as b, c as d} from './MyOtherVars';
     `,
-      `"use strict";${CREATE_NAMED_EXPORT_FROM_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${CREATE_NAMED_EXPORT_FROM_PREFIX}
       var _MyVars = require('./MyVars'); _createNamedExportFrom(_MyVars, 'x', 'x');
       var _MyOtherVars = require('./MyOtherVars'); _createNamedExportFrom(_MyOtherVars, 'b', 'a'); _createNamedExportFrom(_MyOtherVars, 'd', 'c');
     `,
@@ -806,7 +806,7 @@ module.exports = exports.default;
       `
       export * from './MyVars';
     `,
-      `"use strict";${CREATE_STAR_EXPORT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${CREATE_STAR_EXPORT_PREFIX}
       var _MyVars = require('./MyVars'); _createStarExport(_MyVars);
     `,
     );
@@ -927,7 +927,7 @@ module.exports = exports.default;
       import a from 'a';
       export {a};
     `,
-      `"use strict";${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireDefault(_a);
       exports.a = _a2.default;
     `,
@@ -979,7 +979,7 @@ module.exports = exports.default;
       `
       export * as a from 'a';
     `,
-      `"use strict";${IMPORT_WILDCARD_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_WILDCARD_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireWildcard(_a); exports.a = _a2;
     `,
     );

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -13,21 +13,21 @@ if (foo) {
         {transforms: ["jsx", "imports"]},
       ),
       `\
-Location  Label  Raw            contextualKeyword isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression
-1:1-1:3   if     if             0                                                                                       
-1:4-1:5   (      (              0                                                                                       
-1:5-1:8   name   foo            0                        0                                                              
-1:8-1:9   )      )              0                                                                                       
-1:10-1:11 {      {              0                                                                                       
-2:3-2:10  name   console        0                        0                                                              
-2:10-2:11 .      .              0                                                                                       
-2:11-2:14 name   log            0                                                                                       
-2:14-2:15 (      (              0                                                     1                                 
-2:15-2:29 string 'Hello world!' 0                                                                                       
-2:29-2:30 )      )              0                                                     1                                 
-2:30-2:31 ;      ;              0                                                                                       
-3:1-3:2   }      }              0                                                                                       
-3:2-3:2   eof                   0                                                                                       `,
+Location  Label  Raw            contextualKeyword isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression numNullishCoalesceStarts numNullishCoalesceEnds
+1:1-1:3   if     if             0                                                                                        0                        0                     
+1:4-1:5   (      (              0                                                                                        0                        0                     
+1:5-1:8   name   foo            0                        0                                                               0                        0                     
+1:8-1:9   )      )              0                                                                                        0                        0                     
+1:10-1:11 {      {              0                                                                                        0                        0                     
+2:3-2:10  name   console        0                        0                                                               0                        0                     
+2:10-2:11 .      .              0                                                                                        0                        0                     
+2:11-2:14 name   log            0                                                                                        0                        0                     
+2:14-2:15 (      (              0                                                     1                                  0                        0                     
+2:15-2:29 string 'Hello world!' 0                                                                                        0                        0                     
+2:29-2:30 )      )              0                                                     1                                  0                        0                     
+2:30-2:31 ;      ;              0                                                                                        0                        0                     
+3:1-3:2   }      }              0                                                                                        0                        0                     
+3:2-3:2   eof                   0                                                                                        0                        0                     `,
     );
   });
 });

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -17,3 +17,5 @@ export const ESMODULE_PREFIX = 'Object.defineProperty(exports, "__esModule", {va
 export const RHL_PREFIX = `(function () { \
 var enterModule = require('react-hot-loader').enterModule; enterModule && enterModule(module); \
 })();`;
+export const NULLISH_COALESCE_PREFIX = ` function _nullishCoalesce(lhs, rhsFn) { \
+if (lhs != null) { return lhs; } else { return rhsFn(); } }`;

--- a/test/react-display-name-test.ts
+++ b/test/react-display-name-test.ts
@@ -163,7 +163,7 @@ describe("transform react-display-name", () => {
         }
       });
     `,
-      `"use strict";const _jsxFileName = "MyComponent.js";${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";const _jsxFileName = "MyComponent.js";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _react = require('react'); var _react2 = _interopRequireDefault(_react);
 
       exports. default = _react2.default.createClass({displayName: 'MyComponent',

--- a/test/react-hot-loader-test.ts
+++ b/test/react-hot-loader-test.ts
@@ -51,7 +51,7 @@ describe("transform react-hot-loader", () => {
       
       export default 12;
     `,
-      `"use strict";const _jsxFileName = "sample.tsx";${RHL_PREFIX}${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";const _jsxFileName = "sample.tsx";${RHL_PREFIX}${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _react = require('react'); var _react2 = _interopRequireDefault(_react);
       
       const x = 3;

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1,5 +1,5 @@
-import {ESMODULE_PREFIX, IMPORT_DEFAULT_PREFIX} from "./prefixes";
-import {assertResult} from "./util";
+import {ESMODULE_PREFIX, IMPORT_DEFAULT_PREFIX, NULLISH_COALESCE_PREFIX} from "./prefixes";
+import {assertOutput, assertResult} from "./util";
 
 /**
  * Test cases that aren't associated with any particular transform.
@@ -870,6 +870,50 @@ describe("sucrase", () => {
       function foo([foo, /* not used */, /* not used */]) {
       }
     `,
+      {transforms: []},
+    );
+  });
+
+  it("transpiles basic nullish coalescing", () => {
+    assertResult(
+      `
+      const x = a ?? b;
+    `,
+      `${NULLISH_COALESCE_PREFIX}
+      const x = _nullishCoalesce(a, () => b);
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("transpiles nested nullish coalescing", () => {
+    assertResult(
+      `
+      const x = a ?? b ?? c;
+    `,
+      `${NULLISH_COALESCE_PREFIX}
+      const x = _nullishCoalesce(_nullishCoalesce(a, () => b), () => c);
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("handles falsy LHS values correctly in nullish coalescing", () => {
+    assertOutput(
+      `
+      setOutput([undefined ?? 7, null ?? 7, 0 ?? 7, false ?? 7, '' ?? 7]);
+    `,
+      [7, 7, 0, false, ""],
+      {transforms: []},
+    );
+  });
+
+  it("handles nested optional chain operations", () => {
+    assertOutput(
+      `
+      setOutput(undefined ?? 7 ?? null);
+    `,
+      7,
       {transforms: []},
     );
   });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -820,7 +820,7 @@ describe("typescript transform", () => {
       import A from 'a';
       export {A};
     `,
-      `"use strict";${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _a = require('a'); var _a2 = _interopRequireDefault(_a);
       exports.A = _a2.default;
     `,
@@ -862,7 +862,7 @@ describe("typescript transform", () => {
       `
       export * from './MyVars';
     `,
-      `"use strict";${CREATE_STAR_EXPORT_PREFIX}${ESMODULE_PREFIX}
+      `"use strict";${ESMODULE_PREFIX}${CREATE_STAR_EXPORT_PREFIX}
       var _MyVars = require('./MyVars'); _createStarExport(_MyVars);
     `,
     );
@@ -1557,7 +1557,7 @@ describe("typescript transform", () => {
       export {A, b, c, d, E, F, G, h, I, J};
     `,
       {
-        expectedCJSResult: `"use strict";${IMPORT_DEFAULT_PREFIX}${ESMODULE_PREFIX}
+        expectedCJSResult: `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
       var _foo = require('./foo'); var _foo2 = _interopRequireDefault(_foo);
       var E; (function (E) { const X = 1; E[E["X"] = X] = "X"; })(E || (E = {}));
       class F {}


### PR DESCRIPTION
Progress toward #461

Tech plan at https://github.com/alangpierce/sucrase/wiki/Sucrase-Optional-Chaining-and-Nullish-Coalescing-Technical-Plan

Some details:
* In the parser, operator parsing now keeps track of the start token index so
  that when we observe a `??` operator, we can mark the first token as being the
  start of an optional chain.
* The token format now has fields for the number of optional chain starts and
  ends for each token, which the transformer will use to inject code.
* Optional chaining code needs to use the HelperManager system, so I refactored
  it to be on the RootTransformer instead of just on one of them.
* The actual start/end code injection is done by the token system so that it
  works alongside all existing transforms.
* Since TokenProcessor now needs a HelperManager, I had to break the dependency
  cycle by making NameManager no longer depend on TokenProcessor, since it was
  only barely using it anyway.

Some quick perf benchmarks show this as having potentially a 4% slowdown even
for code not using nullish coalescing, though I wasn't able to track down any
specific area of code responsible, and it may have been partially due to
variability or other factors. Except for more egregious cases, I'll leave
performance work as a follow-up.