### PR TITLE
[jest-plugin] Fix transform regex in README

### DIFF
--- a/integrations/jest-plugin/README.md
+++ b/integrations/jest-plugin/README.md
@@ -16,7 +16,7 @@ yarn add --dev @sucrase/jest-plugin
 Then change the default transform in jest.config.js file:
 ```
   ...
-  transform: { ".(js|jsx|ts|tsx)": "@sucrase/jest-plugin" },
+  transform: { "\\.(js|jsx|ts|tsx)$": "@sucrase/jest-plugin" },
   ...
 ```
 


### PR DESCRIPTION
Previously, the regex would match filenames that simply contained `js` or `ts`, even if it wasn't the file extension. Like `my_js_logo.png`.