### PR TITLE
Don't emit `await` keyword with ES transforms disabled

### DIFF
--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -212,9 +212,6 @@ export default class TokenProcessor {
       token.isAsyncOperation = isAsyncOperation(this);
     }
     if (this.disableESTransforms) {
-      if (token.isAsyncOperation) {
-        this.resultCode += "await ";
-      }
       return;
     }
     if (token.numNullishCoalesceStarts) {

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1302,7 +1302,7 @@ describe("sucrase", () => {
     );
   });
 
-  it("omits optional changing nullish transformations if ES transforms disabled", () => {
+  it("omits optional chaining nullish transformations if ES transforms disabled", () => {
     assertResult(
       `
       await navigator.share?.({});
@@ -1311,6 +1311,22 @@ describe("sucrase", () => {
       `
       await navigator.share?.({});
       console.log(window.globalStore?.value);
+    `,
+      {transforms: [], disableESTransforms: true},
+    );
+  });
+
+  it("properly skips optional chaining transform when the right-hand side uses await", () => {
+    assertResult(
+      `
+      async function foo() {
+        a?.b(await f());
+      }
+    `,
+      `
+      async function foo() {
+        a?.b(await f());
+      }
     `,
       {transforms: [], disableESTransforms: true},
     );


### PR DESCRIPTION
Follow-up to #623. With transforms disabled, we should just early return even in
the async case.