### PR TITLE
Add CI job to compare perf before and after and leave a comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,29 @@ jobs:
       - run: yarn
       - run: yarn fast-build
       - run: yarn run-examples ${{ matrix.projects }}
+  perf-benchmark:
+    name: "Compare performance"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Fetch all branches so we can compare with the default branch.
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+      - run: yarn
+      # Clone the jest repo and run an untimed benchmark first, since the first
+      # run immediately after cloning tends to be slower.
+      - run: yarn benchmark jest-dev
+      - run: yarn benchmark-compare
+      # The benchmark-compare script leaves a ./.perf-comparison/summary.txt file
+      # to be forwarded to the comment-perf.yml workflow via an artifact. We
+      # also need to send the PR number. See that file and 
+      # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+      # for details of how the two fit together.
+      - run: echo ${{ github.event.number }} > ./.perf-comparison/pr-number.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: perf-comparison
+          path: .perf-comparison/

--- a/.github/workflows/comment-perf.yml
+++ b/.github/workflows/comment-perf.yml
@@ -1,0 +1,74 @@
+name: "Post performance comparison comment on PR"
+
+on:
+  workflow_run:
+    workflows: ["All tests"]
+    types:
+      - completed
+
+# This is based off of the code snippets from:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+jobs:
+  post-perf-comparison:
+    name: "Post performance comparison"
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "perf-comparison"
+            })[0];
+            const download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/perf-comparison.zip', Buffer.from(download.data));
+      - run: unzip perf-comparison.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const prNumber = Number(fs.readFileSync('./pr-number.txt'));
+            const summary = fs.readFileSync('./summary.txt').toString();
+            
+            const prComments = await github.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const existingComment = prComments.data.find(
+              (comment) => comment.body.includes("## Benchmark results")
+            );
+            
+            if (existingComment) {
+              await github.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: summary,
+              });
+            } else {
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: summary,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ integrations/gulp-plugin/dist
 .nyc_output
 coverage.lcov
 benchmark/sample/jest
+.perf-comparison

--- a/benchmark/compare-performance.ts
+++ b/benchmark/compare-performance.ts
@@ -1,0 +1,141 @@
+#!./node_modules/.bin/sucrase-node
+/* eslint-disable no-console */
+import {exec} from "mz/child_process";
+import {writeFile} from "mz/fs";
+
+import run from "../script/run";
+
+interface BenchmarkResult {
+  name: string;
+  totalTime: number;
+  linesPerSecond: number;
+  totalLines: number;
+}
+
+interface Comparison {
+  // Both of these values are speed in lines of code per second.
+  before: number;
+  after: number;
+}
+
+// Handle SIGINT, which makes it so the child benchmark process is stopped with
+// an exception and we hit the finally block to switch back to the original
+// branch.
+process.on("SIGINT", () => {
+  console.log("Detected SIGINT, letting main process clean up...");
+});
+
+async function main(): Promise<void> {
+  console.log(`\
+WARNING: This script performs \`git checkout\` to test changes on the current
+branch compared with the default branch. It attempts to clean up the branch
+state at the end, but prefer using it while in a clean git state and
+double-check the git state after running.
+`);
+  const branchRef = await getBranchRef();
+  let baseRef = "origin/master";
+  if (branchRef === "master") {
+    // If this is a default branch build, compare with the previous commit.
+    baseRef = "origin/master~1";
+  }
+  console.log(`Branch ref: ${branchRef}, base ref: ${baseRef}`);
+  try {
+    await runBenchmarkComparison(baseRef, branchRef);
+  } finally {
+    if ((await getBranchRef()) !== branchRef) {
+      console.log("Restoring to original branch...");
+      await run(`git -c advice.detachedHead=false checkout ${branchRef}`);
+    }
+  }
+}
+
+async function getBranchRef(): Promise<string> {
+  let branchRef = (await exec("git rev-parse --abbrev-ref HEAD"))[0].toString().trim();
+  if (branchRef === "HEAD") {
+    branchRef = (await exec("git rev-parse HEAD"))[0].toString().trim();
+  }
+  return branchRef;
+}
+
+async function runBenchmarkComparison(baseRef: string, branchRef: string): Promise<void> {
+  const baseResults: Array<BenchmarkResult> = [];
+  const branchResults: Array<BenchmarkResult> = [];
+  for (let i = 0; i < 5; i++) {
+    await run(`git -c advice.detachedHead=false checkout ${baseRef}`);
+    const baseResult = await runBenchmark();
+    console.log(baseResult);
+    baseResults.push(baseResult);
+    await run(`git -c advice.detachedHead=false checkout ${branchRef}`);
+    const branchResult = await runBenchmark();
+    console.log(branchResult);
+    branchResults.push(branchResult);
+  }
+  const baseSpeeds = baseResults.map((r) => r.linesPerSecond).sort((a, b) => a - b);
+  const branchSpeeds = branchResults.map((r) => r.linesPerSecond).sort((a, b) => a - b);
+
+  console.log(`Base speeds  : ${baseSpeeds.join(", ")}`);
+  console.log(`Branch speeds: ${branchSpeeds.join(", ")}`);
+
+  const fairComparison: Comparison = {before: baseSpeeds[2], after: branchSpeeds[2]};
+  const pessimisticComparison: Comparison = {before: baseSpeeds[3], after: branchSpeeds[1]};
+  const optimisticComparison: Comparison = {before: baseSpeeds[1], after: branchSpeeds[3]};
+
+  // For now, express uncertainty via actual measurements taken fairly, pessimistically, and
+  // optimistically.
+  const summary = `\
+## Benchmark results
+**Before this PR:** ${formatSpeed(fairComparison.before)}
+**After this PR:**  ${formatSpeed(fairComparison.after)}
+
+**Measured change:** ${describeDifference(fairComparison)} (${describeDifference(
+    pessimisticComparison,
+  )} to ${describeDifference(optimisticComparison)})
+**Summary:** ${summarizeChange(pessimisticComparison, optimisticComparison)}`;
+  console.log(summary);
+  await exec("mkdir -p ./.perf-comparison");
+  await writeFile("./.perf-comparison/summary.txt", summary);
+}
+
+function formatSpeed(speed: number): string {
+  const thousandLinesPerSecond = speed / 1000;
+  return `${Math.round(thousandLinesPerSecond * 10) / 10} thousand lines per second`;
+}
+
+function describeDifference({before, after}: Comparison): string {
+  if (after > before) {
+    const percentFaster = (after / before - 1) * 100;
+    return `${Math.round(percentFaster * 100) / 100}% faster`;
+  } else if (after < before) {
+    const percentSlower = (1 - after / before) * 100;
+    return `${Math.round(percentSlower * 100) / 100}% slower`;
+  } else {
+    return "same speed";
+  }
+}
+
+function summarizeChange(
+  pessimisticComparison: Comparison,
+  optimisticComparison: Comparison,
+): string {
+  if (pessimisticComparison.after > pessimisticComparison.before) {
+    return "Probably faster";
+  } else if (optimisticComparison.after < optimisticComparison.before) {
+    return "Probably slower";
+  } else {
+    return "Likely no significant difference";
+  }
+}
+
+async function runBenchmark(): Promise<BenchmarkResult> {
+  return JSON.parse(
+    (await exec("node -r sucrase/register benchmark/benchmark.ts jest-diff"))[0].toString(),
+  );
+}
+
+main().catch((e) => {
+  if (e.signal !== "SIGINT") {
+    console.error("Unhandled error:");
+    console.error(e);
+    process.exitCode = 1;
+  }
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf ./build ./dist ./dist-self-build ./dist-types ./example-runner/example-repos ./test262/test262-checkout",
     "generate": "sucrase-node generator/generate.ts",
     "benchmark": "cd benchmark && yarn && sucrase-node ./benchmark.ts",
+    "benchmark-compare": "sucrase-node ./benchmark/compare-performance.ts",
     "microbenchmark": "sucrase-node benchmark/microbenchmark.ts",
     "lint": "sucrase-node script/lint.ts",
     "profile": "node --inspect-brk ./node_modules/.bin/sucrase-node ./benchmark/profile",


### PR DESCRIPTION
This should add some discipline to future perf improvements and help quantify
the negative perf impact of different changes when there is one. It runs the
Jest benchmark on the branch code and on the default branch code, alternating
between the two and doing five runs each and taking the median.

In order to properly report perf on PRs from forks, we save an artifact from the
main CI build and download it in a new `workflow_run` build which runs with
write access from the default branch code.

This article goes though a lot of the rationale and details:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests