### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -374,12 +374,12 @@ function processEntity(text: string, indexAfterAmpersand: number): {entity: stri
     if (ch === ";") {
       if (str[0] === "#") {
         if (str[1] === "x") {
-          str = str.substr(2);
+          str = str.slice(2);
           if (HEX_NUMBER.test(str)) {
             entity = String.fromCodePoint(parseInt(str, 16));
           }
         } else {
-          str = str.substr(1);
+          str = str.slice(1);
           if (DECIMAL_NUMBER.test(str)) {
             entity = String.fromCodePoint(parseInt(str, 10));
           }

--- a/website/src/URLHashState.ts
+++ b/website/src/URLHashState.ts
@@ -72,7 +72,7 @@ export function loadHashState(): Partial<BaseHashState> | null {
     if (!hashContents.startsWith("#")) {
       return null;
     }
-    const components = hashContents.substr(1).split("&");
+    const components = hashContents.slice(1).split("&");
     const result: Partial<HashState> = {};
     for (const component of components) {
       const [key, value] = component.split("=");


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.