### PR TITLE
Disable ES transforms (#602) (#622)

### DIFF
--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -1,6 +1,6 @@
 import type NameManager from "./NameManager";
 
-const HELPERS = {
+const HELPERS: {[name: string]: string} = {
   interopRequireWildcard: `
     function interopRequireWildcard(obj) {
       if (obj && obj.__esModule) {
@@ -123,22 +123,11 @@ const HELPERS = {
   `,
 };
 
-export type HelperName = keyof typeof HELPERS;
-
-const esTransformHelperNames: Array<HelperName> = [
-  "optionalChain",
-  "optionalChainDelete",
-  "nullishCoalesce",
-  "asyncOptionalChain",
-  "asyncOptionalChainDelete",
-  "asyncNullishCoalesce",
-];
-
 export class HelperManager {
-  helperNames: {[baseName in HelperName]?: string} = {};
-  constructor(readonly nameManager: NameManager, readonly disableESTransforms: boolean) {}
+  helperNames: {[baseName in keyof typeof HELPERS]?: string} = {};
+  constructor(readonly nameManager: NameManager) {}
 
-  getHelperName(baseName: HelperName): string {
+  getHelperName(baseName: keyof typeof HELPERS): string {
     let helperName = this.helperNames[baseName];
     if (helperName) {
       return helperName;
@@ -156,26 +145,20 @@ export class HelperManager {
     if (this.helperNames.asyncOptionalChainDelete) {
       this.getHelperName("asyncOptionalChain");
     }
-    for (const [rawBaseName, helperCodeTemplate] of Object.entries(HELPERS)) {
-      const baseName = rawBaseName as HelperName;
-      const shouldOmitHelper =
-        this.disableESTransforms && esTransformHelperNames.includes(baseName);
-
-      if (!shouldOmitHelper) {
-        const helperName = this.helperNames[baseName];
-        let helperCode = helperCodeTemplate;
-        if (baseName === "optionalChainDelete") {
-          helperCode = helperCode.replace("OPTIONAL_CHAIN_NAME", this.helperNames.optionalChain!);
-        } else if (baseName === "asyncOptionalChainDelete") {
-          helperCode = helperCode.replace(
-            "ASYNC_OPTIONAL_CHAIN_NAME",
-            this.helperNames.asyncOptionalChain!,
-          );
-        }
-        if (helperName) {
-          resultCode += " ";
-          resultCode += helperCode.replace(baseName, helperName).replace(/\s+/g, " ").trim();
-        }
+    for (const [baseName, helperCodeTemplate] of Object.entries(HELPERS)) {
+      const helperName = this.helperNames[baseName];
+      let helperCode = helperCodeTemplate;
+      if (baseName === "optionalChainDelete") {
+        helperCode = helperCode.replace("OPTIONAL_CHAIN_NAME", this.helperNames.optionalChain!);
+      } else if (baseName === "asyncOptionalChainDelete") {
+        helperCode = helperCode.replace(
+          "ASYNC_OPTIONAL_CHAIN_NAME",
+          this.helperNames.asyncOptionalChain!,
+        );
+      }
+      if (helperName) {
+        resultCode += " ";
+        resultCode += helperCode.replace(baseName, helperName).replace(/\s+/g, " ").trim();
       }
     }
     return resultCode;

--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -26,6 +26,7 @@ export const Options = t.iface([], {
   sourceMapOptions: t.opt("SourceMapOptions"),
   filePath: t.opt("string"),
   production: t.opt("boolean"),
+  disableESTransforms: t.opt("boolean"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -47,7 +47,7 @@ export interface Options {
    */
   production?: boolean;
   /**
-   * Opts out ES syntax transformations, like optional chaining, nullish coalescing, class fields, numeric
+   * Opts out ES syntax transformations, like optional chaining, nullish coalescing, numeric
    * separators, etc.
    */
   disableESTransforms?: boolean;

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -46,6 +46,11 @@ export interface Options {
    * If specified, omit any development-specific code in the output.
    */
   production?: boolean;
+  /**
+   * Opts out ES syntax transformations, like optional chaining, nullish coalescing, class fields, numeric
+   * separators, etc.
+   */
+  disableESTransforms?: boolean;
 }
 
 export function validateOptions(options: Options): void {

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -17,6 +17,7 @@ export default class TokenProcessor {
     readonly code: string,
     readonly tokens: Array<Token>,
     readonly isFlowEnabled: boolean,
+    readonly disableESTransforms: boolean,
     readonly helperManager: HelperManager,
   ) {}
 
@@ -210,6 +211,12 @@ export default class TokenProcessor {
     if (token.numNullishCoalesceStarts || token.isOptionalChainStart) {
       token.isAsyncOperation = isAsyncOperation(this);
     }
+    if (this.disableESTransforms) {
+      if (token.isAsyncOperation) {
+        this.resultCode += "await ";
+      }
+      return;
+    }
     if (token.numNullishCoalesceStarts) {
       for (let i = 0; i < token.numNullishCoalesceStarts; i++) {
         if (token.isAsyncOperation) {
@@ -242,10 +249,10 @@ export default class TokenProcessor {
 
   private appendTokenSuffix(): void {
     const token = this.currentToken();
-    if (token.isOptionalChainEnd) {
+    if (token.isOptionalChainEnd && !this.disableESTransforms) {
       this.resultCode += "])";
     }
-    if (token.numNullishCoalesceEnds) {
+    if (token.numNullishCoalesceEnds && !this.disableESTransforms) {
       for (let i = 0; i < token.numNullishCoalesceEnds; i++) {
         this.resultCode += "))";
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
   const scopes = file.scopes;
 
   const nameManager = new NameManager(code, tokens);
-  const helperManager = new HelperManager(nameManager, disableESTransforms);
+  const helperManager = new HelperManager(nameManager);
   const tokenProcessor = new TokenProcessor(
     code,
     tokens,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,13 +85,20 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
   const isJSXEnabled = options.transforms.includes("jsx");
   const isTypeScriptEnabled = options.transforms.includes("typescript");
   const isFlowEnabled = options.transforms.includes("flow");
+  const disableESTransforms = options.disableESTransforms === true;
   const file = parse(code, isJSXEnabled, isTypeScriptEnabled, isFlowEnabled);
   const tokens = file.tokens;
   const scopes = file.scopes;
 
   const nameManager = new NameManager(code, tokens);
-  const helperManager = new HelperManager(nameManager);
-  const tokenProcessor = new TokenProcessor(code, tokens, isFlowEnabled, helperManager);
+  const helperManager = new HelperManager(nameManager, disableESTransforms);
+  const tokenProcessor = new TokenProcessor(
+    code,
+    tokens,
+    isFlowEnabled,
+    disableESTransforms,
+    helperManager,
+  );
   const enableLegacyTypeScriptModuleInterop = Boolean(options.enableLegacyTypeScriptModuleInterop);
 
   let importProcessor = null;

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -40,11 +40,12 @@ export default class RootTransformer {
     this.isImportsTransformEnabled = transforms.includes("imports");
     this.isReactHotLoaderTransformEnabled = transforms.includes("react-hot-loader");
 
-    this.transformers.push(
-      new OptionalChainingNullishTransformer(tokenProcessor, this.nameManager),
-    );
-    this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
-    this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
+    if (!options.disableESTransforms) {
+      this.transformers.push(new OptionalChainingNullishTransformer(tokenProcessor, this.nameManager));
+      this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
+      this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
+    }
+
     if (transforms.includes("jsx")) {
       this.transformers.push(
         new JSXTransformer(this, tokenProcessor, importProcessor, this.nameManager, options),

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -41,7 +41,9 @@ export default class RootTransformer {
     this.isReactHotLoaderTransformEnabled = transforms.includes("react-hot-loader");
 
     if (!options.disableESTransforms) {
-      this.transformers.push(new OptionalChainingNullishTransformer(tokenProcessor, this.nameManager));
+      this.transformers.push(
+        new OptionalChainingNullishTransformer(tokenProcessor, this.nameManager),
+      );
       this.transformers.push(new NumericSeparatorTransformer(tokenProcessor));
       this.transformers.push(new OptionalCatchBindingTransformer(tokenProcessor, this.nameManager));
     }

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -10,8 +10,8 @@ import TokenProcessor from "../src/TokenProcessor";
 function assertHasShadowedGlobals(code: string, expected: boolean): void {
   const file = parse(code, false, false, false);
   const nameManager = new NameManager(code, file.tokens);
-  const helperManager = new HelperManager(nameManager);
-  const tokenProcessor = new TokenProcessor(code, file.tokens, false, helperManager);
+  const helperManager = new HelperManager(nameManager, false);
+  const tokenProcessor = new TokenProcessor(code, file.tokens, false, false, helperManager);
   const importProcessor = new CJSImportProcessor(
     nameManager,
     tokenProcessor,

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -10,7 +10,7 @@ import TokenProcessor from "../src/TokenProcessor";
 function assertHasShadowedGlobals(code: string, expected: boolean): void {
   const file = parse(code, false, false, false);
   const nameManager = new NameManager(code, file.tokens);
-  const helperManager = new HelperManager(nameManager, false);
+  const helperManager = new HelperManager(nameManager);
   const tokenProcessor = new TokenProcessor(code, file.tokens, false, false, helperManager);
   const importProcessor = new CJSImportProcessor(
     nameManager,

--- a/test/react-hot-loader-test.ts
+++ b/test/react-hot-loader-test.ts
@@ -1,4 +1,6 @@
-import type {Transform} from "../src";
+import * as assert from "assert";
+
+import {Transform, transform} from "../src";
 import {ESMODULE_PREFIX, IMPORT_DEFAULT_PREFIX, RHL_PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
@@ -248,5 +250,20 @@ describe("transform react-hot-loader", () => {
         filePath: "C:\\dev\\sample.tsx",
       },
     );
+  });
+
+  it("checks that filePath is specified", () => {
+    assert.throws(() => {
+      transform(
+        `
+          import React from 'react';
+      
+          export const App = () => <div />;
+          `,
+        {
+          transforms: ["jsx", "imports", "react-hot-loader"],
+        },
+      );
+    }, new Error("filePath is required when using the react-hot-loader transform."));
   });
 });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1305,12 +1305,14 @@ describe("sucrase", () => {
   it("omits optional changing nullish transformations if ES transforms disabled", () => {
     assertResult(
       `
-      navigator.share?.({})
+      await navigator.share?.({});
+      console.log(window.globalStore?.value);
     `,
       `
-      navigator.share?.({})
+      await navigator.share?.({});
+      console.log(window.globalStore?.value);
     `,
-        {transforms: [], disableESTransforms: true},
+      {transforms: [], disableESTransforms: true},
     );
   });
 
@@ -1330,7 +1332,7 @@ describe("sucrase", () => {
         console.log('Caught');
       }
     `,
-        {transforms: [], disableESTransforms: true},
+      {transforms: [], disableESTransforms: true},
     );
   });
 
@@ -1342,7 +1344,7 @@ describe("sucrase", () => {
       `
       console.log(123_456.777_888_999);
     `,
-        {transforms: [], disableESTransforms: true},
+      {transforms: [], disableESTransforms: true},
     );
   });
 });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1301,4 +1301,48 @@ describe("sucrase", () => {
       {transforms: []},
     );
   });
+
+  it("omits optional changing nullish transformations if ES transforms disabled", () => {
+    assertResult(
+      `
+      navigator.share?.({})
+    `,
+      `
+      navigator.share?.({})
+    `,
+        {transforms: [], disableESTransforms: true},
+    );
+  });
+
+  it("omits optional catch binding transformations if ES transforms disabled", () => {
+    assertResult(
+      `
+      try {
+        throw 0;
+      } catch {
+        console.log('Caught');
+      }
+    `,
+      `
+      try {
+        throw 0;
+      } catch {
+        console.log('Caught');
+      }
+    `,
+        {transforms: [], disableESTransforms: true},
+    );
+  });
+
+  it("omits numeric separator transformations if ES transforms disabled", () => {
+    assertResult(
+      `
+      console.log(123_456.777_888_999);
+    `,
+      `
+      console.log(123_456.777_888_999);
+    `,
+        {transforms: [], disableESTransforms: true},
+    );
+  });
 });


### PR DESCRIPTION
The idea of this PR is to allow to opt-out the transformations of "modern" ES features like optional chaining, numbers separators, etc.

Please check issues #602, #622 for more details.

I've tried to implement such a flag, as @alangpierce suggested in #602.
The implementation appeared bigger than I expected as I had to implement changes in 3 main modules:
1. `RootTransformer` – omit unnecessary ES transformers
2. `HelperManager` – disable unused helpers emitting (reverted after finding in https://github.com/alangpierce/sucrase/pull/623#issuecomment-859917228)
3. `TokenProcessor` – disable helpers insertion into a final code, e.g. `_optionalChain(...)` wrapper.

All described scenarios were covered by test cases.

I can't say that this fix is the ideal solution, so please let me know you think we need to fix this in another way.

P.S. Small comment from contribution experience – have you considered migrating to Yarn2? :)