### PR TITLE
Add source map support to Jest plugin

### DIFF
--- a/integrations/jest-plugin/package.json
+++ b/integrations/jest-plugin/package.json
@@ -8,5 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "sucrase": "^3.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^16.11.4"
   }
 }

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -14,7 +14,14 @@ function getTransforms(filename: string): Array<Transform> | null {
 export function process(src: string, filename: string): string {
   const transforms = getTransforms(filename);
   if (transforms !== null) {
-    return transform(src, {transforms, filePath: filename}).code;
+    const {code, sourceMap} = transform(src, {
+      transforms,
+      sourceMapOptions: {compiledFilename: filename},
+      filePath: filename,
+    });
+    const mapBase64 = Buffer.from(JSON.stringify(sourceMap)).toString("base64");
+    const suffix = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${mapBase64}`;
+    return `${code}\n${suffix}`;
   } else {
     return src;
   }

--- a/integrations/jest-plugin/yarn.lock
+++ b/integrations/jest-plugin/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@^16.11.4":
+  version "16.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.4.tgz#90771124822d6663814f7c1c9b45a6654d8fd964"
+  integrity sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ==
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"


### PR DESCRIPTION
Fixes #660

Previously, the Jest plugin would just return source code without attempting to
generate and return source maps. Even though the source map is always the
identity map, the lack of source map meant that WebStorm didn't allow debugger
breakpoints. To fix, we can use the same strategy as in `register.ts`: ask for a
source map, generate a base64 string of it, and append it to the end of the file
in a data URL.

One nuance here is that this adds a dependency on node because it uses the
`Buffer` class to convert to base64. I believe this is non-breaking because Jest
always runs in node anyway.

I was able to test this successfully in WebStorm and confirm that breakpoints
now work. Jest caches transform results, so I had to clear its cache for pick up
the change:
```
./node_modules/.bin/jest --clearCache
```