### PR TITLE
Disable the class fields transform when disableESTransforms is set

### DIFF
--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -698,6 +698,7 @@ function flowParseTypeAnnotatableIdentifier(): void {
 export function flowParseVariance(): void {
   if (match(tt.plus) || match(tt.minus)) {
     next();
+    state.tokens[state.tokens.length - 1].isType = true;
   }
 }
 

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -25,6 +25,7 @@ export default class RootTransformer {
   private generatedVariables: Array<string> = [];
   private isImportsTransformEnabled: boolean;
   private isReactHotLoaderTransformEnabled: boolean;
+  private disableESTransforms: boolean;
   private helperManager: HelperManager;
 
   constructor(
@@ -39,6 +40,7 @@ export default class RootTransformer {
     this.tokens = tokenProcessor;
     this.isImportsTransformEnabled = transforms.includes("imports");
     this.isReactHotLoaderTransformEnabled = transforms.includes("react-hot-loader");
+    this.disableESTransforms = Boolean(options.disableESTransforms);
 
     if (!options.disableESTransforms) {
       this.transformers.push(
@@ -193,7 +195,7 @@ export default class RootTransformer {
   }
 
   processClass(): void {
-    const classInfo = getClassInfo(this, this.tokens, this.nameManager);
+    const classInfo = getClassInfo(this, this.tokens, this.nameManager, this.disableESTransforms);
 
     // Both static and instance initializers need a class name to use to invoke the initializer, so
     // assign to one if necessary.

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -1,15 +1,23 @@
 import {throws} from "assert";
 
-import {transform} from "../src";
+import {transform, Options} from "../src";
 import {IMPORT_DEFAULT_PREFIX} from "./prefixes";
 import {assertResult} from "./util";
 
-function assertFlowResult(code: string, expectedResult: string): void {
-  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "flow"]});
+function assertFlowResult(
+  code: string,
+  expectedResult: string,
+  options: Partial<Options> = {},
+): void {
+  assertResult(code, expectedResult, {transforms: ["jsx", "imports", "flow"], ...options});
 }
 
-function assertFlowESMResult(code: string, expectedResult: string): void {
-  assertResult(code, expectedResult, {transforms: ["jsx", "flow"]});
+function assertFlowESMResult(
+  code: string,
+  expectedResult: string,
+  options: Partial<Options> = {},
+): void {
+  assertResult(code, expectedResult, {transforms: ["jsx", "flow"], ...options});
 }
 
 describe("transform flow", () => {
@@ -425,6 +433,24 @@ describe("transform flow", () => {
         }}
       }
     `,
+    );
+  });
+
+  it("properly removes class property variance markers with ES transforms disabled", () => {
+    assertFlowResult(
+      `
+      class C {
+        +foo: number;
+        -bar: number;
+      }
+    `,
+      `"use strict";
+      class C {
+        foo;
+        bar;
+      }
+    `,
+      {disableESTransforms: true},
     );
   });
 });

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1363,4 +1363,40 @@ describe("sucrase", () => {
       {transforms: [], disableESTransforms: true},
     );
   });
+
+  it("skips class field transform when ES transforms are disabled", () => {
+    assertResult(
+      `
+      class A {
+        x = 1;
+        static y = 2;
+      }
+    `,
+      `
+      class A {
+        x = 1;
+        static y = 2;
+      }
+    `,
+      {transforms: [], disableESTransforms: true},
+    );
+  });
+
+  it("skips class field transform for expression classes when ES transforms are disabled", () => {
+    assertResult(
+      `
+      C = class {
+        x = 1;
+        static y = 2;
+      }
+    `,
+      `
+      C = class {
+        x = 1;
+        static y = 2;
+      }
+    `,
+      {transforms: [], disableESTransforms: true},
+    );
+  });
 });


### PR DESCRIPTION
When disableESTransforms is specified, the class transform can almost entirely
be skipped, but we still need to do some work:
* TS constructor initializers (e.g. constructor params with `readonly` or
  `private`) need to be transformed to assignments within the constructor.
* Fields marked `declare` need to be removed. Uninitialized fields not marked
  declare are preserved, matching the ES spec and the `useDefineForClassFields`
  flag in TS.

For now, we still use the `getClassInfo` code path but give alternate results.
In the future we can hopefully simplify that code path, and possibly change
`declare` parsing so the whole line consists of type tokens that will naturally
be erased.