### PR TITLE
Fix bug in scientific notation parsing

### DIFF
--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1469,4 +1469,48 @@ describe("sucrase", () => {
       {transforms: ["typescript"]},
     );
   });
+
+  it("parses scientific notation number literals followed by dot", () => {
+    assertResult(
+      `
+      console.log(1e5.toString());
+    `,
+      `"use strict";
+      console.log(1e5.toString());
+    `,
+    );
+  });
+
+  it("handles parsing of hex literals", () => {
+    assertResult(
+      `
+      const x = 0x8badf00d;
+    `,
+      `"use strict";
+      const x = 0x8badf00d;
+    `,
+    );
+  });
+
+  it("handles parsing of hex bigint literals", () => {
+    assertResult(
+      `
+      const x = 0xabcden;
+    `,
+      `"use strict";
+      const x = 0xabcden;
+    `,
+    );
+  });
+
+  it("handles parsing of negative exponents", () => {
+    assertResult(
+      `
+      const x = 1e-10;
+    `,
+      `"use strict";
+      const x = 1e-10;
+    `,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #676

Scientific notation parsing was using the shared `readInt` code path, which I
had made more flexible to handle hex digits, but that means that literals like
`1e2` were being treated as a complete number (with the hex digit `e`) rather
than as scientific notation. Normally this wouldn't be a problem since it's all
a number token anyway, but it caused trouble when using dot-style property
access like `1e2.toString()`. Expressions like `1.toString()` are expected to
fail because `.` is interpreted as a decimal point, but when using scientific
notation, the parser needs to be smart enough see that a decimal point wouldn't
be valid, and therefore not include it as part of the token.

The fix was to change `readInt` to only handle decimal digits, not hex digits,
and to inline the hex case into `readRadixNumber`. This should make number
parsing slightly faster because it's not checking for hex digits anymore.

I also added some tests since some of this code wasn't well covered by test
coverage.