### PR TITLE
Preserve declarations for private fields, static fields, and methods

### DIFF
--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -79,14 +79,23 @@ export default function getClassInfo(
       // Either a method or a field. Skip to the identifier part.
       const statementStartIndex = tokens.currentIndex();
       let isStatic = false;
+      let isESPrivate = false;
       while (isAccessModifier(tokens.currentToken())) {
         if (tokens.matches1(tt._static)) {
           isStatic = true;
+        }
+        if (tokens.matches1(tt.hash)) {
+          isESPrivate = true;
         }
         tokens.nextToken();
       }
       if (isStatic && tokens.matches1(tt.braceL)) {
         // This is a static block, so don't process it in any special way.
+        skipToNextClassElement(tokens, classContextId);
+        continue;
+      }
+      if (isESPrivate) {
+        // Sucrase doesn't attempt to transpile private fields; just leave them as-is.
         skipToNextClassElement(tokens, classContextId);
         continue;
       }
@@ -280,6 +289,7 @@ function isAccessModifier(token: Token): boolean {
     tt._abstract,
     tt.star,
     tt._declare,
+    tt.hash,
   ].includes(token.type);
 }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -323,9 +323,9 @@ describe("transform flow", () => {
       }
     `,
       `"use strict";
-      class A {constructor() { A.prototype.__init.call(this); }
-        
-        __init() {this.prop2 = value}
+      class A {
+        #prop1;
+        #prop2 = value;
       }
     `,
     );

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1233,4 +1233,46 @@ describe("sucrase", () => {
       {transforms: ["typescript"]},
     );
   });
+
+  it("correctly preserves private fields, static fields, and methods", () => {
+    assertResult(
+      `
+      class A {
+        #x = 1;
+        y = 2;
+        
+        static #privateStaticField = 3;
+        
+        #privateMethod() {
+          return A.#privateStaticField;
+        }
+        
+        printValues() {
+          console.log(this.#x);
+          console.log(this.y);
+          console.log(this.#privateMethod());
+        }
+      }
+    `,
+      `
+      class A {constructor() { A.prototype.__init.call(this); }
+        #x = 1;
+        __init() {this.y = 2}
+        
+        static #privateStaticField = 3;
+        
+        #privateMethod() {
+          return A.#privateStaticField;
+        }
+        
+        printValues() {
+          console.log(this.#x);
+          console.log(this.y);
+          console.log(this.#privateMethod());
+        }
+      }
+    `,
+      {transforms: []},
+    );
+  });
 });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1926,11 +1926,13 @@ describe("typescript transform", () => {
       `
       class Foo {
         readonly #x: number;
+        readonly #y: number;
       }
     `,
       `"use strict";
       class Foo {
-        
+         #x;
+         #y;
       }
     `,
     );


### PR DESCRIPTION
Fixes #560

Alternate approach to #570 where we emit the declarations as-is, e.g. `#foo = 3;`
in the class body. Note that this does *not* transpile these private fields, so
the underlying runtime still needs to support them and will give a syntax error
if it doesn't.