### PR TITLE
Fix regression causing incomplete nullish coalesce in some cases

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -168,13 +168,11 @@ export default class TokenProcessor {
   }
 
   removeInitialToken(): void {
-    this.resultCode += this.previousWhitespaceAndComments();
-    this.tokenIndex++;
+    this.replaceToken("");
   }
 
   removeToken(): void {
-    this.resultCode += this.previousWhitespaceAndComments().replace(/[^\r\n]/g, "");
-    this.tokenIndex++;
+    this.replaceTokenTrimmingLeftWhitespace("");
   }
 
   copyExpectedToken(tokenType: TokenType): void {

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1052,6 +1052,32 @@ describe("sucrase", () => {
     );
   });
 
+  it("does not crash with nullish coalescing followed by TS `as`", () => {
+    assertOutput(
+      `
+      setOutput(1 ?? 2 as any);
+    `,
+      1,
+      {transforms: ["typescript"]},
+    );
+  });
+
+  it("correctly transforms nullish coalescing followed by TS `as`", () => {
+    assertResult(
+      `
+      const foo = {
+        bar: baz ?? null as any
+      }
+    `,
+      `${NULLISH_COALESCE_PREFIX}
+      const foo = {
+        bar: _nullishCoalesce(baz, () => ( null ))
+      }
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
+
   it("correctly transforms async functions using await in an optional chain", () => {
     assertResult(
       `


### PR DESCRIPTION
Fixes #609

The original implementation of the Jest transform (#540) needed to remove
regions of code, but ran into issues with the optional chaining and nullish
coalescing transforms, since those transforms would still emit function calls
around tokens even if they were removed. The implementation fixed those issues
by disabling the optional chaining and nullish coalescing code emit in
`removeToken` and `removeInitialToken`. Unfortunately, this broke other cases,
like a nullish coalescing call immediately followed by a type token. The nullish
coalescing implementation expected `appendTokenSuffix` to be called on the last
token even though it was a type token.

The changes to `TokenProcessor` actually became unnecessary as of #608 since we
no longer are deleting a region of code, so I reverted the two methods back to
their original implementation, which fixes the issue.