### PR TITLE
Jest-Plugin: Support v28

### DIFF
--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -11,7 +11,11 @@ function getTransforms(filename: string): Array<Transform> | null {
   return null;
 }
 
-export function process(src: string, filename: string): string {
+// this is compatible to the one that is required by Jest, using the type from here:
+// https://github.com/mozilla/source-map/blob/0.6.1/source-map.d.ts#L6-L12
+type RawSourceMap = ReturnType<typeof transform>['sourceMap'];
+
+export function process(src: string, filename: string): {code: string; map?: RawSourceMap | string | null} {
   const transforms = getTransforms(filename);
   if (transforms !== null) {
     const {code, sourceMap} = transform(src, {
@@ -21,9 +25,9 @@ export function process(src: string, filename: string): string {
     });
     const mapBase64 = Buffer.from(JSON.stringify(sourceMap)).toString("base64");
     const suffix = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${mapBase64}`;
-    return `${code}\n${suffix}`;
+    return {code: `${code}\n${suffix}`, map: sourceMap};
   } else {
-    return src;
+    return {code: src};
   }
 }
 

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -13,9 +13,12 @@ function getTransforms(filename: string): Array<Transform> | null {
 
 // this is compatible to the one that is required by Jest, using the type from here:
 // https://github.com/mozilla/source-map/blob/0.6.1/source-map.d.ts#L6-L12
-type RawSourceMap = ReturnType<typeof transform>['sourceMap'];
+type RawSourceMap = ReturnType<typeof transform>["sourceMap"];
 
-export function process(src: string, filename: string): {code: string; map?: RawSourceMap | string | null} {
+export function process(
+  src: string,
+  filename: string,
+): {code: string; map?: RawSourceMap | string | null} {
   const transforms = getTransforms(filename);
   if (transforms !== null) {
     const {code, sourceMap} = transform(src, {


### PR DESCRIPTION
This change is also backward compatible to earlier versions of Jest. Tested it also with Jest@27.

Fixes: https://github.com/alangpierce/sucrase/issues/694