### PR TITLE
Properly transform enum values, rewrite enum implementation

### DIFF
--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -571,21 +571,23 @@ describe("typescript transform", () => {
         "\\n",
         ",",
         "'",
+        "f f" = "g g"
       }
     `,
       `"use strict";
       var Foo; (function (Foo) {
         const A = 15.5; Foo[Foo["A"] = A] = "A";
         Foo[Foo["Hello world"] = A / 2] = "Hello world";
-        Foo[Foo[""] = (A / 2) + 1] = "";
+        Foo[Foo[""] = Foo["Hello world"] + 1] = "";
         const D = "foo".length; Foo[Foo["D"] = D] = "D";
         const E = D / D; Foo[Foo["E"] = E] = "E";
         Foo[Foo["debugger"] = 4] = "debugger";
         Foo[Foo["default"] = 7] = "default";
         Foo[Foo["!"] = E << E] = "!";
-        Foo[Foo["\\n"] = (E << E) + 1] = "\\n";
-        Foo[Foo[","] = ((E << E) + 1) + 1] = ",";
-        Foo[Foo["'"] = (((E << E) + 1) + 1) + 1] = "'";
+        Foo[Foo["\\n"] = Foo["!"] + 1] = "\\n";
+        Foo[Foo[","] = Foo["\\n"] + 1] = ",";
+        Foo[Foo["'"] = Foo[","] + 1] = "'";
+        Foo["f f"] = "g g";
       })(Foo || (Foo = {}));
     `,
     );
@@ -2422,6 +2424,27 @@ describe("typescript transform", () => {
         method(a) {}
         
       }
+    `,
+    );
+  });
+
+  it("correctly transforms enum expressions", () => {
+    assertTypeScriptResult(
+      `
+      import A from './A';
+      
+      enum E {
+        Foo = A.Foo,
+        Bar = A.Bar,
+      }
+    `,
+      `"use strict";${IMPORT_DEFAULT_PREFIX}
+      var _A = require('./A'); var _A2 = _interopRequireDefault(_A);
+      
+      var E; (function (E) {
+        const Foo = _A2.default.Foo; E[E["Foo"] = Foo] = "Foo";
+        const Bar = _A2.default.Bar; E[E["Bar"] = Bar] = "Bar";
+      })(E || (E = {}));
     `,
     );
   });


### PR DESCRIPTION
Fixes #620

The previous enum implementation was a bit tangled, handling several different
cases in one big `while` loop. This PR refactors the code into three distinct
cases: string enum members, calculated/constant enum members, and
autoincrementing enum members, and the transform details are handled separately
for each. Each case still needs to think about the case where we save a variable
and the case where we don't, but hopefully the whole thing is more
understandable now, and certainly better-documented.

This refactor makes it much easier to fix #620, where we weren't actually
passing the RHS expressions to the root transformer for their own transforms. In
particular, that meant that imported values weren't transformed correctly. To
fix, we now call out to the root transformer and apply the enum transform in a
purely left-to-right way rather than needing to save and re-emit a region of code.

As part of the refactor, I also changed the emitted code so that when
autoincrementing a previous value, we always reference from the enum it rather
than copying the entire expression. This should reduce cases where we need to
copy a large range of code, which is generally questionable in Sucrase.