### PR TITLE
Add support for TS 4.5 import type modifiers

### DIFF
--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -23,8 +23,10 @@ import {
   tsAfterParseVarHead,
   tsIsDeclarationStart,
   tsParseExportDeclaration,
+  tsParseExportSpecifier,
   tsParseIdentifierStatement,
   tsParseImportEqualsDeclaration,
+  tsParseImportSpecifier,
   tsParseMaybeDecoratorArguments,
   tsParseModifiers,
   tsStartParseFunctionParams,
@@ -1059,12 +1061,19 @@ export function parseExportSpecifiers(): void {
         break;
       }
     }
+    parseExportSpecifier();
+  }
+}
 
+function parseExportSpecifier(): void {
+  if (isTypeScriptEnabled) {
+    tsParseExportSpecifier();
+    return;
+  }
+  parseIdentifier();
+  state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ExportAccess;
+  if (eatContextual(ContextualKeyword._as)) {
     parseIdentifier();
-    state.tokens[state.tokens.length - 1].identifierRole = IdentifierRole.ExportAccess;
-    if (eatContextual(ContextualKeyword._as)) {
-      parseIdentifier();
-    }
   }
 }
 
@@ -1164,6 +1173,10 @@ function parseImportSpecifiers(): void {
 }
 
 function parseImportSpecifier(): void {
+  if (isTypeScriptEnabled) {
+    tsParseImportSpecifier();
+    return;
+  }
   if (isFlowEnabled) {
     flowParseImportSpecifier();
     return;

--- a/src/util/getImportExportSpecifierInfo.ts
+++ b/src/util/getImportExportSpecifierInfo.ts
@@ -1,0 +1,92 @@
+import {TokenType as tt} from "../parser/tokenizer/types";
+import type TokenProcessor from "../TokenProcessor";
+
+export type ImportExportSpecifierInfo =
+  | {
+      isType: false;
+      leftName: string;
+      rightName: string;
+      endIndex: number;
+    }
+  | {
+      isType: true;
+      leftName: null;
+      rightName: null;
+      endIndex: number;
+    };
+
+/**
+ * Determine information about this named import or named export specifier.
+ *
+ * This syntax is the `a` from statements like these:
+ * import {A} from "./foo";
+ * export {A};
+ * export {A} from "./foo";
+ *
+ * As it turns out, we can exactly characterize the syntax meaning by simply
+ * counting the number of tokens, which can be from 1 to 4:
+ * {A}
+ * {type A}
+ * {A as B}
+ * {type A as B}
+ *
+ * In the type case, we never actually need the names in practice, so don't get
+ * them.
+ *
+ * TODO: There's some redundancy with the type detection here and the isType
+ * flag that's already present on tokens in TS mode. This function could
+ * potentially be simplified and/or pushed to the call sites to avoid the object
+ * allocation.
+ */
+export default function getImportExportSpecifierInfo(
+  tokens: TokenProcessor,
+  index: number = tokens.currentIndex(),
+): ImportExportSpecifierInfo {
+  let endIndex = index + 1;
+  if (isSpecifierEnd(tokens, endIndex)) {
+    // import {A}
+    const name = tokens.identifierNameAtIndex(index);
+    return {
+      isType: false,
+      leftName: name,
+      rightName: name,
+      endIndex,
+    };
+  }
+  endIndex++;
+  if (isSpecifierEnd(tokens, endIndex)) {
+    // import {type A}
+    return {
+      isType: true,
+      leftName: null,
+      rightName: null,
+      endIndex,
+    };
+  }
+  endIndex++;
+  if (isSpecifierEnd(tokens, endIndex)) {
+    // import {A as B}
+    return {
+      isType: false,
+      leftName: tokens.identifierNameAtIndex(index),
+      rightName: tokens.identifierNameAtIndex(index + 2),
+      endIndex,
+    };
+  }
+  endIndex++;
+  if (isSpecifierEnd(tokens, endIndex)) {
+    // import {type A as B}
+    return {
+      isType: true,
+      leftName: null,
+      rightName: null,
+      endIndex,
+    };
+  }
+  throw new Error(`Unexpected import/export specifier at ${index}`);
+}
+
+function isSpecifierEnd(tokens: TokenProcessor, index: number): boolean {
+  const token = tokens.tokens[index];
+  return token.type === tt.braceR || token.type === tt.comma;
+}

--- a/src/util/getTSImportedNames.ts
+++ b/src/util/getTSImportedNames.ts
@@ -1,6 +1,6 @@
-import {ContextualKeyword} from "../parser/tokenizer/keywords";
 import {TokenType as tt} from "../parser/tokenizer/types";
 import type TokenProcessor from "../TokenProcessor";
+import getImportExportSpecifierInfo from "./getImportExportSpecifierInfo";
 
 /**
  * Special case code to scan for imported names in ESM TypeScript. We need to do this so we can
@@ -65,16 +65,12 @@ function collectNamesForNamedImport(
       return;
     }
 
-    // We care about the local name, which might be the first token, or if there's an "as", is the
-    // one after that.
-    let name = tokens.identifierNameAtIndex(index);
-    index++;
-    if (tokens.matchesContextualAtIndex(index, ContextualKeyword._as)) {
-      index++;
-      name = tokens.identifierNameAtIndex(index);
-      index++;
+    const specifierInfo = getImportExportSpecifierInfo(tokens, index);
+    index = specifierInfo.endIndex;
+    if (!specifierInfo.isType) {
+      importedNames.add(specifierInfo.rightName);
     }
-    importedNames.add(name);
+
     if (tokens.matches2AtIndex(index, tt.comma, tt.braceR)) {
       return;
     } else if (tokens.matches1AtIndex(index, tt.braceR)) {


### PR DESCRIPTION
Fixes #668

Details on the syntax are described here:
https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names

This was implemented in Babel here: https://github.com/babel/babel/pull/13802

In terms of behavior, the type syntax is *almost* a no-op in valid code; we
already scan the file to see which identifiers have been used in a value or type
context and remove type imports automatically, and this PR doesn't change that.
However, there are a few subtle differences:
* When targeting commonjs, if an imported name has a `type` modifier and is used
  in a value context, we do *not* transform the syntax to access the module like
  we did before. For example, this comes up if accessing a global value with the
  same name as an imported type.
* In both CJS and ESM targets, code that imports and then re-exports a type
  needs to have that export elided. Previously, this was a situation where TS
  doesn't know whether the name is a type or not, so it included the export as a
  value.

Right now, there is no equivalent to `--preserveValueImports`, but this could be
added in the future. It *almost* would turn the TS transform into a purely
syntax-level transform without the need for scope analysis and variable name
tracking (thus simplifying and speeding up Sucrase if it became the standard
approach), except that even with that flag set, type-only exports are still
elided.

In terms of implementation details, the Babel parser details were a bit
AST-focused and didn't need to deal with `IdentifierRole`s, so I re-implemented
parsing using a simpler approach, which was also useful in the transform step.

It turns out that in both Flow and TS, you can parse an import or export
specifier by accepting anywhere from 1 to 4 identifiers, and the number of
identifiers is enough to exactly determine the syntax. This is more reliable
than matching on the names `type` (or `typeof`) and `as` because those are
contextual keywords that might be valid identifiers.

In the transform step, there were 5 places where we were manually walking
import/export specifiers, so it seemed best to unify that parsing into a shared
utility. This potentially has some performance cost due to the object
allocations, but it's likely to be very minor and could potentially be improved
later.