### PR TITLE
Handle shadowed globals when they are JSX names

### DIFF
--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -87,7 +87,10 @@ function markShadowedGlobals(
 function markShadowedForScope(scope: Scope, tokens: TokenProcessor, name: string): void {
   for (let i = scope.startTokenIndex; i < scope.endTokenIndex; i++) {
     const token = tokens.tokens[i];
-    if ((token.type === tt.name || token.type === tt.jsxName) && tokens.identifierNameForToken(token) === name) {
+    if (
+      (token.type === tt.name || token.type === tt.jsxName) &&
+      tokens.identifierNameForToken(token) === name
+    ) {
       token.shadowsGlobal = true;
     }
   }

--- a/src/identifyShadowedGlobals.ts
+++ b/src/identifyShadowedGlobals.ts
@@ -87,7 +87,7 @@ function markShadowedGlobals(
 function markShadowedForScope(scope: Scope, tokens: TokenProcessor, name: string): void {
   for (let i = scope.startTokenIndex; i < scope.endTokenIndex; i++) {
     const token = tokens.tokens[i];
-    if (token.type === tt.name && tokens.identifierNameForToken(token) === name) {
+    if ((token.type === tt.name || token.type === tt.jsxName) && tokens.identifierNameForToken(token) === name) {
       token.shadowsGlobal = true;
     }
   }

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -639,6 +639,29 @@ var _moduleName = require('moduleName');
     );
   });
 
+  it("properly handles React.createElement with shadowing", () => {
+    assertResult(
+      `
+      import React from 'react';
+      import Foo from './Foo';
+      
+      const fn = () => {
+        const Foo = div;
+        return <Foo />;
+      }
+    `,
+      `"use strict";${JSX_PREFIX}${IMPORT_DEFAULT_PREFIX}
+      var _react = require('react'); var _react2 = _interopRequireDefault(_react);
+      var _Foo = require('./Foo'); var _Foo2 = _interopRequireDefault(_Foo);
+      
+      const fn = () => {
+        const Foo = div;
+        return _react2.default.createElement(Foo, {${devProps(7)}} );
+      }
+    `,
+    );
+  });
+
   it("properly transforms imported JSX props", () => {
     assertResult(
       `


### PR DESCRIPTION
The existing logic to identify shadowed globals was not used when the shadowed name is a JSX name, even though shadowing can happen in this case.

I encountered that while using sucrase so here's the change that makes this case work