### PR TITLE
Add support for TS type-only re-exports

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -310,6 +310,15 @@ export default class CJSImportTransformer extends Transformer {
         this.tokens.removeToken();
       }
       this.tokens.removeToken();
+
+      // Remove type re-export `... } from './T'`
+      if (
+        this.tokens.matchesContextual(ContextualKeyword._from) &&
+        this.tokens.matches1AtIndex(this.tokens.currentIndex() + 1, tt.string)
+      ) {
+        this.tokens.removeToken();
+        this.tokens.removeToken();
+      }
       return true;
     } else {
       throw new Error("Unrecognized export syntax.");

--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -65,6 +65,15 @@ export default class ESMImportTransformer extends Transformer {
         this.tokens.removeToken();
       }
       this.tokens.removeToken();
+
+      // Remove type re-export `... } from './T'`
+      if (
+        this.tokens.matchesContextual(ContextualKeyword._from) &&
+        this.tokens.matches1AtIndex(this.tokens.currentIndex() + 1, tt.string)
+      ) {
+        this.tokens.removeToken();
+        this.tokens.removeToken();
+      }
       return true;
     }
     return false;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2052,6 +2052,32 @@ describe("typescript transform", () => {
     );
   });
 
+  it("parses and removes export type re-export statements in CJS mode", () => {
+    assertTypeScriptResult(
+      `
+      export type {T} from './T';
+      export type {T1 as TX, T2 as TY} from './OtherTs';
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      ;
+      ;
+    `,
+    );
+  });
+
+  it("parses and removes export type re-export statements in ESM mode", () => {
+    assertTypeScriptESMResult(
+      `
+      export type {T} from './T';
+      export type {T1 as TX, T2 as TY} from './OtherTs';
+    `,
+      `
+      ;
+      ;
+    `,
+    );
+  });
+
   it("properly handles default args in constructors", () => {
     assertTypeScriptResult(
       `


### PR DESCRIPTION
Hi! I ran into some trouble using type re-exports in TypeScript.

```ts
export type { T } from './T';
```

would be transpiled to

```ts
       from './T';
```

The syntax form is mentioned in the PR adding the functionality to TS: https://github.com/microsoft/TypeScript/pull/35200

Wondering if this looks like an alright fix?