### PR TITLE
Port babel-parser changes from 2021-04-28 to 2021-07-02

### DIFF
--- a/src/parser/plugins/flow.ts
+++ b/src/parser/plugins/flow.ts
@@ -643,7 +643,8 @@ function flowParsePrimaryType(): void {
 
 function flowParsePostfixType(): void {
   flowParsePrimaryType();
-  while (!canInsertSemicolon() && match(tt.bracketL)) {
+  while (!canInsertSemicolon() && (match(tt.bracketL) || match(tt.questionDot))) {
+    eat(tt.questionDot);
     expect(tt.bracketL);
     if (eat(tt.bracketR)) {
       // Array type

--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -1287,14 +1287,6 @@ export function tsTryParseStatementContent(): boolean {
   return false;
 }
 
-export function tsParseAccessModifier(): void {
-  tsParseModifier([
-    ContextualKeyword._public,
-    ContextualKeyword._protected,
-    ContextualKeyword._private,
-  ]);
-}
-
 export function tsTryParseClassMemberWithIsStatic(isStatic: boolean): boolean {
   const memberStartIndexAfterStatic = state.tokens.length;
   tsParseModifiers([

--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -505,8 +505,8 @@ export function parseExprAtom(): boolean {
         return false;
       } else if (
         canBeArrow &&
-        !canInsertSemicolon() &&
         contextualKeyword === ContextualKeyword._async &&
+        !canInsertSemicolon() &&
         match(tt.name)
       ) {
         state.scopeDepth++;
@@ -515,6 +515,10 @@ export function parseExprAtom(): boolean {
         // let foo = async bar => {};
         parseArrowExpression(startTokenIndex);
         return true;
+      } else if (match(tt._do) && !canInsertSemicolon()) {
+        next();
+        parseBlock();
+        return false;
       }
 
       if (canBeArrow && !canInsertSemicolon() && match(tt.arrow)) {

--- a/src/parser/traverser/lval.ts
+++ b/src/parser/traverser/lval.ts
@@ -128,6 +128,7 @@ function parseAssignableListItem(allowModifiers: boolean, isBlockScope: boolean)
       ContextualKeyword._protected,
       ContextualKeyword._private,
       ContextualKeyword._readonly,
+      ContextualKeyword._override,
     ]);
   }
 

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -449,6 +449,19 @@ describe("transform flow", () => {
     );
   });
 
+  it("recognizes flow optional indexed access types", () => {
+    assertFlowResult(
+      `
+      type A = Obj?.['a'];
+      type B = Array<string>?.[number];
+    `,
+      `"use strict";
+      
+
+    `,
+    );
+  });
+
   it("properly removes class property variance markers with ES transforms disabled", () => {
     assertFlowResult(
       `

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1302,6 +1302,22 @@ describe("sucrase", () => {
     );
   });
 
+  it("parses and passes through `async do` expressions", () => {
+    assertResult(
+      `
+      async do {
+        await foo();
+      }
+    `,
+      `
+      async do {
+        await foo();
+      }
+    `,
+      {transforms: []},
+    );
+  });
+
   it("omits optional chaining nullish transformations if ES transforms disabled", () => {
     assertResult(
       `

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2650,6 +2650,23 @@ describe("typescript transform", () => {
     );
   });
 
+  it("allows override on constructor params", () => {
+    assertTypeScriptESMResult(
+      `
+      class A extends B {
+        constructor(override foo: string) {
+        }
+      }
+    `,
+      `
+      class A extends B {
+        constructor( foo) {;this.foo = foo;
+        }
+      }
+    `,
+    );
+  });
+
   it("allows getters and setters on interfaces and object types", () => {
     assertTypeScriptESMResult(
       `


### PR DESCRIPTION
Instructions: https://github.com/alangpierce/sucrase/wiki/Porting-changes-from-Babel's-parser

b116865077 Use this.isThisParam in typescript parser (#13163)
🚫 Refactor not directly relevant to Sucrase.

ceaab0bae7 Parse class fields and private methods by default (#13175)
🚫 Sucrase doesn't gate ES features.

57daba85aa Parse string export names by default (`moduleStringNames`) (#13195)
🚫 Sucrase doesn't gate ES features.

8433cd0c05 Support parsing Flow's Optional Indexed Access Types (#13224)
✅ Straightforward port, didn't seem to need the lexer change.

22b0eb038f [ts] Enforce order for the `override` modifier (#13209)
🚫 TS only.

7f5b212322 babel-parser: Add new `typescript` plugin option `dts: boolean` (#13113)
🚫 Only affects error handling.

28d7442aae Parse async do expressions (#13043)
✅ Ported in a similar way.

a2ac2f39b5 Update `@babel/parser` fixtures
🚫 Tests only.

0f2a1a8153 Add `runFixtureTestsWithoutExactASTMatch` in parser test runner (#13227)
🚫 Only affects test infra.

3c0152a217 v7.14.0
🚫 Release only.

2a3e35f026 chore: remove duplicate test262 parser tests (#13241)
🚫 Only affects tests.

fa01fbe052 Parse `for await (async of ...)` (#13244)
🚫 This feels like unreasonable enough code and enough parser complexity that it feels probably fine to not support in Sucrase, at least for now.

175a51f94e Don't use `"composite": true` in tsc (until it supports cycles)  (#13242)
🚫 Babel-internal.

ef87648f3f Parse static blocks with typescript plugin (#13243)
🚫 Seems to be working fine from my testing.

3ecc7919c5 v7.14.1
🚫 Release only.

278193b6f7 fix: update chunkStart on missing unicode escape (#13261)
🚫 Code not relevant to Sucrase.

a387973821 Refactor private name tokenizing (#13256)
🚫 I'll skip the refactor for now, the benefits don't currently seem compelling.

a8fea4037d Faster identifier tokenizing (#13262)
🚫 I'll skip the refactor for now, the benefits don't currently seem compelling.

1d54419ec4 Parse attributes of import expression with estree plugin (#13284)
🚫 Sucrase doesn't support estree.

b2d9156cc6 Update to Prettier 2.3 (#13288)
🚫 Babel-internal.

7512095c84 v7.14.2
🚫 Release only.

b3d35cd412 [Babel 8]: remove module attributes parser/generator support (#13308)
🚫 Wasn't in Sucrase in the first place.

c2181343f1 Parse `let` declarations whose id starts with `\` (#13325)
🚫 Bug doesn't affect Sucrase.

0d0950f341 fix: preserve tokensLength in tryParse (#13326)
🚫 Only affects recovery mode.

1487a46dd5 v7.14.3
🚫 Release only.

2a5b23186a perf: minimize identifier lookahead when parsing let (#13328)
🚫 Sucrase doesn't special-case the let keyword.

461ba2531a refactor: add parse*Literal parser routines (#13333)
🚫 Benefits don't seem relevant for Sucrase.

d6a5f6190d [ts] Default `typeAnnotation` of `TSTypePredicate` to `null` (#13354)
🚫 AST only.

acf2a10899 Faster tokenizer lookahead (#13341)
🚫 Doesn't seem worth porting for now, unclear if it really applies as-is in Sucrase.

079f8cd5bc fix: disallow surrogate in the end of contextual name (#13377)
🚫 Code not relevant for Sucrase.

1341e560ff Skip `flow/typecasts/3` test on Node.js 6 (#13382)
🚫 Babel-internal.

219fd3ab1f v7.14.4
🚫 Release only.

0b29b5c2c0 Add support for d flag of regex literals in parser (#13396)
🚫 Already works in Sucrase.

140ec5aa5c chore: setup Yarn constraints (#13363)
🚫 Babel-internal.

ae3f5d905a Back parser state `exportedIdentifiers` by set (#13406)
🚫 Not relevant to Sucrase.

cbad50ac1d Faster checkReservedWord (#13386)
🚫 Sucrase does reserved word checking using readWordTree, which is likely faster.

b281fe352c Use set in parser scope (#13408)
🚫 Code path not relevant to Sucrase.

b8175ec060 Relax import assertion key-is-type constraint (#13409)
🚫 Validation only.

a0369fdbfa fix: throw when `async()` call param is object with assignement (#13410)
🚫 Validation only.

56db172b0e fix(`@babel/parser`): fix tokenizer context update code (#13422)
🚫 Code not relevant to Sucrase.

a64d08c101 fix(parser): correctly parse record and tuple tokens (#13418)
🚫 Holding off on an implementation for now.

b9c1884a58 Reduce `exprAllowed` usage (#13431)
🚫 This tokenizer code no longer exists in Sucrase.

d3f4c22c28 update test fixtures (#13440)
🚫 Babel-internal.

7a2a928398 v7.14.5
🚫 Release only.

b1fe831e4a fix: disallow JSX tag after non-null assertion (#13449)
🚫 Bug doesn't appear to come up in Sucrase.

0eb2853732 [ts] Support override modifiers for parameter properties (#13428)
✅ Ported basic change by allowing override in that position.

6c8b2336f6 Faster readRegexp (#13453)
🚫 Many of the optimizations have been applied already.

1774e2aaef v7.14.6
🚫 Release only.

101249f3aa refactor(parser): remove refNeedsArrowPos (#13419)
🚫 Already removed from Sucrase.

5145c98a73 Simplify token context (#13450)
🚫 Sucrase already removed token context.

268e4ca0de v7.14.7
🚫 Release only.

b0fe6bdbc3 chore(parser): add test to handle optional paramteter in async call (#13504)
🚫 Test only.

e6068cd9a5 enhance benchmark output with thousands separators (#13512)
🚫 Babel-internal.

9bad558d13 [babel 8] Use an identifier for `TSTypeParameter.name` (#12829)
🚫 AST-only.