### PR TITLE
Add support for TS type-only imports and exports

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -300,6 +300,17 @@ export default class CJSImportTransformer extends Transformer {
     } else if (this.tokens.matches2(tt._export, tt.star)) {
       this.processExportStar();
       return true;
+    } else if (
+      this.tokens.matches3(tt._export, tt.name, tt.braceL) &&
+      this.tokens.matchesContextualAtIndex(this.tokens.currentIndex() + 1, ContextualKeyword._type)
+    ) {
+      // TS `export type {` case: just remove the export entirely.
+      this.tokens.removeInitialToken();
+      while (!this.tokens.matches1(tt.braceR)) {
+        this.tokens.removeToken();
+      }
+      this.tokens.removeToken();
+      return true;
     } else {
       throw new Error("Unrecognized export syntax.");
     }

--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -55,6 +55,18 @@ export default class ESMImportTransformer extends Transformer {
     if (this.tokens.matches2(tt._export, tt.braceL)) {
       return this.processNamedExports();
     }
+    if (
+      this.tokens.matches3(tt._export, tt.name, tt.braceL) &&
+      this.tokens.matchesContextualAtIndex(this.tokens.currentIndex() + 1, ContextualKeyword._type)
+    ) {
+      // TS `export type {` case: just remove the export entirely.
+      this.tokens.removeInitialToken();
+      while (!this.tokens.matches1(tt.braceR)) {
+        this.tokens.removeToken();
+      }
+      this.tokens.removeToken();
+      return true;
+    }
     return false;
   }
 

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1962,15 +1962,92 @@ describe("typescript transform", () => {
     );
   });
 
-  it("parses and removes import type statements", () => {
+  it("parses and removes import type statements in CJS mode", () => {
     assertTypeScriptResult(
       `
       import type foo from 'foo';
-      console.log(foo);
+      import bar from 'bar';
+      console.log(foo, bar);
+    `,
+      `"use strict";${IMPORT_DEFAULT_PREFIX}
+      
+      var _bar = require('bar'); var _bar2 = _interopRequireDefault(_bar);
+      console.log(foo, _bar2.default);
+    `,
+    );
+  });
+
+  it("parses and removes named import type statements in CJS mode", () => {
+    assertTypeScriptResult(
+      `
+      import type {foo} from 'foo';
+      import {bar} from 'bar';
+      console.log(foo, bar);
     `,
       `"use strict";
       
-      console.log(foo);
+      var _bar = require('bar');
+      console.log(foo, _bar.bar);
+    `,
+    );
+  });
+
+  it("parses and removes import type statements in ESM mode", () => {
+    assertTypeScriptESMResult(
+      `
+      import type foo from 'foo';
+      import bar from 'bar';
+      console.log(foo, bar);
+    `,
+      `
+
+      import bar from 'bar';
+      console.log(foo, bar);
+    `,
+    );
+  });
+
+  it("parses and removes named import type statements in ESM mode", () => {
+    assertTypeScriptESMResult(
+      `
+      import type {foo} from 'foo';
+      import {bar} from 'bar';
+      console.log(foo, bar);
+    `,
+      `
+
+      import {bar} from 'bar';
+      console.log(foo, bar);
+    `,
+    );
+  });
+
+  it("parses and removes export type statements in CJS mode", () => {
+    assertTypeScriptResult(
+      `
+      import T from './T';
+      let x: T;
+      export type {T};
+    `,
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
+      var _T = require('./T'); var _T2 = _interopRequireDefault(_T);
+      let x;
+      ;
+    `,
+    );
+  });
+
+  it("parses and removes export type statements in ESM mode", () => {
+    assertTypeScriptESMResult(
+      `
+      import T from './T';
+      let x: T;
+      export type {T};
+    `,
+      `
+      import T from './T';
+      let x;
+      ;
     `,
     );
   });


### PR DESCRIPTION
Fixes #520

The PR #523 already added parsing support for type-only import and export
syntax, and there was already support for removing `import type` from Flow, so
the only new logic was to fully support `export type`. The implementation here
is a little ugly; Flow's version sets the tokens as type tokens, whereas the TS
version sets the types as regular tokens and removes them at transform type.
This seems to be necessary to follow the behavior that `export type` statements
do not result in the imported value being elided.

Ideally, Sucrase would support the `importsNotUsedAsValues` TS preference in
some way, but for now, it keeps the old behavior of eliding type-only imports.
The setting `importsNotUsedAsValues=error` should make the distinction
irrelevant anyway, so it seems low priority to support.