### PR TITLE
Update CI to use node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
       - run: yarn
       - run: yarn build
       - run: yarn lint
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
       - run: yarn
       - run: yarn fast-build
       - run: yarn run-examples ${{ matrix.projects }}
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
       - run: yarn
       # Clone the jest repo and run an untimed benchmark first, since the first
       # run immediately after cloning tends to be slower.


### PR DESCRIPTION
This fixes an issue in CI with espree dropping node 15 support.