### PR TITLE
Allow super when using optional chaining

### DIFF
--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1092,4 +1092,44 @@ describe("sucrase", () => {
       {transforms: []},
     );
   });
+
+  it("allows super in an optional chain", () => {
+    assertResult(
+      `
+      class A extends B {
+        foo() {
+          console.log(super.foo?.a);
+        }
+      }
+    `,
+      `${OPTIONAL_CHAIN_PREFIX}
+      class A extends B {
+        foo() {
+          console.log(_optionalChain([super.foo, 'optionalAccess', _ => _.a]));
+        }
+      }
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("allows a super method call in an optional chain", () => {
+    assertResult(
+      `
+      class A extends B {
+        foo() {
+          console.log(super.a()?.b);
+        }
+      }
+    `,
+      `${OPTIONAL_CHAIN_PREFIX}
+      class A extends B {
+        foo() {
+          console.log(_optionalChain([super.a.bind(this), 'call', _ => _(), 'optionalAccess', _2 => _2.b]));
+        }
+      }
+    `,
+      {transforms: []},
+    );
+  });
 });


### PR DESCRIPTION
Progress toward #461

Tech plan:
https://github.com/alangpierce/sucrase/wiki/Sucrase-Optional-Chaining-and-Nullish-Coalescing-Technical-Plan

To allow super, we mostly just need to skip the code transform on the first
subscript. We also need to add a `.bind(this)` when transforming the second
subscript, which can be determined through a relatively straightforward token
scan.