### PR TITLE
Add more benchmark scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "generate": "sucrase-node generator/generate.ts",
     "benchmark": "cd benchmark && yarn && sucrase-node ./benchmark.ts",
     "microbenchmark": "sucrase-node benchmark/microbenchmark.ts",
-    "benchmark-react": "sucrase-node benchmark/benchmark-react.ts",
-    "benchmark-project": "sucrase-node benchmark/benchmark-project.ts",
     "lint": "sucrase-node script/lint.ts",
     "profile": "node --inspect-brk ./node_modules/.bin/sucrase-node ./benchmark/profile",
     "profile-project": "node --inspect-brk ./node_modules/.bin/sucrase-node ./benchmark/benchmark-project.ts --profile",


### PR DESCRIPTION
This adds a jest-dev script to test the Jest dataset in better conditions to
measure the impact of code changes in Sucrase, plus a jest-diff script that is
similar and outputs JSON so that it can be used by an upcoming CI script to
measure performance before and after.

Also add some docs and clean up the package.json scripts.