### PR TITLE
Implement optional chaining deletion

### DIFF
--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -77,6 +77,12 @@ const HELPERS = {
       return value;
     }
   `,
+  optionalChainDelete: `
+    function optionalChainDelete(ops) {
+      const result = OPTIONAL_CHAIN_NAME(ops);
+      return result == null ? true : result;
+    }
+  `,
 };
 
 export class HelperManager {
@@ -95,8 +101,15 @@ export class HelperManager {
 
   emitHelpers(): string {
     let resultCode = "";
-    for (const [baseName, helperCode] of Object.entries(HELPERS)) {
+    if (this.helperNames.optionalChainDelete) {
+      this.getHelperName("optionalChain");
+    }
+    for (const [baseName, helperCodeTemplate] of Object.entries(HELPERS)) {
       const helperName = this.helperNames[baseName];
+      let helperCode = helperCodeTemplate;
+      if (baseName === "optionalChainDelete") {
+        helperCode = helperCode.replace("OPTIONAL_CHAIN_NAME", this.helperNames.optionalChain!);
+      }
       if (helperName) {
         resultCode += " ";
         resultCode += helperCode

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -213,7 +213,11 @@ export default class TokenProcessor {
       }
     }
     if (token.isOptionalChainStart) {
-      this.resultCode += this.helperManager.getHelperName("optionalChain");
+      if (this.tokenIndex > 0 && this.tokenAtRelativeIndex(-1).type === tt._delete) {
+        this.resultCode += this.helperManager.getHelperName("optionalChainDelete");
+      } else {
+        this.resultCode += this.helperManager.getHelperName("optionalChain");
+      }
       this.resultCode += "([";
     }
   }

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -28,3 +28,5 @@ if (op === 'access' || op === 'optionalAccess') { lastAccessLHS = value; value =
 else if (op === 'call' || op === 'optionalCall') { \
 value = fn((...args) => value.call(lastAccessLHS, ...args)); lastAccessLHS = undefined; \
 } } return value; }`;
+export const OPTIONAL_CHAIN_DELETE_PREFIX = ` function _optionalChainDelete(ops) { \
+const result = _optionalChain(ops); return result == null ? true : result; }`;


### PR DESCRIPTION
Progress toward #461

Tech plan: https://github.com/alangpierce/sucrase/wiki/Sucrase-Optional-Chaining-and-Nullish-Coalescing-Technical-Plan

This ended up being a relatively small tweak to the optional chaining
implementation:
* There's a new helper that wraps the optionalChain helper, and I needed to add
  a way for helpers to depend on each other.
* In most cases, we condition on the delete and non-delete cases based on
  whether there's a delete token just before the start of the optional chain.
* To determine whether a subscript is the last of its chain (and therefore needs
  a delete operation), we can walk the tokens forward tracking depth until we
  get to either another subscript or the end of the chain. This means there was
  no need for any changes to the parser. Since it only walks between two
adjacent subscripts, it takes linear extra time unless there's nesting, and only
ever does the more expensive operation when processing an optional delete.