### PR TITLE
build esm files to separate folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Super-fast alternative to Babel for when you can target modern JS runtimes",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
-  "main": "dist/index",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "bin": {
     "sucrase": "./bin/sucrase",
     "sucrase-node": "./bin/sucrase-node"

--- a/script/build.ts
+++ b/script/build.ts
@@ -53,19 +53,15 @@ async function buildSucrase(): Promise<void> {
     // code again. The second and third outputs should be exactly identical; otherwise we may have a
     // problem where it miscompiled itself.
     await run(`${SUCRASE_SELF} ./src -d ./dist-self-build --transforms imports,typescript -q`);
-    await run(
-      `${SUCRASE_SELF} ./src -d ./dist-self-build --transforms typescript --out-extension mjs -q`,
-    );
+    await run(`${SUCRASE_SELF} ./src -d ./dist-self-build/esm --transforms typescript -q`);
     await run("rm -rf ./dist");
     await run("mv ./dist-self-build ./dist");
     await run(`${SUCRASE_SELF} ./src -d ./dist-self-build --transforms imports,typescript -q`);
-    await run(
-      `${SUCRASE_SELF} ./src -d ./dist-self-build --transforms typescript --out-extension mjs -q`,
-    );
+    await run(`${SUCRASE_SELF} ./src -d ./dist-self-build/esm --transforms typescript -q`);
     await run("diff -r ./dist ./dist-self-build");
     // Also add in .d.ts files from tsc, which only need to be compiled once.
     await run(`${TSC} --project ./src --outDir ./dist-types`);
-    await mergeDirectoryContents("./dist-types/src", "./dist");
+    await mergeDirectoryContents("./dist-types/src", "./dist/types");
     // Link all integrations to Sucrase so that all building/linting/testing is up to date.
     await run("yarn link");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ export type SourceMapOptions = import("./Options").SourceMapOptions;
 export type Transform = import("./Options").Transform;
 
 export function getVersion(): string {
-  // eslint-disable-next-line
-  return require("../package.json").version;
+  return "3.20.3";
 }
 
 export function transform(code: string, options: Options): TransformResult {


### PR DESCRIPTION
I build a [package](https://github.com/nihgwu/react-runner) based on `sucrase` and the current folder structure has raised lots of problem, I've tried my best to workaround them without touching `sucrase`, but now I think it's impossible. 

The current folder structure doesn't work for ESM as `mjs` extension is required by Node for importing an ESM file, while `sucrase` doesn't, so for webpack5 we have to add `resolve.fullySpecified: false` as a workaround, and for `esbuild` probably we need other workaround https://github.com/evanw/esbuild/issues/2128#issuecomment-1079108795, but for some build tools they don't expose the way to config esbuild, like Remix, Vite supports partially and doesn't change that config, so only alias to cjs version works for Vite, but there is no way to do that in Remix

So the case is that, even we import `sucrase/dist/index.mjs`, esbuild will import `NameManager.js` instead of `NameManager.mjs`, while webpack will import `NameManager.mjs` even we import from `sucrase/dist/index.js`

After this change, we don't need any workarounds to make it work properly in the frontend world, and it won't break the Node environment as the current mjs file importing is wrong and doesn't work

I didn't move cjs files to `cjs` folder on purpose, in case some one would import the sub files manually