### PR TITLE
Speed up linting by excluding irrelevant directories in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
   ],
   "exclude": [
     "benchmark/sample",
-    "example-runner/example-repos"
+    "example-runner/example-repos",
+    "test262/test262-checkout"
   ]
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -15,6 +15,8 @@
     "importHelpers": true,
   },
   "exclude": [
-    "node_modules",
+    "build",
+    "gh-pages",
+    "node_modules"
   ]
 }


### PR DESCRIPTION
This avoids some slowdowns that can happen when running TS checking and ESLint
after running commands that generate directories containing js/ts files.

This gets `yarn test` down to about 10 seconds for me; previously it was about
1 minute.