### PR TITLE
First pass at implementation of optional chaining

### DIFF
--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -54,6 +54,29 @@ const HELPERS = {
       }
     }
   `,
+  optionalChain: `
+    function optionalChain(ops) {
+      let lastAccessLHS = undefined;
+      let value = ops[0];
+      let i = 1;
+      while (i < ops.length) {
+        const op = ops[i];
+        const fn = ops[i + 1];
+        i += 2;
+        if ((op === 'optionalAccess' || op === 'optionalCall') && value == null) {
+          return undefined;
+        }
+        if (op === 'access' || op === 'optionalAccess') {
+          lastAccessLHS = value;
+          value = fn(value);
+        } else if (op === 'call' || op === 'optionalCall') {
+          value = fn((...args) => value.call(lastAccessLHS, ...args));
+          lastAccessLHS = undefined;
+        }
+      }
+      return value;
+    }
+  `,
 };
 
 export class HelperManager {

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -212,10 +212,17 @@ export default class TokenProcessor {
         this.resultCode += "(";
       }
     }
+    if (token.isOptionalChainStart) {
+      this.resultCode += this.helperManager.getHelperName("optionalChain");
+      this.resultCode += "([";
+    }
   }
 
   private appendTokenSuffix(): void {
     const token = this.currentToken();
+    if (token.isOptionalChainEnd) {
+      this.resultCode += "])";
+    }
     if (token.numNullishCoalesceEnds) {
       for (let i = 0; i < token.numNullishCoalesceEnds; i++) {
         this.resultCode += ")";

--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -714,7 +714,11 @@ export function flowParseFunctionBodyAndFinish(funcContextId: number): void {
   parseFunctionBody(false, funcContextId);
 }
 
-export function flowParseSubscript(noCalls: boolean, stopState: StopState): void {
+export function flowParseSubscript(
+  startTokenIndex: number,
+  noCalls: boolean,
+  stopState: StopState,
+): void {
   if (match(tt.questionDot) && lookaheadType() === tt.lessThan) {
     if (noCalls) {
       stopState.stop = true;
@@ -736,7 +740,7 @@ export function flowParseSubscript(noCalls: boolean, stopState: StopState): void
       return;
     }
   }
-  baseParseSubscript(noCalls, stopState);
+  baseParseSubscript(startTokenIndex, noCalls, stopState);
 }
 
 export function flowStartParseNewArguments(): void {
@@ -1014,7 +1018,7 @@ export function flowParseArrow(): boolean {
   return eat(tt.arrow);
 }
 
-export function flowParseSubscripts(noCalls: boolean = false): void {
+export function flowParseSubscripts(startTokenIndex: number, noCalls: boolean = false): void {
   if (
     state.tokens[state.tokens.length - 1].contextualKeyword === ContextualKeyword._async &&
     match(tt.lessThan)
@@ -1027,7 +1031,7 @@ export function flowParseSubscripts(noCalls: boolean = false): void {
     state.restoreFromSnapshot(snapshot);
   }
 
-  baseParseSubscripts(noCalls);
+  baseParseSubscripts(startTokenIndex, noCalls);
 }
 
 // Returns true if there was an arrow function here.

--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -1054,7 +1054,11 @@ export function tsParseFunctionBodyAndFinish(functionStart: number, funcContextI
   parseFunctionBody(false, funcContextId);
 }
 
-export function tsParseSubscript(noCalls: boolean, stopState: StopState): void {
+export function tsParseSubscript(
+  startTokenIndex: number,
+  noCalls: boolean,
+  stopState: StopState,
+): void {
   if (!hasPrecedingLineBreak() && eat(tt.bang)) {
     state.tokens[state.tokens.length - 1].type = tt.nonNullAssertion;
     return;
@@ -1089,7 +1093,7 @@ export function tsParseSubscript(noCalls: boolean, stopState: StopState): void {
       return;
     }
   }
-  baseParseSubscript(noCalls, stopState);
+  baseParseSubscript(startTokenIndex, noCalls, stopState);
 }
 
 export function tsStartParseNewArguments(): void {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -102,6 +102,9 @@ export class Token {
     this.isExpression = false;
     this.numNullishCoalesceStarts = 0;
     this.numNullishCoalesceEnds = 0;
+    this.isOptionalChainStart = false;
+    this.isOptionalChainEnd = false;
+    this.subscriptStartIndex = null;
   }
 
   type: TokenType;
@@ -122,6 +125,13 @@ export class Token {
   numNullishCoalesceStarts: number;
   // Number of times to insert a `)` snippet after this token.
   numNullishCoalesceEnds: number;
+  // If true, insert an `optionalChain([` snippet before this token.
+  isOptionalChainStart: boolean;
+  // If true, insert a `])` snippet after this token.
+  isOptionalChainEnd: boolean;
+  // Tag for `.`, `?.`, `[`, `?.[`, `(`, and `?.(` to denote the "root" token for this
+  // subscript chain. This can be used to determine if this chain is an optional chain.
+  subscriptStartIndex: number | null;
 }
 
 // ## Tokenizer

--- a/src/transformers/OptionalChainingNullishTransformer.ts
+++ b/src/transformers/OptionalChainingNullishTransformer.ts
@@ -1,0 +1,50 @@
+import NameManager from "../NameManager";
+import {TokenType as tt} from "../parser/tokenizer/types";
+import TokenProcessor from "../TokenProcessor";
+import Transformer from "./Transformer";
+
+/**
+ * Transformer supporting the optional chaining and nullish coalescing operators.
+ *
+ * Tech plan here:
+ * https://github.com/alangpierce/sucrase/wiki/Sucrase-Optional-Chaining-and-Nullish-Coalescing-Technical-Plan
+ *
+ * The prefix and suffix code snippets are handled by TokenProcessor, and this transformer handles
+ * the operators themselves.
+ */
+export default class OptionalChainingNullishTransformer extends Transformer {
+  constructor(readonly tokens: TokenProcessor, readonly nameManager: NameManager) {
+    super();
+  }
+
+  process(): boolean {
+    if (this.tokens.matches1(tt.nullishCoalescing)) {
+      this.tokens.replaceTokenTrimmingLeftWhitespace(", () =>");
+      return true;
+    }
+    const token = this.tokens.currentToken();
+    if (
+      token.subscriptStartIndex != null &&
+      this.tokens.tokens[token.subscriptStartIndex].isOptionalChainStart
+    ) {
+      const param = this.nameManager.claimFreeName("_");
+      if (this.tokens.matches2(tt.questionDot, tt.parenL)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'optionalCall', ${param} => ${param}`);
+      } else if (this.tokens.matches2(tt.questionDot, tt.bracketL)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'optionalAccess', ${param} => ${param}`);
+      } else if (this.tokens.matches1(tt.questionDot)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'optionalAccess', ${param} => ${param}.`);
+      } else if (this.tokens.matches1(tt.dot)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'access', ${param} => ${param}.`);
+      } else if (this.tokens.matches1(tt.bracketL)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'access', ${param} => ${param}[`);
+      } else if (this.tokens.matches1(tt.parenL)) {
+        this.tokens.replaceTokenTrimmingLeftWhitespace(`, 'call', ${param} => ${param}(`);
+      } else {
+        throw new Error("Unexpected subscript operator in optional chain.");
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -11,6 +11,7 @@ import FlowTransformer from "./FlowTransformer";
 import JSXTransformer from "./JSXTransformer";
 import NumericSeparatorTransformer from "./NumericSeparatorTransformer";
 import OptionalCatchBindingTransformer from "./OptionalCatchBindingTransformer";
+import OptionalChainingNullishTransformer from "./OptionalChainingNullishTransformer";
 import ReactDisplayNameTransformer from "./ReactDisplayNameTransformer";
 import ReactHotLoaderTransformer from "./ReactHotLoaderTransformer";
 import Transformer from "./Transformer";
@@ -38,6 +39,9 @@ export default class RootTransformer {
     this.isImportsTransformEnabled = transforms.includes("imports");
     this.isReactHotLoaderTransformEnabled = transforms.includes("react-hot-loader");
 
+    this.transformers.push(
+      new OptionalChainingNullishTransformer(tokenProcessor, this.nameManager),
+    );
     this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
     this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
     if (transforms.includes("jsx")) {
@@ -151,10 +155,6 @@ export default class RootTransformer {
   }
 
   processToken(): void {
-    if (this.tokens.matches1(tt.nullishCoalescing)) {
-      this.tokens.replaceTokenTrimmingLeftWhitespace(", () =>");
-      return;
-    }
     if (this.tokens.matches1(tt._class)) {
       this.processClass();
       return;

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -13,21 +13,21 @@ if (foo) {
         {transforms: ["jsx", "imports"]},
       ),
       `\
-Location  Label  Raw            contextualKeyword isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression numNullishCoalesceStarts numNullishCoalesceEnds
-1:1-1:3   if     if             0                                                                                        0                        0                     
-1:4-1:5   (      (              0                                                                                        0                        0                     
-1:5-1:8   name   foo            0                        0                                                               0                        0                     
-1:8-1:9   )      )              0                                                                                        0                        0                     
-1:10-1:11 {      {              0                                                                                        0                        0                     
-2:3-2:10  name   console        0                        0                                                               0                        0                     
-2:10-2:11 .      .              0                                                                                        0                        0                     
-2:11-2:14 name   log            0                                                                                        0                        0                     
-2:14-2:15 (      (              0                                                     1                                  0                        0                     
-2:15-2:29 string 'Hello world!' 0                                                                                        0                        0                     
-2:29-2:30 )      )              0                                                     1                                  0                        0                     
-2:30-2:31 ;      ;              0                                                                                        0                        0                     
-3:1-3:2   }      }              0                                                                                        0                        0                     
-3:2-3:2   eof                   0                                                                                        0                        0                     `,
+Location  Label  Raw            contextualKeyword isType identifierRole shadowsGlobal contextId rhsEndIndex isExpression numNullishCoalesceStarts numNullishCoalesceEnds isOptionalChainStart isOptionalChainEnd subscriptStartIndex
+1:1-1:3   if     if             0                                                                                        0                        0                                                                                 
+1:4-1:5   (      (              0                                                                                        0                        0                                                                                 
+1:5-1:8   name   foo            0                        0                                                               0                        0                                                                                 
+1:8-1:9   )      )              0                                                                                        0                        0                                                                                 
+1:10-1:11 {      {              0                                                                                        0                        0                                                                                 
+2:3-2:10  name   console        0                        0                                                               0                        0                                                                                 
+2:10-2:11 .      .              0                                                                                        0                        0                                                              5                  
+2:11-2:14 name   log            0                                                                                        0                        0                                                                                 
+2:14-2:15 (      (              0                                                     1                                  0                        0                                                              5                  
+2:15-2:29 string 'Hello world!' 0                                                                                        0                        0                                                                                 
+2:29-2:30 )      )              0                                                     1                                  0                        0                                                                                 
+2:30-2:31 ;      ;              0                                                                                        0                        0                                                                                 
+3:1-3:2   }      }              0                                                                                        0                        0                                                                                 
+3:2-3:2   eof                   0                                                                                        0                        0                                                                                 `,
     );
   });
 });

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -19,3 +19,12 @@ var enterModule = require('react-hot-loader').enterModule; enterModule && enterM
 })();`;
 export const NULLISH_COALESCE_PREFIX = ` function _nullishCoalesce(lhs, rhsFn) { \
 if (lhs != null) { return lhs; } else { return rhsFn(); } }`;
+export const OPTIONAL_CHAIN_PREFIX = ` function _optionalChain(ops) { \
+let lastAccessLHS = undefined; let value = ops[0]; let i = 1; \
+while (i < ops.length) { \
+const op = ops[i]; const fn = ops[i + 1]; i += 2; \
+if ((op === 'optionalAccess' || op === 'optionalCall') && value == null) { return undefined; } \
+if (op === 'access' || op === 'optionalAccess') { lastAccessLHS = value; value = fn(value); } \
+else if (op === 'call' || op === 'optionalCall') { \
+value = fn((...args) => value.call(lastAccessLHS, ...args)); lastAccessLHS = undefined; \
+} } return value; }`;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -4,6 +4,7 @@ import {
   IMPORT_DEFAULT_PREFIX,
   IMPORT_WILDCARD_PREFIX,
   JSX_PREFIX,
+  OPTIONAL_CHAIN_PREFIX,
 } from "./prefixes";
 import {assertResult, devProps} from "./util";
 
@@ -1899,8 +1900,8 @@ describe("typescript transform", () => {
       `
       example.inner?.greet<string>()
     `,
-      `"use strict";
-      example.inner?.greet()
+      `"use strict";${OPTIONAL_CHAIN_PREFIX}
+      _optionalChain([example, 'access', _ => _.inner, 'optionalAccess', _2 => _2.greet()])
     `,
     );
   });


### PR DESCRIPTION
Progress toward #461

Tech plan: https://github.com/alangpierce/sucrase/wiki/Sucrase-Optional-Chaining-and-Nullish-Coalescing-Technical-Plan

The parser now associates each access operation with the start token for the
chain, and marks each chain containing an optional chain operation so that we
can wrap it in a function call.

This does not yet handle optional deletion, and there are a number of follow-up
tests that would be good to write, but the feature seems to be working with this
implementation.