### PR TITLE
Fix transformation of anonymous "export default" classes

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -195,7 +195,7 @@ export default class RootTransformer {
     // Both static and instance initializers need a class name to use to invoke the initializer, so
     // assign to one if necessary.
     const needsCommaExpression =
-      (classInfo.headerInfo.isExpression || !classInfo.headerInfo.className)  &&
+      (classInfo.headerInfo.isExpression || !classInfo.headerInfo.className) &&
       classInfo.staticInitializerNames.length + classInfo.instanceInitializerNames.length > 0;
 
     let className = classInfo.headerInfo.className;

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -195,7 +195,7 @@ export default class RootTransformer {
     // Both static and instance initializers need a class name to use to invoke the initializer, so
     // assign to one if necessary.
     const needsCommaExpression =
-      classInfo.headerInfo.isExpression &&
+      (classInfo.headerInfo.isExpression || !classInfo.headerInfo.className)  &&
       classInfo.staticInitializerNames.length + classInfo.instanceInitializerNames.length > 0;
 
     let className = classInfo.headerInfo.className;

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -388,6 +388,38 @@ describe("sucrase", () => {
     );
   });
 
+  it("properly converts exported anonymous classes with static fields", () => {
+    assertResult(
+      `
+      export default class {
+        static x = 3;
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX} var _class;
+      exports. default = (_class = class {
+        static __initStatic() {this.x = 3}
+      }, _class.__initStatic(), _class)
+    `,
+      {transforms: ["jsx", "imports", "typescript"]},
+    );
+  });
+
+  it("properly converts exported anonymous classes with instance fields", () => {
+    assertResult(
+      `
+      export default class {
+        x = 3
+      }
+    `,
+      `"use strict";${ESMODULE_PREFIX} var _class;
+      exports. default = (_class = class {constructor() { _class.prototype.__init.call(this); }
+        __init() {this.x = 3}
+      }, _class)
+    `,
+      {transforms: ["jsx", "imports", "typescript"]},
+    );
+  });
+
   it("properly resolves imported names in class fields", () => {
     assertResult(
       `


### PR DESCRIPTION
This is a fix for https://github.com/alangpierce/sucrase/issues/449.

I can't really tell if this is the right way / a good way to do this, but it's a small change and tests seem to pass :)

