### PR TITLE
Bugfix allow re-export of existing named members

### DIFF
--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -26,7 +26,7 @@ const HELPERS: {[name: string]: string} = {
   `,
   createNamedExportFrom: `
     function createNamedExportFrom(obj, localName, importedName) {
-      Object.defineProperty(exports, localName, {enumerable: true, get: () => obj[importedName]});
+      Object.defineProperty(exports, localName, {enumerable: true, configurable: true, get: () => obj[importedName]});
     }
   `,
   // Note that TypeScript and Babel do this differently; TypeScript does a simple existence
@@ -41,7 +41,7 @@ const HELPERS: {[name: string]: string} = {
           if (exports.hasOwnProperty(key)) {
             return;
           }
-          Object.defineProperty(exports, key, {enumerable: true, get: () => obj[key]});
+          Object.defineProperty(exports, key, {enumerable: true, configurable: true, get: () => obj[key]});
         });
     }
   `,

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -8,11 +8,11 @@ if (Object.prototype.hasOwnProperty.call(obj, key)) { newObj[key] = obj[key]; } 
 newObj.default = obj; return newObj; } }`;
 export const CREATE_NAMED_EXPORT_FROM_PREFIX = ` function _createNamedExportFrom(obj, \
 localName, importedName) { Object.defineProperty(exports, localName, \
-{enumerable: true, get: () => obj[importedName]}); }`;
+{enumerable: true, configurable: true, get: () => obj[importedName]}); }`;
 export const CREATE_STAR_EXPORT_PREFIX = ` function _createStarExport(obj) { \
 Object.keys(obj) .filter((key) => key !== "default" && key !== "__esModule") \
 .forEach((key) => { if (exports.hasOwnProperty(key)) { return; } \
-Object.defineProperty(exports, key, {enumerable: true, get: () => obj[key]}); }); }`;
+Object.defineProperty(exports, key, {enumerable: true, configurable: true, get: () => obj[key]}); }); }`;
 export const ESMODULE_PREFIX = 'Object.defineProperty(exports, "__esModule", {value: true});';
 export const RHL_PREFIX = `(function () { \
 var enterModule = require('react-hot-loader').enterModule; enterModule && enterModule(module); \


### PR DESCRIPTION
Add configurable: true to Object.defineProperty to allow overwriting existing named exports.

Consider the following valid code

```typescript
// lib1.ts
export const a = '1';

// lib2.ts
export const a = '2'

// index.ts
export * from 'lib1.ts'
export * from 'lib2.ts'
export { a } from 'lib2.ts'

```
Currently tsc and babel compile this fine but sucrase fails with

```
TypeError: Cannot redefine property: a
        at Function.defineProperty (<anonymous>)
```