### PR TITLE
Add jest transform for hoisting module mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ transforms are available:
   transform in the [react-hot-loader](https://github.com/gaearon/react-hot-loader)
   project. This enables advanced hot reloading use cases such as editing of
   bound methods.
+* **jest**: Hoist desired [jest](https://jestjs.io/) method calls above imports in
+  the same way as [babel-plugin-jest-hoist](https://github.com/facebook/jest/tree/master/packages/babel-plugin-jest-hoist).
+  Does not validate the arguments passed to `jest.mock`, but the same rules still apply.
 
 These proposed JS features are built-in and always transformed:
 * [Optional chaining](https://github.com/tc39/proposal-optional-chaining): `a?.b`

--- a/integrations/jest-plugin/README.md
+++ b/integrations/jest-plugin/README.md
@@ -24,5 +24,5 @@ Then add it as a transform to your Jest config in package.json:
 ```
 
 Currently, the transforms are not configurable; it uses always runs the import
-transform and uses the file extension to decide whether to run the JSX, Flow,
-and/or TypeScript transforms.
+and jest transforms and uses the file extension to decide whether to run the
+JSX, Flow, and/or TypeScript transforms.

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -2,11 +2,11 @@ import {Transform, transform} from "sucrase";
 
 function getTransforms(filename: string): Array<Transform> | null {
   if (filename.endsWith(".js") || filename.endsWith(".jsx")) {
-    return ["flow", "jsx", "imports"];
+    return ["flow", "jsx", "imports", "jest"];
   } else if (filename.endsWith(".ts")) {
-    return ["typescript", "imports"];
+    return ["typescript", "imports", "jest"];
   } else if (filename.endsWith(".tsx")) {
-    return ["typescript", "jsx", "imports"];
+    return ["typescript", "jsx", "imports", "jest"];
   }
   return null;
 }

--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -10,6 +10,7 @@ export const Transform = t.union(
   t.lit("flow"),
   t.lit("imports"),
   t.lit("react-hot-loader"),
+  t.lit("jest"),
 );
 
 export const SourceMapOptions = t.iface([], {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -3,7 +3,7 @@ import OptionsGenTypes from "./Options-gen-types";
 
 const {Options: OptionsChecker} = createCheckers(OptionsGenTypes);
 
-export type Transform = "jsx" | "typescript" | "flow" | "imports" | "react-hot-loader";
+export type Transform = "jsx" | "typescript" | "flow" | "imports" | "react-hot-loader" | "jest";
 
 export interface SourceMapOptions {
   /**

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -172,7 +172,8 @@ export default class TokenProcessor {
   }
 
   removeToken(): void {
-    this.replaceTokenTrimmingLeftWhitespace("");
+    this.resultCode += this.previousWhitespaceAndComments().replace(/[^\r\n]/g, "");
+    this.tokenIndex++;
   }
 
   copyExpectedToken(tokenType: TokenType): void {

--- a/src/transformers/JestHoistTransformer.ts
+++ b/src/transformers/JestHoistTransformer.ts
@@ -1,0 +1,105 @@
+import type CJSImportProcessor from "../CJSImportProcessor";
+import {TokenType as tt} from "../parser/tokenizer/types";
+import type TokenProcessor from "../TokenProcessor";
+import type RootTransformer from "./RootTransformer";
+import Transformer from "./Transformer";
+
+const JEST_GLOBAL_NAME = "jest";
+const HOISTED_METHODS = ["mock", "unmock", "enableAutomock", "disableAutomock"];
+
+/**
+ * Implementation of babel-plugin-jest-hoist, which hoists up some jest method
+ * calls above the imports to allow them to override other imports.
+ */
+export default class JestHoistTransformer extends Transformer {
+  private readonly hoistedCalls: Array<string> = [];
+
+  constructor(
+    readonly rootTransformer: RootTransformer,
+    readonly tokens: TokenProcessor,
+    readonly importProcessor: CJSImportProcessor | null,
+  ) {
+    super();
+  }
+
+  process(): boolean {
+    if (
+      this.tokens.currentToken().scopeDepth === 0 &&
+      this.tokens.matches4(tt.name, tt.dot, tt.name, tt.parenL) &&
+      this.tokens.identifierName() === JEST_GLOBAL_NAME
+    ) {
+      // TODO: This only works if imports transform is active, which it will be for jest.
+      //       But if jest adds module support and we no longer need the import transform, this needs fixing.
+      if (this.importProcessor?.getGlobalNames()?.has(JEST_GLOBAL_NAME)) {
+        return false;
+      }
+      return this.extractHoistedCalls();
+    }
+
+    return false;
+  }
+
+  getHoistedCode(): string {
+    if (this.hoistedCalls.length > 0) {
+      // This will be placed before module interop code, but that's fine since
+      // imports aren't allowed in module mock factories.
+      return `\n${JEST_GLOBAL_NAME}${this.hoistedCalls.join("")};`;
+    }
+    return "";
+  }
+
+  /**
+   * Extracts any methods calls on the jest-object that should be hoisted.
+   *
+   * According to the jest docs, https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options,
+   * mock, unmock, enableAutomock, disableAutomock, are the methods that should be hoisted.
+   *
+   * We do not apply the same checks of the arguments as babel-plugin-jest-hoist does.
+   */
+  private extractHoistedCalls(): boolean {
+    // We remove the `jest` expression, then add it back later if we find a non-hoisted call
+    this.tokens.removeToken();
+    let restoredJest = false;
+
+    // Iterate through all chained calls on the jest object
+    while (this.tokens.matches3(tt.dot, tt.name, tt.parenL)) {
+      const methodName = this.tokens.identifierNameAtIndex(this.tokens.currentIndex() + 1);
+      const shouldHoist = HOISTED_METHODS.includes(methodName);
+      if (shouldHoist) {
+        // We've matched e.g. `.mock(...)` or similar call
+        // Start by applying transforms to the entire call, including parameters
+        const snapshotBefore = this.tokens.snapshot();
+        this.tokens.copyToken();
+        this.tokens.copyToken();
+        this.tokens.copyToken();
+        this.rootTransformer.processBalancedCode();
+        this.tokens.copyExpectedToken(tt.parenR);
+        const snapshotAfter = this.tokens.snapshot();
+
+        // Then grab the transformed code and store it for hoisting
+        const processedCall = snapshotAfter.resultCode.slice(snapshotBefore.resultCode.length);
+        this.hoistedCalls.push(processedCall);
+
+        // Now go back and remove the entire method call
+        const endIndex = this.tokens.currentIndex();
+        this.tokens.restoreToSnapshot(snapshotBefore);
+        while (this.tokens.currentIndex() < endIndex) {
+          this.tokens.removeToken();
+        }
+      } else {
+        if (!restoredJest) {
+          restoredJest = true;
+          this.tokens.appendCode(JEST_GLOBAL_NAME);
+        }
+        // When not hoisting we just transform the method call as usual
+        this.tokens.copyToken();
+        this.tokens.copyToken();
+        this.tokens.copyToken();
+        this.rootTransformer.processBalancedCode();
+        this.tokens.copyExpectedToken(tt.parenR);
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -8,6 +8,7 @@ import getClassInfo, {ClassInfo} from "../util/getClassInfo";
 import CJSImportTransformer from "./CJSImportTransformer";
 import ESMImportTransformer from "./ESMImportTransformer";
 import FlowTransformer from "./FlowTransformer";
+import JestHoistTransformer from "./JestHoistTransformer";
 import JSXTransformer from "./JSXTransformer";
 import NumericSeparatorTransformer from "./NumericSeparatorTransformer";
 import OptionalCatchBindingTransformer from "./OptionalCatchBindingTransformer";
@@ -100,6 +101,9 @@ export default class RootTransformer {
         new TypeScriptTransformer(this, tokenProcessor, transforms.includes("imports")),
       );
     }
+    if (transforms.includes("jest")) {
+      this.transformers.push(new JestHoistTransformer(this, tokenProcessor, importProcessor));
+    }
   }
 
   transform(): string {
@@ -113,6 +117,9 @@ export default class RootTransformer {
     }
     prefix += this.helperManager.emitHelpers();
     prefix += this.generatedVariables.map((v) => ` var ${v};`).join("");
+    for (const transformer of this.transformers) {
+      prefix += transformer.getHoistedCode();
+    }
     let suffix = "";
     for (const transformer of this.transformers) {
       suffix += transformer.getSuffixCode();

--- a/src/transformers/Transformer.ts
+++ b/src/transformers/Transformer.ts
@@ -6,6 +6,10 @@ export default abstract class Transformer {
     return "";
   }
 
+  getHoistedCode(): string {
+    return "";
+  }
+
   getSuffixCode(): string {
     return "";
   }

--- a/test/jest-test.ts
+++ b/test/jest-test.ts
@@ -1,0 +1,250 @@
+import {
+  ESMODULE_PREFIX,
+  IMPORT_DEFAULT_PREFIX,
+  NULLISH_COALESCE_PREFIX,
+  OPTIONAL_CHAIN_PREFIX,
+} from "./prefixes";
+import {assertResult} from "./util";
+
+function assertCJSResult(code: string, expectedResult: string): void {
+  assertResult(code, expectedResult, {transforms: ["jsx", "jest", "imports"]});
+}
+
+function assertESMResult(code: string, expectedResult: string): void {
+  assertResult(code, expectedResult, {transforms: ["jsx", "jest"]});
+}
+
+function assertImportResult(
+  code: string,
+  {expectedCJSResult, expectedESMResult}: {expectedCJSResult: string; expectedESMResult: string},
+): void {
+  assertCJSResult(code, expectedCJSResult);
+  assertESMResult(code, expectedESMResult);
+}
+
+describe("transform jest", () => {
+  it("hoists desired methods", () => {
+    assertESMResult(
+      `
+      import 'moduleName';
+      jest.mock('a');
+      jest.unmock('b').unknown().enableAutomock();
+      jest.disableAutomock()
+      jest.mock('c', () => {}).mock('d', () => {});
+      jest.doMock('a', () => {});
+    `,
+      `
+jest.mock('a').unmock('b').enableAutomock().disableAutomock().mock('c', () => {}).mock('d', () => {});
+      import 'moduleName';
+;
+jest.unknown();
+
+;
+jest.doMock('a', () => {});
+    `,
+    );
+  });
+
+  it("hoists jest mocks with interleaved imports", () => {
+    assertImportResult(
+      `
+        import {A} from 'a';
+        jest.mock('a');
+        import {B} from 'b';
+        jest.mock('b', () => ({}));
+        import C from 'c';
+        jest.unmock('c')
+      `,
+      {
+        expectedCJSResult: `"use strict";${IMPORT_DEFAULT_PREFIX}
+jest.mock('a').mock('b', () => ({})).unmock('c');
+        var _a = require('a');
+;
+        var _b = require('b');
+;
+        var _c = require('c'); var _c2 = _interopRequireDefault(_c);
+
+      `,
+        expectedESMResult: `
+jest.mock('a').mock('b', () => ({})).unmock('c');
+        import {A} from 'a';
+;
+        import {B} from 'b';
+;
+        import C from 'c';
+
+      `,
+      },
+    );
+  });
+
+  it("places import helpers properly", () => {
+    assertCJSResult(
+      `
+      import a from './a';
+      import {B} from './b';
+      jest.mock('a');
+
+      export const x = 1
+    `,
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
+jest.mock('a');
+      var _a = require('./a'); var _a2 = _interopRequireDefault(_a);
+      var _b = require('./b');
+;
+
+       const x = 1; exports.x = x
+    `,
+    );
+  });
+
+  it("transforms arguments and includes helpers", () => {
+    assertCJSResult(
+      `
+      import A from './a';
+jest.mock('a', () => ({
+  f(x) {
+    return x?.a ?? 0;
+  }
+}));
+    `,
+      `"use strict";${IMPORT_DEFAULT_PREFIX}${NULLISH_COALESCE_PREFIX}${OPTIONAL_CHAIN_PREFIX}
+jest.mock('a', () => ({
+  f(x) {
+    return _nullishCoalesce(_optionalChain([x, 'optionalAccess', _ => _.a]), () => ( 0));
+  }
+}));
+      var _a = require('./a'); var _a2 = _interopRequireDefault(_a);
+
+
+
+
+;
+    `,
+    );
+  });
+
+  it("transforms typescript arguments", () => {
+    assertResult(
+      `
+      import {x, X} from './a';
+jest.mock('a'! as number, (arg: unknown) => ({
+  f(x?: string): void {
+    return x! as X;
+  }
+}) as any);
+      x()
+    `,
+      `"use strict";
+jest.mock('a' , (arg) => ({
+  f(x) {
+    return x ;
+  }
+}) );
+      var _a = require('./a');
+
+
+
+
+;
+      _a.x.call(void 0, )
+    `,
+      {transforms: ["jsx", "jest", "imports", "typescript"]},
+    );
+  });
+
+  it("transforms flow arguments", () => {
+    assertResult(
+      `
+      import {x, X} from './a';
+jest.mock('a': number, (arg: string) => ({
+  f(x: string): void {
+    return (x: X);
+  }
+}): any);
+      x()
+    `,
+      `"use strict";
+jest.mock('a', (arg) => ({
+  f(x) {
+    return (x);
+  }
+}));
+      var _a = require('./a');
+
+
+
+
+;
+      _a.x.call(void 0, )
+    `,
+      {transforms: ["jsx", "jest", "imports", "flow"]},
+    );
+  });
+
+  it("transforms jsx in parameters", () => {
+    assertResult(
+      `
+      import {x, X} from './a';
+jest.mock('a': number, (arg: string) => ({
+  f(x: string): void {
+    return (x: X);
+  }
+}): any);
+      x()
+    `,
+      `"use strict";
+jest.mock('a', (arg) => ({
+  f(x) {
+    return (x);
+  }
+}));
+      var _a = require('./a');
+
+
+
+
+;
+      _a.x.call(void 0, )
+    `,
+      {transforms: ["jsx", "jest", "imports", "flow"]},
+    );
+  });
+
+  it("avoids hoisting if jest is an imported symbol", () => {
+    assertImportResult(
+      `
+      import {jest} from './a';
+      jest.mock('x');
+    `,
+      {
+        expectedCJSResult: `"use strict";
+      var _a = require('./a');
+      _a.jest.mock('x');
+    `,
+        // Note that this behavior is incorrect, but jest requires imports transform for now.
+        expectedESMResult: `
+jest.mock('x');
+      import {jest} from './a';
+;
+    `,
+      },
+    );
+  });
+
+  it("avoids hoisting if jest is imported in typescript", () => {
+    assertResult(
+      `
+      import './a'
+      import {jest} from './b';
+      jest.mock('x');
+    `,
+      `"use strict";
+      require('./a');
+      var _b = require('./b');
+      _b.jest.mock('x');
+    `,
+      {transforms: ["jsx", "jest", "imports", "typescript"]},
+    );
+  });
+});


### PR DESCRIPTION
Made an attempt at #539, let me know if this makes sense :grin:

It doesn't do all the same checks as babel-plugin-jest-hoist, which verifies that only whitelisted out-of-scope variables are accessed inside module mock factories.

Also had to add `getHoistedCode` to `Transformer`, to be able to move code up below all the helpers. There might be some nicer way to do this though.

It also doesn't support non-imports transform + jest, but since jest currently doesn't support ESM, that can be added later. Figured the most straight-forward way to do that would be to add global names to the `SucraseContext`, regardless of which transform is selected. Basically adding an equivalent of `importProcessor.getGlobalNames()` and `getTSImportedNames(tokenProcessor)` for when neither `imports` or `typescript` processors are active.
