### PR TITLE
Fix crash when access modifiers are used in constructor param defaults

### DIFF
--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -86,6 +86,7 @@ export function parseBindingList(
   isBlockScope: boolean,
   allowEmpty: boolean = false,
   allowModifiers: boolean = false,
+  contextId: number = 0,
 ): void {
   let first = true;
 
@@ -97,6 +98,7 @@ export function parseBindingList(
       first = false;
     } else {
       expect(tt.comma);
+      state.tokens[state.tokens.length - 1].contextId = contextId;
       // After a "this" type in TypeScript, we need to set the following comma (if any) to also be
       // a type token so that it will be removed.
       if (!hasRemovedComma && state.tokens[firstItemTokenIndex].isType) {

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -614,7 +614,13 @@ export function parseFunctionParams(
   if (funcContextId) {
     state.tokens[state.tokens.length - 1].contextId = funcContextId;
   }
-  parseBindingList(tt.parenR, false /* isBlockScope */, false /* allowEmpty */, allowModifiers);
+  parseBindingList(
+    tt.parenR,
+    false /* isBlockScope */,
+    false /* allowEmpty */,
+    allowModifiers,
+    funcContextId,
+  );
   if (funcContextId) {
     state.tokens[state.tokens.length - 1].contextId = funcContextId;
   }

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1974,4 +1974,34 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("properly handles default args in constructors", () => {
+    assertTypeScriptResult(
+      `
+      class Foo {
+        constructor(p = -1) {}
+      }
+    `,
+      `"use strict";
+      class Foo {
+        constructor(p = -1) {}
+      }
+    `,
+    );
+  });
+
+  it("properly emits assignments with multiple constructor initializers", () => {
+    assertTypeScriptResult(
+      `
+      class Foo {
+        constructor(a: number, readonly b: number, private c: number) {}
+      }
+    `,
+      `"use strict";
+      class Foo {
+        constructor(a,  b,  c) {;this.b = b;this.c = c;}
+      }
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #522

Previously, the logic to compile TS constructor param assignments walked through
all tokens in the constructor looking for access modifiers, but this can cause
problems if default values include access modifiers. Now, we mark commas
associated with the constructor and only emit assignments when we see an
open-paren or comma followed by an access modifier.