### PR TITLE
Add support for parsing `declare` TS class fields

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -113,6 +113,9 @@ export function tsParseModifier(
       case ContextualKeyword._protected:
         state.tokens[state.tokens.length - 1].type = tt._protected;
         break;
+      case ContextualKeyword._declare:
+        state.tokens[state.tokens.length - 1].type = tt._declare;
+        break;
       default:
         break;
     }
@@ -1213,18 +1216,21 @@ export function tsTryParseClassMemberWithIsStatic(
   let isAbstract = false;
   let isReadonly = false;
 
-  const mod = tsParseModifier([ContextualKeyword._abstract, ContextualKeyword._readonly]);
-  switch (mod) {
-    case ContextualKeyword._readonly:
+  while (true) {
+    const mod = tsParseModifier([
+      ContextualKeyword._abstract,
+      ContextualKeyword._readonly,
+      ContextualKeyword._declare,
+    ]);
+    if (mod == null) {
+      break;
+    }
+    if (mod === ContextualKeyword._readonly) {
       isReadonly = true;
-      isAbstract = !!tsParseModifier([ContextualKeyword._abstract]);
-      break;
-    case ContextualKeyword._abstract:
+    }
+    if (mod === ContextualKeyword._abstract) {
       isAbstract = true;
-      isReadonly = !!tsParseModifier([ContextualKeyword._readonly]);
-      break;
-    default:
-      break;
+    }
   }
 
   // We no longer check for public/private/etc, but tsTryParseIndexSignature should just return

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -688,7 +688,9 @@ function parseClassBody(classContextId: number): void {
 
 function parseClassMember(memberStart: number, classContextId: number): void {
   if (isTypeScriptEnabled) {
+    eatContextual(ContextualKeyword._declare);
     tsParseAccessModifier();
+    eatContextual(ContextualKeyword._declare);
   }
   let isStatic = false;
   if (match(tt.name) && state.contextualKeyword === ContextualKeyword._static) {

--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -263,6 +263,7 @@ function isAccessModifier(token: Token): boolean {
     tt._protected,
     tt._abstract,
     tt.star,
+    tt._declare,
   ].includes(token.type);
 }
 

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2107,4 +2107,41 @@ describe("typescript transform", () => {
     `,
     );
   });
+
+  it("properly removes class fields with declare", () => {
+    assertTypeScriptResult(
+      `
+      class Foo {
+          declare a: number;
+          public declare b: number;
+          declare public c: number;
+          static declare d: number;
+          declare static e: number;
+          declare public static f: number;
+          public declare static g: number;
+          public static declare h: number;
+          
+          constructor() {
+              console.log('Hi');
+          }
+      }
+    `,
+      `"use strict";
+      class Foo {
+           
+           
+           
+          
+           
+           
+           
+          
+          
+          constructor() {
+              console.log('Hi');
+          }
+      }
+    `,
+    );
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,
+    "useDefineForClassFields": true,
     "plugins": [
       {
         "name": "typescript-tslint-plugin",


### PR DESCRIPTION
Fixes #536

We already completely remove uninitialized class fields for now, which agrees
with the `declare` behavior, so the only change needed here was to parse the
syntax without crashing. In the future, when we remove the class fields
transform, we'll need to distinguish declare vs non-declare fields.