### PR TITLE
Fix parsing of methods and fields named "declare"

### DIFF
--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -26,6 +26,7 @@ import {
   tsParseIdentifierStatement,
   tsParseImportEqualsDeclaration,
   tsParseMaybeDecoratorArguments,
+  tsParseModifier,
   tsStartParseFunctionParams,
   tsTryParseClassMemberWithIsStatic,
   tsTryParseExport,
@@ -692,9 +693,9 @@ function parseClassBody(classContextId: number): void {
 
 function parseClassMember(memberStart: number, classContextId: number): void {
   if (isTypeScriptEnabled) {
-    eatContextual(ContextualKeyword._declare);
+    tsParseModifier([ContextualKeyword._declare]);
     tsParseAccessModifier();
-    eatContextual(ContextualKeyword._declare);
+    tsParseModifier([ContextualKeyword._declare]);
   }
   let isStatic = false;
   if (match(tt.name) && state.contextualKeyword === ContextualKeyword._static) {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2233,13 +2233,13 @@ describe("typescript transform", () => {
     `,
       `"use strict";
       class Foo {
-           
-           
-           
           
-           
-           
-           
+          
+          
+          
+          
+          
+          
           
           
           constructor() {
@@ -2372,6 +2372,37 @@ describe("typescript transform", () => {
 
 
 
+    `,
+    );
+  });
+
+  it("correctly handles methods and fields named declare", () => {
+    assertTypeScriptResult(
+      `
+      class A {
+        declare() {
+        }
+      }
+      class B {
+        static declare() {
+        }
+      }
+      class C {
+        declare = 2;
+      }
+    `,
+      `"use strict";
+      class A {
+        declare() {
+        }
+      }
+      class B {
+        static declare() {
+        }
+      }
+      class C {constructor() { C.prototype.__init.call(this); }
+        __init() {this.declare = 2}
+      }
     `,
     );
   });


### PR DESCRIPTION
Fixes #545

When originally porting https://github.com/babel/babel/pull/11146, there was a
mistake where we were using `eatContextual` when actually it was important to
use `tsParseModifier`, since `tsParseModifier` won't eat a name token if the
following token indicates that it must be the name of a method or field. This PR
fixes that by switching to `tsParseModifier` as Babel does.

It might be good to later refactor/simplify `tsParseModifier` if the keyword
specificity is just for error handling (and to maybe avoid the
snapshot/restore), but that can be a follow-up.