### PR TITLE
Add null as reserved word in enum emit, other follow-ups

### DIFF
--- a/src/util/isIdentifier.ts
+++ b/src/util/isIdentifier.ts
@@ -21,7 +21,6 @@ const RESERVED_WORDS = new Set([
   "else",
   "export",
   "extends",
-  "false",
   "finally",
   "for",
   "function",
@@ -35,7 +34,6 @@ const RESERVED_WORDS = new Set([
   "switch",
   "this",
   "throw",
-  "true",
   "try",
   "typeof",
   "var",
@@ -54,8 +52,19 @@ const RESERVED_WORDS = new Set([
   "public",
   "static",
   "await",
+  // Literals that cannot be used as identifiers
+  "false",
+  "null",
+  "true",
 ]);
 
+/**
+ * Determine if the given name is a legal variable name.
+ *
+ * This is needed when transforming TypeScript enums; if an enum key is a valid
+ * variable name, it might be referenced later in the enum, so we need to
+ * declare a variable.
+ */
 export default function isIdentifier(name: string): boolean {
   if (name.length === 0) {
     return false;

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -602,6 +602,27 @@ describe("typescript transform", () => {
     );
   });
 
+  it("handles reserved literals when transforming enums", () => {
+    assertTypeScriptESMResult(
+      `
+      enum Foo {
+        true,
+        false,
+        null,
+        undefined
+      }
+    `,
+      `
+      var Foo; (function (Foo) {
+        Foo[Foo["true"] = 0] = "true";
+        Foo[Foo["false"] = Foo["true"] + 1] = "false";
+        Foo[Foo["null"] = Foo["false"] + 1] = "null";
+        const undefined = Foo["null"] + 1; Foo[Foo["undefined"] = undefined] = "undefined";
+      })(Foo || (Foo = {}));
+    `,
+    );
+  });
+
   it("removes functions without bodies", () => {
     assertTypeScriptResult(
       `


### PR DESCRIPTION
Follow-up to #656:
* Add `null` as a new case that should not have a variable declared in enum
  emit.
* Rearrange the declaration to group these special non-identifier literals.
* Add a test, also confirming that `undefined` is *not* reserved here.
* Add a jsdoc comment for `isIdentifier`.