### PR TITLE
Fix #560: Support for private class fields

### DIFF
--- a/benchmark/sample/expression.ts
+++ b/benchmark/sample/expression.ts
@@ -301,7 +301,7 @@ export function baseParseSubscript(
       parseIdentifier();
     }
   } else if (eat(tt.dot)) {
-    parseMaybePrivateName();
+    parseIdentifier();
   } else if (eat(tt.bracketL)) {
     parseExpression();
     expect(tt.bracketR);
@@ -506,11 +506,6 @@ export function parseExprAtom(): boolean {
     default:
       throw unexpected();
   }
-}
-
-function parseMaybePrivateName(): void {
-  eat(tt.hash);
-  parseIdentifier();
 }
 
 function parseFunctionExpression(): void {
@@ -839,7 +834,7 @@ export function parsePropertyName(objectContextId: number): void {
     if (match(tt.num) || match(tt.string)) {
       parseExprAtom();
     } else {
-      parseMaybePrivateName();
+      parseIdentifier();
     }
 
     state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ObjectKey;

--- a/generator/generateTokenTypes.ts
+++ b/generator/generateTokenTypes.ts
@@ -76,7 +76,6 @@ const types = {
   backQuote: new TokenType("`"),
   dollarBraceL: new TokenType("${"),
   at: new TokenType("@"),
-  hash: new TokenType("#"),
 
   eq: new TokenType("=", {isAssign}),
   assign: new TokenType("_=", {isAssign}),

--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -84,7 +84,6 @@ function tsNextTokenCanFollowModifier(): boolean {
       match(tt.braceL) ||
       match(tt.star) ||
       match(tt.ellipsis) ||
-      match(tt.hash) ||
       isLiteralPropertyName()) &&
     !hasPrecedingLineBreak();
 

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -228,10 +228,6 @@ export function nextTokenStartSince(pos: number): number {
   return pos + skip![0].length;
 }
 
-export function lookaheadCharCode(): number {
-  return input.charCodeAt(nextTokenStart());
-}
-
 // Read a single token, updating the parser object's token-related
 // properties.
 export function nextToken(): void {
@@ -549,11 +545,6 @@ function readToken_question(): void {
 
 export function getTokenFromCode(code: number): void {
   switch (code) {
-    case charCodes.numberSign:
-      ++state.pos;
-      finishToken(tt.hash);
-      return;
-
     // The interpretation of a dot depends on whether it is followed
     // by a digit or another two dots.
 

--- a/src/parser/tokenizer/types.ts
+++ b/src/parser/tokenizer/types.ts
@@ -39,7 +39,6 @@ export enum TokenType {
   backQuote = 12800, // `
   dollarBraceL = 13312, // ${
   at = 13824, // @
-  hash = 14336, // #
   eq = 14880, // = isAssign
   assign = 15392, // _= isAssign
   preIncDec = 16256, // ++/-- prefix postfix
@@ -180,8 +179,6 @@ export function formatTokenType(tokenType: TokenType): string {
       return "${";
     case TokenType.at:
       return "@";
-    case TokenType.hash:
-      return "#";
     case TokenType.eq:
       return "=";
     case TokenType.assign:

--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -45,7 +45,6 @@ import {
 import {
   eat,
   IdentifierRole,
-  lookaheadCharCode,
   lookaheadType,
   match,
   next,
@@ -57,8 +56,6 @@ import {
 import {ContextualKeyword} from "../tokenizer/keywords";
 import {Scope} from "../tokenizer/state";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
-import {charCodes} from "../util/charcodes";
-import {IS_IDENTIFIER_START} from "../util/identifier";
 import {getNextContextId, isFlowEnabled, isJSXEnabled, isTypeScriptEnabled, state} from "./base";
 import {
   markPriorBindingIdentifier,
@@ -328,11 +325,11 @@ export function baseParseSubscript(
     } else if (eat(tt.parenL)) {
       parseCallExpressionArguments();
     } else {
-      parseMaybePrivateName();
+      parseIdentifier();
     }
   } else if (eat(tt.dot)) {
     state.tokens[state.tokens.length - 1].subscriptStartIndex = startTokenIndex;
-    parseMaybePrivateName();
+    parseIdentifier();
   } else if (eat(tt.bracketL)) {
     state.tokens[state.tokens.length - 1].subscriptStartIndex = startTokenIndex;
     parseExpression();
@@ -565,26 +562,10 @@ export function parseExprAtom(): boolean {
       return false;
     }
 
-    case tt.hash: {
-      const code = lookaheadCharCode();
-      if (IS_IDENTIFIER_START[code] || code === charCodes.backslash) {
-        parseMaybePrivateName();
-      } else {
-        next();
-      }
-      // Smart pipeline topic reference.
-      return false;
-    }
-
     default:
       unexpected();
       return false;
   }
-}
-
-function parseMaybePrivateName(): void {
-  eat(tt.hash);
-  parseIdentifier();
 }
 
 function parseFunctionExpression(): void {
@@ -885,7 +866,7 @@ export function parsePropertyName(objectContextId: number): void {
     if (match(tt.num) || match(tt.string) || match(tt.bigint) || match(tt.decimal)) {
       parseExprAtom();
     } else {
-      parseMaybePrivateName();
+      parseIdentifier();
     }
 
     state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ObjectKey;

--- a/src/parser/util/identifier.ts
+++ b/src/parser/util/identifier.ts
@@ -2,6 +2,7 @@ import {charCodes} from "./charcodes";
 import {WHITESPACE_CHARS} from "./whitespace";
 
 function computeIsIdentifierChar(code: number): boolean {
+  if (code < 36) return code === 35;
   if (code < 48) return code === 36;
   if (code < 58) return true;
   if (code < 65) return false;

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -312,8 +312,6 @@ describe("transform flow", () => {
     );
   });
 
-  // Note that we don't actually transform private fields at the moment, this just makes sure it
-  // parses.
   it("allows private properties with type annotations", () => {
     assertFlowResult(
       `
@@ -325,7 +323,7 @@ describe("transform flow", () => {
       `"use strict";
       class A {constructor() { A.prototype.__init.call(this); }
         
-        __init() {this.prop2 = value}
+        __init() {this.#prop2 = value}
       }
     `,
     );

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -333,7 +333,6 @@ describe("tokens", () => {
       [
         {type: tt._class},
         {type: tt.braceL},
-        {type: tt.hash},
         {type: tt.name, identifierRole: IdentifierRole.ObjectKey},
         {type: tt.eq},
         {type: tt.num},
@@ -341,7 +340,6 @@ describe("tokens", () => {
 
         {type: tt._this},
         {type: tt.dot},
-        {type: tt.hash},
         {type: tt.name},
         {type: tt.eq},
         {type: tt.num},
@@ -349,12 +347,10 @@ describe("tokens", () => {
         {type: tt._delete},
         {type: tt._this},
         {type: tt.questionDot},
-        {type: tt.hash},
         {type: tt.name},
 
         {type: tt._if},
         {type: tt.parenL},
-        {type: tt.hash},
         {type: tt.name},
         {type: tt._in},
         {type: tt.name},


### PR DESCRIPTION
Removed # from tokenizer, consider it to be part of identifier.