### PR TITLE
Add a default export to the jest-plugin

### DIFF
--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -19,3 +19,5 @@ export function process(src: string, filename: string): string {
     return src;
   }
 }
+
+export default {process};


### PR DESCRIPTION
When I try to transform my Jest code with `sucrase`, I get the following error from Jest:

```
Jest: a transform must export something
```

It looks like this is because Jest now expects transformers to have a default export (I'm not sure when this changed).

I published a [test package](https://www.npmjs.com/package/@luma-team/sucrase-jest-plugin-test) and checked that this change works on my own codebase.

I don't expect this will break anything because it preserves the current exports.

Closes #638