### PR TITLE
Fix nullish coalescing when the RHS is an object literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-  - '12'
 # Theoretically we could cache node_modules and example-repos, but those end up
 # being very slow to download and are largely duplicated with yarn cache.
 cache:
@@ -11,19 +9,23 @@ branches:
     - "master"
 before_install:
   - npm install -g yarn@latest
-matrix:
+jobs:
   include:
     # Put the slowest builds first, since they are more likely to start first
-    - script:
+    - node_js: '12'
+      script:
         - yarn fast-build
         - yarn run-examples babel
-    - script:
+    - node_js: '12'
+      script:
         - yarn fast-build
         - yarn run-examples react decaffeinate decaffeinate-parser coffee-lex
-    - script:
+    - node_js: '12'
+      script:
         - yarn fast-build
         - yarn run-examples tslint apollo-client
-    - script:
+    - node_js: '12'
+      script:
         - yarn build
         - yarn lint
         - yarn test-with-coverage && yarn report-coverage
@@ -32,6 +34,3 @@ matrix:
       script:
         - yarn build
         - yarn test-only
-  # Exclude the default build; we only want to run explicitly-included builds.
-  exclude:
-    node_js: '12'

--- a/example-runner/example-configs/babel.patch
+++ b/example-runner/example-configs/babel.patch
@@ -174,6 +174,40 @@ index d92699883..2bdedecaa 100644
  
  export type BindingTypes =
    | typeof BIND_NONE
+diff --git a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
+index 204120c62..1950ebc1c 100644
+--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
++++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/T6755/output.js
+@@ -20,7 +20,7 @@ function () {
+             return _context.stop();
+         }
+       }
+-    });
++    }, null, null, null, Promise);
+   };
+ 
+   _proto.test2 =
+diff --git a/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/with-unicode-property-escape/output.js b/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/with-unicode-property-escape/output.js
+index a8ddf757d..c00aa15a9 100644
+--- a/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/with-unicode-property-escape/output.js
++++ b/packages/babel-plugin-transform-dotall-regex/test/fixtures/dotall-regex/with-unicode-property-escape/output.js
+@@ -1,2 +1,2 @@
+-var a = /[\u3400-\u4DB5\u4E00-\u9FEF\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29\u{20000}-\u{2A6D6}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}][\0-\t\x0B\f\x0E-\u2027\u202A-\u{10FFFF}]/u;
+-var b = /[\u3400-\u4DB5\u4E00-\u9FEF\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29\u{20000}-\u{2A6D6}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}][\0-\u{10FFFF}]/u;
++var a = /[\u3400-\u4DBF\u4E00-\u9FFC\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29\u{20000}-\u{2A6DD}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}\u{30000}-\u{3134A}][\0-\t\x0B\f\x0E-\u2027\u202A-\u{10FFFF}]/u;
++var b = /[\u3400-\u4DBF\u4E00-\u9FFC\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29\u{20000}-\u{2A6DD}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}\u{30000}-\u{3134A}][\0-\u{10FFFF}]/u;
+diff --git a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
+index a3b8fd1f2..3fa934c71 100644
+--- a/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
++++ b/packages/babel-plugin-transform-regenerator/test/fixtures/regression/4219/output.js
+@@ -12,6 +12,6 @@ function test(fn) {
+             return _context.stop();
+         }
+       }
+-    });
++    }, null, null, null, Promise);
+   };
+ }
 diff --git a/packages/babel-polyfill/src/index.js b/packages/babel-polyfill/src/index.js
 index aa1b4639f..cca92db5a 100644
 --- a/packages/babel-polyfill/src/index.js

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -247,7 +247,7 @@ export default class TokenProcessor {
     }
     if (token.numNullishCoalesceEnds) {
       for (let i = 0; i < token.numNullishCoalesceEnds; i++) {
-        this.resultCode += ")";
+        this.resultCode += "))";
       }
     }
   }

--- a/src/transformers/OptionalChainingNullishTransformer.ts
+++ b/src/transformers/OptionalChainingNullishTransformer.ts
@@ -21,9 +21,9 @@ export default class OptionalChainingNullishTransformer extends Transformer {
     if (this.tokens.matches1(tt.nullishCoalescing)) {
       const token = this.tokens.currentToken();
       if (this.tokens.tokens[token.nullishStartIndex!].isAsyncOperation) {
-        this.tokens.replaceTokenTrimmingLeftWhitespace(", async () =>");
+        this.tokens.replaceTokenTrimmingLeftWhitespace(", async () => (");
       } else {
-        this.tokens.replaceTokenTrimmingLeftWhitespace(", () =>");
+        this.tokens.replaceTokenTrimmingLeftWhitespace(", () => (");
       }
       return true;
     }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -889,7 +889,7 @@ describe("sucrase", () => {
       const x = a ?? b;
     `,
       `${NULLISH_COALESCE_PREFIX}
-      const x = _nullishCoalesce(a, () => b);
+      const x = _nullishCoalesce(a, () => ( b));
     `,
       {transforms: []},
     );
@@ -901,7 +901,7 @@ describe("sucrase", () => {
       const x = a ?? b ?? c;
     `,
       `${NULLISH_COALESCE_PREFIX}
-      const x = _nullishCoalesce(_nullishCoalesce(a, () => b), () => c);
+      const x = _nullishCoalesce(_nullishCoalesce(a, () => ( b)), () => ( c));
     `,
       {transforms: []},
     );
@@ -957,6 +957,29 @@ describe("sucrase", () => {
       setOutput(a?.b.c ?? 10);
     `,
       10,
+      {transforms: []},
+    );
+  });
+
+  it("correctly transpiles nullish coalescing with an object right-hand side", () => {
+    assertResult(
+      `
+      null ?? {x: 5}
+    `,
+      `${NULLISH_COALESCE_PREFIX}
+      _nullishCoalesce(null, () => ( {x: 5}))
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("correctly handles nullish coalescing with an object on the right-hand side", () => {
+    assertOutput(
+      `
+      const value = null ?? {x: 5};
+      setOutput(value.x)
+    `,
+      5,
       {transforms: []},
     );
   });
@@ -1086,7 +1109,7 @@ describe("sucrase", () => {
     `,
       `${ASYNC_NULLISH_COALESCE_PREFIX}
       async function foo() {
-        return await _asyncNullishCoalesce(a, async () => await b());
+        return await _asyncNullishCoalesce(a, async () => ( await b()));
       }
     `,
       {transforms: []},


### PR DESCRIPTION
Fixes #505

The RHS is meant to be transpiled into an expression arrow function, but if the
expression is an object literal, it gets interpreted as a block body. To fix, we
can unconditionally surround the arrow body in parens. This is a little ugly in
that it leaves an extra space, but avoiding that is probably more trouble than
it's worth.

Also fix two issues with test infra:
* The build was only running the very last build configuration due to what seems to be a
  breaking change in Travis. Updated the yaml file to use `jobs` instead of `matrix`, which
  seems to work better.
* Three Babel tests had broken due to fixture tests that were testing unpinned behavior (looks
  like regex transformation and preset-env behavior). I was hoping to fix them by pinning the
  dependencies or updating to latest Babel, but ended up just updating the expected test code
  for now. I confirmed that this was a regression on the Babel end rather than anything caused by
  a Sucrase change.