### PR TITLE
Add options argument to addHook to pass to pirates.addHook

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -1,9 +1,13 @@
-// @ts-ignore: no types available.
 import * as pirates from "pirates";
 
 import {Options, transform} from "./index";
 
-export function addHook(extension: string, options: Options): void {
+export interface HookOptions {
+  matcher?: (code: string) => boolean;
+  ignoreNodeModules?: boolean;
+}
+
+export function addHook(extension: string, options: Options, hookOptions?: HookOptions): void {
   pirates.addHook(
     (code: string, filePath: string): string => {
       const {code: transformedCode, sourceMap} = transform(code, {
@@ -15,7 +19,7 @@ export function addHook(extension: string, options: Options): void {
       const suffix = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${mapBase64}`;
       return `${transformedCode}\n${suffix}`;
     },
-    {exts: [extension]},
+    {...hookOptions, exts: [extension]},
   );
 }
 


### PR DESCRIPTION
I've added an optional argument to `addHook` to pass through to pirates. You would use it like this:

```typescript
addHook(".js", { transforms: ["imports"] }, { ignoreNodeModules: false });
```

I also removed the `ts-ignore` comment because pirates has types now.