### PR TITLE
Add early return in comment-perf.yml

### DIFF
--- a/.github/workflows/comment-perf.yml
+++ b/.github/workflows/comment-perf.yml
@@ -44,7 +44,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            
             const prNumber = Number(fs.readFileSync('./pr-number.txt'));
+            if (!prNumber) {
+              return;
+            }
+            
             const summary = fs.readFileSync('./summary.txt').toString();
             
             const prComments = await github.issues.listComments({


### PR DESCRIPTION
It looks like the `if` conditional isn't working right despite being exactly the
code from the blog post, so as a workaround, we early return if the pr-number is
blank (which means that `Number()` evalutes to 0). This should avoid the build
failure on default branch builds.