### PR TITLE
Add support for basic TS assertion signature syntax

### DIFF
--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1836,6 +1836,25 @@ describe("typescript transform", () => {
   it("allows assertion signature syntax", () => {
     assertTypeScriptResult(
       `
+      function assert(condition: any, msg?: string): asserts condition {
+          if (!condition) {
+              throw new AssertionError(msg)
+          }
+      }
+    `,
+      `"use strict";
+      function assert(condition, msg) {
+          if (!condition) {
+              throw new AssertionError(msg)
+          }
+      }
+    `,
+    );
+  });
+
+  it("allows assertion signature syntax with is", () => {
+    assertTypeScriptResult(
+      `
       function assertIsDefined<T>(x: T): asserts x is NonNullable<T> {
         if (x == null) throw "oh no";
       }


### PR DESCRIPTION
Fixes #503

The previous code didn't handle the basic case `asserts x`, which I just
overlooked when backporting Babel parser changes. The new code has a special
case for that and conditionally tells the caller whether to parse a type
afterward. I also made the contract a little simpler; it either fully parses the
return type or it doesn't.