### PR TITLE
Fix for CJSImportProcessor not using interop helper for aliased default imports

### DIFF
--- a/src/CJSImportProcessor.ts
+++ b/src/CJSImportProcessor.ts
@@ -178,7 +178,7 @@ export default class CJSImportProcessor {
   private preprocessImportAtIndex(index: number): void {
     const defaultNames: Array<string> = [];
     const wildcardNames: Array<string> = [];
-    let namedImports: Array<NamedImport> = [];
+    const namedImports: Array<NamedImport> = [];
 
     index++;
     if (
@@ -212,8 +212,17 @@ export default class CJSImportProcessor {
     }
 
     if (this.tokens.matches1AtIndex(index, tt.braceL)) {
-      index++;
-      ({newIndex: index, namedImports} = this.getNamedImports(index));
+      const result = this.getNamedImports(index + 1);
+      index = result.newIndex;
+
+      for (const namedImport of result.namedImports) {
+        // Treat {default as X} as a default import to ensure usage of require interop helper
+        if (namedImport.importedName === "default") {
+          defaultNames.push(namedImport.localName);
+        } else {
+          namedImports.push(namedImport);
+        }
+      }
     }
 
     if (this.tokens.matchesContextualAtIndex(index, ContextualKeyword._from)) {

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -402,6 +402,23 @@ var _moduleName = require('moduleName');
     );
   });
 
+  it("transforms named default import access to property access", () => {
+    assertResult(
+      `
+      import {default as foo} from 'my-module';
+      
+      foo.test();
+      test.foo();
+    `,
+      `"use strict";${IMPORT_DEFAULT_PREFIX}
+      var _mymodule = require('my-module'); var _mymodule2 = _interopRequireDefault(_mymodule);
+      
+      _mymodule2.default.test();
+      test.foo();
+    `,
+    );
+  });
+
   it("transforms named import access to property access", () => {
     assertResult(
       `

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -414,7 +414,7 @@ describe("typescript transform", () => {
     assertTypeScriptResult(
       `
       import A from 'a';
-      import B from 'b';
+      import {default as B} from 'b';
       import 'c';
       import D from 'd';
       import 'd';


### PR DESCRIPTION
Hi! Found something that I think is a bug in the handling of aliased default imports.

For example, given the following code:

```ts
import { default as myFunc } from './myFunc';

myFunc();
```

We want this to be transpiled to something like this (simplified):

```ts
const myFunc = _interopRequireDefault(require('./myFunc'));

myFunc.default();
```

But since it's not treated as a default import, we get this kind of thing instead:

```ts
const myFunc = require('./myFunc');

myFunc.default();
```

Which may cause trouble if the imported module is not an ESM module.