### PR TITLE
[Proposal] Add keepUnusedImports option

### DIFF
--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -26,6 +26,7 @@ export const Options = t.iface([], {
   sourceMapOptions: t.opt("SourceMapOptions"),
   filePath: t.opt("string"),
   production: t.opt("boolean"),
+  keepUnusedImports: t.opt("boolean"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -46,6 +46,12 @@ export interface Options {
    * If specified, omit any development-specific code in the output.
    */
   production?: boolean;
+
+  /**
+   * If specified, keep unused import specifiers on typescript.
+   * This feature is needed by svelte compiler to tell template block from script block.
+   */
+  keepUnusedImports?: boolean;
 }
 
 export function validateOptions(options: Options): void {

--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -20,7 +20,7 @@ import Transformer from "./Transformer";
 export default class ESMImportTransformer extends Transformer {
   private nonTypeIdentifiers: Set<string>;
   private declarationInfo: DeclarationInfo;
-
+  private keepUnusedImports: boolean = false;
   constructor(
     readonly tokens: TokenProcessor,
     readonly nameManager: NameManager,
@@ -29,6 +29,7 @@ export default class ESMImportTransformer extends Transformer {
     options: Options,
   ) {
     super();
+    this.keepUnusedImports = options.keepUnusedImports ?? false;
     this.nonTypeIdentifiers = isTypeScriptTransformEnabled
       ? getNonTypeIdentifiers(tokens, options)
       : new Set();
@@ -132,6 +133,10 @@ export default class ESMImportTransformer extends Transformer {
     if (this.tokens.matches1(tt.string)) {
       // This is a bare import, so we should proceed with the import.
       this.tokens.copyToken();
+      return false;
+    }
+
+    if (this.keepUnusedImports) {
       return false;
     }
 

--- a/test/keep-unused-imports.ts
+++ b/test/keep-unused-imports.ts
@@ -1,0 +1,26 @@
+import {assertResult} from "./util";
+
+function assertKeepUnusedImportsOption(code: string, expectedResult: string): void {
+  assertResult(code, expectedResult, {transforms: ["typescript"], keepUnusedImports: true});
+}
+
+describe("With keepUnusedImports", () => {
+  it("keep unused imports", () => {
+    assertKeepUnusedImportsOption(
+      `
+      import A from 'a';
+      import B from 'b';
+      import type C from "c";
+      export function f(a: A, b: B, c: C): boolean {
+        return a instanceof A;
+      }`,
+      `
+      import A from 'a';
+      import B from 'b';
+
+      export function f(a, b, c) {
+        return a instanceof A;
+      }`,
+    );
+  });
+});


### PR DESCRIPTION
## Add this feature

```ts
import { transform } from "sucrase";
const build = transform(`
import Foo from "Foo"; // type only
export function handleFoo(foo: Foo) {
  return foo;
}`, { transforms: ["typescript"], keepUnusedImports: true });

console.log(build.code) // keep Foo imports
```

## Why

I tried to use sucrase in svelte preprocess. (I'm creating compiler in browser to svelte preview. sucrase is most lightweight in typescript compilers)

Svelte use script block variables in template.

```js
<script lang="ts">
  import Foo from "./Foo.svelte";
</script>

<Foo/>
```

Current sucrase default will remove this code because `Foo` is not referenced. I need option for svelte compiler.

## Other case: microsoft typescript and svelte

`svelte-preprocess` has custom typescript plugin to restore imports. https://github.com/sveltejs/svelte-preprocess/blob/main/src/transformers/typescript.ts#L35-L54

And svelte recommends `tsconfig.json`'s `importsNotUsedAsValue: "error"` so users handle imports manually.