### PR TITLE
[Proposal] Add removeTypeComments option

### DIFF
--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -27,6 +27,7 @@ export const Options = t.iface([], {
   filePath: t.opt("string"),
   production: t.opt("boolean"),
   disableESTransforms: t.opt("boolean"),
+  removeTypeComments: t.opt("boolean"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -51,6 +51,10 @@ export interface Options {
    * separators, etc.
    */
   disableESTransforms?: boolean;
+  /**
+   * Remove comments attached to removed TypeScript constructs.
+   */
+  removeTypeComments?: boolean;
 }
 
 export function validateOptions(options: Options): void {

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -19,6 +19,7 @@ export default class TokenProcessor {
     readonly isFlowEnabled: boolean,
     readonly disableESTransforms: boolean,
     readonly helperManager: HelperManager,
+    readonly removeTypeComments = false,
   ) {}
 
   /**
@@ -168,12 +169,38 @@ export default class TokenProcessor {
     this.tokenIndex++;
   }
 
+  removeTokenTrimmingAttachedComments(): void {
+    let prev = this.previousWhitespaceAndComments();
+
+    const matches = prev.match(/\r?\n\s*\r?\n/g);
+    if (matches) {
+      const lastMatch = matches[matches.length - 1];
+      const pos = prev.lastIndexOf(lastMatch);
+      prev = prev.slice(0, pos);
+    } else {
+      prev = "";
+    }
+
+    this.resultCode += prev;
+    this.appendTokenPrefix();
+    this.appendTokenSuffix();
+    this.tokenIndex++;
+  }
+
   removeInitialToken(): void {
-    this.replaceToken("");
+    if (this.removeTypeComments) {
+      this.removeTokenTrimmingAttachedComments();
+    } else {
+      this.replaceToken("");
+    }
   }
 
   removeToken(): void {
-    this.replaceTokenTrimmingLeftWhitespace("");
+    if (this.removeTypeComments) {
+      this.removeTokenTrimmingAttachedComments();
+    } else {
+      this.replaceTokenTrimmingLeftWhitespace("");
+    }
   }
 
   copyExpectedToken(tokenType: TokenType): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ const glob = promisify(globCb);
 export default function run(): void {
   commander
     .description(`Sucrase: super-fast Babel alternative.`)
+    .version("fatih")
     .usage("[options] <srcDir>")
     .option(
       "-d, --out-dir <out>",
@@ -43,6 +44,7 @@ export default function run(): void {
     .option("--jsx-pragma <string>", "Element creation function, defaults to `React.createElement`")
     .option("--jsx-fragment-pragma <string>", "Fragment component, defaults to `React.Fragment`")
     .option("--production", "Disable debugging information from JSX in output.")
+    .option("--remove-type-comments", "Remove comments attached to removed TypeScript constructs.")
     .parse(process.argv);
 
   if (commander.project) {
@@ -89,6 +91,7 @@ export default function run(): void {
       jsxPragma: commander.jsxPragma || "React.createElement",
       jsxFragmentPragma: commander.jsxFragmentPragma || "React.Fragment",
       production: commander.production,
+      removeTypeComments: commander.removeTypeComments,
     },
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
     isFlowEnabled,
     disableESTransforms,
     helperManager,
+    options.removeTypeComments,
   );
   const enableLegacyTypeScriptModuleInterop = Boolean(options.enableLegacyTypeScriptModuleInterop);
 

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2776,4 +2776,21 @@ describe("typescript transform", () => {
       {disableESTransforms: true},
     );
   });
+
+  it("removes comments attached to TypeScript-only constructs", () => {
+    assertTypeScriptESMResult(
+      `// This stays
+
+      // This goes
+      interface Foo {}
+
+      // This stays too
+      `,
+      `// This stays
+
+      // This stays too
+      `,
+      {removeTypeComments: true},
+    );
+  });
 });


### PR DESCRIPTION
I have a use case where I want to **generate vanilla JavaScript code samples** (say, usage examples of a library) from TypeScript to **avoid maintaining two versions** of what is essentially the same code. With the right options, Sucrase comes very close. But, unfortunately, it won't remove comments attached to TypeScript-only constructs:

```typescript
// I want this comment to stay

// But I want this one gone, it belongs to the interface (empty line is the heuristic)
interface Foo {}
```

I implemented this behind a new option called `removeTypeComments` and I added a test case.

I think this could quickly become a major use case with, for instance, a Docusaurus or MDX plugin. I have already released [a package](https://www.npmjs.com/package/detype) that does something similar (using Babel + Prettier + a few tricks) but this feels much cleaner.

What do you think?