### PR TITLE
Disable fail-fast mode for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
     name: "Test on older node versions"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           # We support down to node 8, but mocha requires node 14.
@@ -43,6 +44,7 @@ jobs:
     name: "Test example projects"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - projects: "babel"


### PR DESCRIPTION
GitHub Actions by default cancels all other builds in a matrix when one fails,
meaning that we weren't getting a full report of which example repos suceeded
and which failed. By adding `fail-fast: false`, we'll now get a full report, and
retrying on an individual level if necessary should be easier.