### PR TITLE
Fix a few website issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     ],
     "import/no-mutable-exports": "off",
     "import/prefer-default-export": "off",
+    "import/no-unresolved": "off",
     "lines-between-class-members": "off",
     "max-classes-per-file": "off",
     "no-await-in-loop": "off",

--- a/script/lint.ts
+++ b/script/lint.ts
@@ -40,7 +40,7 @@ async function checkProject(path: string): Promise<void> {
   await Promise.all([
     run(`${TSC} --project ${path} --noEmit`),
     run(`${TSLINT} --project ${path}`),
-    run(`${ESLINT} '${path}/src/**/*.ts'`),
+    run(`${ESLINT} '${path}/src/**/*.{ts,tsx}'`),
   ]);
 }
 

--- a/website/src/Editor.tsx
+++ b/website/src/Editor.tsx
@@ -20,11 +20,12 @@ export default class Editor extends Component<EditorProps> {
     setTimeout(this.invalidate, 0);
   }
 
-  _editorDidMount: EditorDidMount = (editor, monaco) => {
-    this.editor = editor;
+  _editorDidMount: EditorDidMount = (monacoEditor, monaco) => {
+    this.editor = monacoEditor;
     monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
       noSemanticValidation: true,
       noSyntaxValidation: true,
+      noSuggestionDiagnostics: true,
     });
     this.invalidate();
   };

--- a/website/src/Worker.worker.ts
+++ b/website/src/Worker.worker.ts
@@ -124,6 +124,8 @@ function runBabel(): {code: string; time: number | null} {
           "proposal-export-namespace-from",
           "proposal-numeric-separator",
           "proposal-optional-catch-binding",
+          "proposal-nullish-coalescing-operator",
+          "proposal-optional-chaining",
           "dynamic-import-node",
         ],
         parserOpts: {
@@ -159,7 +161,7 @@ function runTypeScript(): {code: string; time: number | null} {
         compilerOptions: {
           module: config.selectedTransforms.imports ? ModuleKind.CommonJS : ModuleKind.ESNext,
           jsx: config.selectedTransforms.jsx ? JsxEmit.React : JsxEmit.Preserve,
-          target: ScriptTarget.ESNext,
+          target: ScriptTarget.ES2020,
         },
       }).outputText,
   );


### PR DESCRIPTION
* Lint wasn't running on all files, so enable it and fix some existing lint
  errors.
* Disable in-editor suggestion diagnostics.
* Enable optional chaining and nullish coalescing in Babel and TypeScript
  config.