### PR TITLE
Support for passing transform options via register

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -23,47 +23,49 @@ export function addHook(extension: string, options: Options, hookOptions?: HookO
   );
 }
 
-export function registerJS(hookOptions?: HookOptions): void {
-  addHook(".js", {transforms: ["imports", "flow", "jsx"]}, hookOptions);
+export function registerJS(options?: Options, hookOptions?: HookOptions): void {
+  addHook(".js", {transforms: ["imports", "flow", "jsx"], ...options}, hookOptions);
 }
 
-export function registerJSX(hookOptions?: HookOptions): void {
-  addHook(".jsx", {transforms: ["imports", "flow", "jsx"]}, hookOptions);
+export function registerJSX(options?: Options, hookOptions?: HookOptions): void {
+  addHook(".jsx", {transforms: ["imports", "flow", "jsx"], ...options}, hookOptions);
 }
 
-export function registerTS(hookOptions?: HookOptions): void {
-  addHook(".ts", {transforms: ["imports", "typescript"]}, hookOptions);
+export function registerTS(options?: Options, hookOptions?: HookOptions): void {
+  addHook(".ts", {transforms: ["imports", "typescript"], ...options}, hookOptions);
 }
 
-export function registerTSX(hookOptions?: HookOptions): void {
-  addHook(".tsx", {transforms: ["imports", "typescript", "jsx"]}, hookOptions);
+export function registerTSX(options?: Options, hookOptions?: HookOptions): void {
+  addHook(".tsx", {transforms: ["imports", "typescript", "jsx"], ...options}, hookOptions);
 }
 
-export function registerTSLegacyModuleInterop(hookOptions?: HookOptions): void {
+export function registerTSLegacyModuleInterop(options?: Options, hookOptions?: HookOptions): void {
   addHook(
     ".ts",
     {
       transforms: ["imports", "typescript"],
       enableLegacyTypeScriptModuleInterop: true,
+      ...options,
     },
     hookOptions,
   );
 }
 
-export function registerTSXLegacyModuleInterop(hookOptions?: HookOptions): void {
+export function registerTSXLegacyModuleInterop(options?: Options, hookOptions?: HookOptions): void {
   addHook(
     ".tsx",
     {
       transforms: ["imports", "typescript", "jsx"],
       enableLegacyTypeScriptModuleInterop: true,
+      ...options,
     },
     hookOptions,
   );
 }
 
-export function registerAll(hookOptions?: HookOptions): void {
-  registerJS(hookOptions);
-  registerJSX(hookOptions);
-  registerTS(hookOptions);
-  registerTSX(hookOptions);
+export function registerAll(options?: Options, hookOptions?: HookOptions): void {
+  registerJS(options, hookOptions);
+  registerJSX(options, hookOptions);
+  registerTS(options, hookOptions);
+  registerTSX(options, hookOptions);
 }


### PR DESCRIPTION
Hey there! I've been meaning to dig into sucrase for a while now and finally got around to it :)

I'm experimenting with integrating it into [presta](https://github.com/sure-thing/presta) for the development server and I realized that the `sucrase/register` hook does not support transform options.

Is this something y'all would be open to? Is there a better way to go about this than what I have here? I'm happy to make adjustments. Also, if you'd rather not open up these options, all good too. Just thought I'd check!