### PR TITLE
Switch CI to use node 15 for main tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '15'
       - run: yarn
       - run: yarn build
       - run: yarn lint
@@ -27,6 +27,8 @@ jobs:
       matrix:
         include:
           - node_version: '10'
+          - node_version: '12'
+          - node_version: '14'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -48,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '15'
       - run: yarn
       - run: yarn fast-build
       - run: yarn run-examples ${{ matrix.projects }}

--- a/example-runner/example-configs/babel.patch
+++ b/example-runner/example-configs/babel.patch
@@ -61,10 +61,18 @@ index 2c077a3fb..dfa6ff5e7 100644
  yarn-install: clean-all
  	yarn --ignore-engines
 diff --git a/package.json b/package.json
-index a420748f1..7678c4796 100644
+index a420748f1..0b421c34b 100644
 --- a/package.json
 +++ b/package.json
-@@ -91,6 +91,9 @@
+@@ -76,7 +76,6 @@
+     "@lerna/**/@lerna/collect-updates": "https://github.com/babel/lerna.git#babel-collect-updates"
+   },
+   "engines": {
+-    "node": ">= 6.9.0 < 14.0.0",
+     "npm": ">= 3.x <= 6.x",
+     "yarn": ">=0.27.5 || >=1.0.0-20170811"
+   },
+@@ -91,6 +90,9 @@
      }
    },
    "jest": {


### PR DESCRIPTION
This also required removing the node version requirement for babel for now,
though it looks like that will go away when the babel example is next updated to
latest.