### PR TITLE
Fix line number preservation for Jest transform

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -102,7 +102,9 @@ export default class RootTransformer {
       );
     }
     if (transforms.includes("jest")) {
-      this.transformers.push(new JestHoistTransformer(this, tokenProcessor, importProcessor));
+      this.transformers.push(
+        new JestHoistTransformer(this, tokenProcessor, this.nameManager, importProcessor),
+      );
     }
   }
 

--- a/test/jest-test.ts
+++ b/test/jest-test.ts
@@ -34,13 +34,12 @@ describe("transform jest", () => {
       jest.mock('c', () => {}).mock('d', () => {});
       jest.doMock('a', () => {});
     `,
-      `
-jest.mock('a').unmock('b').enableAutomock().disableAutomock().mock('c', () => {}).mock('d', () => {});
+      `__jestHoist();__jestHoist2();__jestHoist3();__jestHoist4();__jestHoist5();__jestHoist6();
       import 'moduleName';
-;
-jest.unknown();
-
-;
+function __jestHoist(){jest.mock('a');};
+function __jestHoist2(){jest.unmock('b');}jest.unknown()function __jestHoist3(){jest.enableAutomock();};
+function __jestHoist4(){jest.disableAutomock();}
+function __jestHoist5(){jest.mock('c', () => {});}function __jestHoist6(){jest.mock('d', () => {});};
 jest.doMock('a', () => {});
     `,
     );
@@ -57,23 +56,21 @@ jest.doMock('a', () => {});
         jest.unmock('c')
       `,
       {
-        expectedCJSResult: `"use strict";${IMPORT_DEFAULT_PREFIX}
-jest.mock('a').mock('b', () => ({})).unmock('c');
+        expectedCJSResult: `"use strict";${IMPORT_DEFAULT_PREFIX}__jestHoist();__jestHoist2();__jestHoist3();
         var _a = require('a');
-;
+function __jestHoist(){jest.mock('a');};
         var _b = require('b');
-;
+function __jestHoist2(){jest.mock('b', () => ({}));};
         var _c = require('c'); var _c2 = _interopRequireDefault(_c);
-
+function __jestHoist3(){jest.unmock('c');}
       `,
-        expectedESMResult: `
-jest.mock('a').mock('b', () => ({})).unmock('c');
+        expectedESMResult: `__jestHoist();__jestHoist2();__jestHoist3();
         import {A} from 'a';
-;
+function __jestHoist(){jest.mock('a');};
         import {B} from 'b';
-;
+function __jestHoist2(){jest.mock('b', () => ({}));};
         import C from 'c';
-
+function __jestHoist3(){jest.unmock('c');}
       `,
       },
     );
@@ -88,11 +85,10 @@ jest.mock('a').mock('b', () => ({})).unmock('c');
 
       export const x = 1
     `,
-      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}
-jest.mock('a');
+      `"use strict";${ESMODULE_PREFIX}${IMPORT_DEFAULT_PREFIX}__jestHoist();
       var _a = require('./a'); var _a2 = _interopRequireDefault(_a);
       var _b = require('./b');
-;
+function __jestHoist(){jest.mock('a');};
 
        const x = 1; exports.x = x
     `,
@@ -109,18 +105,13 @@ jest.mock('a', () => ({
   }
 }));
     `,
-      `"use strict";${IMPORT_DEFAULT_PREFIX}${NULLISH_COALESCE_PREFIX}${OPTIONAL_CHAIN_PREFIX}
-jest.mock('a', () => ({
+      `"use strict";${IMPORT_DEFAULT_PREFIX}${NULLISH_COALESCE_PREFIX}${OPTIONAL_CHAIN_PREFIX}__jestHoist();
+      var _a = require('./a'); var _a2 = _interopRequireDefault(_a);
+function __jestHoist(){jest.mock('a', () => ({
   f(x) {
     return _nullishCoalesce(_optionalChain([x, 'optionalAccess', _ => _.a]), () => ( 0));
   }
-}));
-      var _a = require('./a'); var _a2 = _interopRequireDefault(_a);
-
-
-
-
-;
+}));};
     `,
     );
   });
@@ -136,18 +127,13 @@ jest.mock('a'! as number, (arg: unknown) => ({
 }) as any);
       x()
     `,
-      `"use strict";
-jest.mock('a' , (arg) => ({
+      `"use strict";__jestHoist();
+      var _a = require('./a');
+function __jestHoist(){jest.mock('a' , (arg) => ({
   f(x) {
     return x ;
   }
-}) );
-      var _a = require('./a');
-
-
-
-
-;
+}) );};
       _a.x.call(void 0, )
     `,
       {transforms: ["jsx", "jest", "imports", "typescript"]},
@@ -165,18 +151,13 @@ jest.mock('a': number, (arg: string) => ({
 }): any);
       x()
     `,
-      `"use strict";
-jest.mock('a', (arg) => ({
+      `"use strict";__jestHoist();
+      var _a = require('./a');
+function __jestHoist(){jest.mock('a', (arg) => ({
   f(x) {
     return (x);
   }
-}));
-      var _a = require('./a');
-
-
-
-
-;
+}));};
       _a.x.call(void 0, )
     `,
       {transforms: ["jsx", "jest", "imports", "flow"]},
@@ -195,19 +176,14 @@ jest.mock('a', (arg) => ({
       }));
       x()
     `,
-      `"use strict";${JSX_PREFIX}${IMPORT_DEFAULT_PREFIX}
-jest.mock('a', (arg) => ({
+      `"use strict";${JSX_PREFIX}${IMPORT_DEFAULT_PREFIX}__jestHoist();
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
+      var _a = require('./a');
+function __jestHoist(){jest.mock('a', (arg) => ({
         f(x) {
           return _react2.default.createElement('div', {__self: this, __source: {fileName: _jsxFileName, lineNumber: 6}} );
         }
-      }));
-      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
-      var _a = require('./a');
-
-
-
-
-;
+      }));};
       _a.x.call(void 0, )
     `,
       {transforms: ["jsx", "jest", "imports"]},
@@ -226,10 +202,9 @@ jest.mock('a', (arg) => ({
       _a.jest.mock('x');
     `,
         // Note that this behavior is incorrect, but jest requires imports transform for now.
-        expectedESMResult: `
-jest.mock('x');
+        expectedESMResult: `__jestHoist();
       import {jest} from './a';
-;
+function __jestHoist(){jest.mock('x');};
     `,
       },
     );
@@ -248,6 +223,20 @@ jest.mock('x');
       _b.jest.mock('x');
     `,
       {transforms: ["jsx", "jest", "imports", "typescript"]},
+    );
+  });
+
+  it("allows chained unknown methods", () => {
+    assertResult(
+      `
+      import './a';
+      console.log(jest.spyOn({foo() {}}, 'foo').getMockName());
+    `,
+      `"use strict";
+      require('./a');
+      console.log(jest.spyOn({foo() {}}, 'foo').getMockName());
+    `,
+      {transforms: ["jest", "imports"]},
     );
   });
 });

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "babel-core": "^6.26.3",
     "babel-jest": "^24.9.0",
     "babel-plugin-dynamic-import-node": "^2.3.0",
+    "babel-plugin-jest-hoist": "^26.6.2",
     "babel-runtime": "^6.26.0",
     "base64-js": "^1.3.1",
     "case-sensitive-paths-webpack-plugin": "^2.2.0",

--- a/website/src/Babel.ts
+++ b/website/src/Babel.ts
@@ -9,10 +9,13 @@ import {registerPlugin, transform} from "@babel/standalone";
 // @ts-ignore
 import DynamicImportPlugin from "babel-plugin-dynamic-import-node";
 // @ts-ignore
+import JestHoistPlugin from "babel-plugin-jest-hoist";
+// @ts-ignore
 import ReactHotLoaderPlugin from "react-hot-loader/dist/babel.development";
 
 registerPlugin("proposal-numeric-separator", NumericSeparatorPlugin);
 registerPlugin("dynamic-import-node", DynamicImportPlugin);
 registerPlugin("react-hot-loader", ReactHotLoaderPlugin);
+registerPlugin("jest-hoist", JestHoistPlugin);
 
 export {transform};

--- a/website/src/Constants.ts
+++ b/website/src/Constants.ts
@@ -42,6 +42,7 @@ export const TRANSFORMS: Array<TransformInfo> = [
   {name: "flow", presetName: "flow"},
   {name: "imports", babelName: "transform-modules-commonjs"},
   {name: "react-hot-loader", babelName: "react-hot-loader"},
+  {name: "jest", babelName: "jest-hoist"},
 ];
 
 export const DEFAULT_TRANSFORMS = ["jsx", "typescript", "imports"];


### PR DESCRIPTION
This is a follow-up from https://github.com/alangpierce/sucrase/pull/540#pullrequestreview-632969664

For the Jest transform, rather than actually moving the `jest.mock` invocations,
it's better to transform them in-place and wrap them in functions, then call
those functions from the top of the file. That guarantees that line numbers are
preserved before and after so that the source map can be correct.

I also added the jest transform to the website so that it's easier to manually
test. It may be possible to hook up the ts-jest version of the transform to the
TypeScript output on the website, but I left that off for now.

To test, I made a simple Jest project and mocked a function that returns a
number. Without the jest tranform, putting the mock call below the import
doesn't work, and with the jest transform it works. Before this change,
breakpoints further down in the file (e.g. in the test) didn't work because line
numbers were wrong. After this change, breakpoints work.

I also manually tested this line to ensure that the chaining transform doesn't
break other uses of the `jest` object:
```javascript
console.log(jest.spyOn({foo() {}}, 'foo').getMockName());
```