### PR TITLE
Port babel-parser changes from 2021-08-20 to 2021-12-30

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -672,7 +672,7 @@ function tsTryParseType(): void {
  */
 function tsParseTypePredicateOrAssertsPrefix(): boolean {
   const snapshot = state.snapshot();
-  if (isContextual(ContextualKeyword._asserts) && !hasPrecedingLineBreak()) {
+  if (isContextual(ContextualKeyword._asserts)) {
     // Normally this is `asserts x is T`, but at this point, it might be `asserts is T` (a user-
     // defined type guard on the `asserts` variable) or just a type called `asserts`.
     next();
@@ -1453,7 +1453,9 @@ export function tsStartParseFunctionParams(): void {
 // `let x: number;`
 export function tsAfterParseVarHead(): void {
   const oldIsType = pushTypeContext(0);
-  eat(tt.bang);
+  if (!hasPrecedingLineBreak()) {
+    eat(tt.bang);
+  }
   tsTryParseTypeAnnotation();
   popTypeContext(oldIsType);
 }

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1513,4 +1513,36 @@ describe("sucrase", () => {
     `,
     );
   });
+
+  it("allows static blocks with a line break after the static keyword", () => {
+    assertResult(
+      `
+      class A {
+        static
+        {
+          console.log("hi");
+        }
+      }
+    `,
+      `"use strict";
+      class A {
+        static
+        {
+          console.log("hi");
+        }
+      }
+    `,
+    );
+  });
+
+  it("allows arrow functions with parameter object assignment", () => {
+    assertResult(
+      `
+      ({x = 1}) => null
+    `,
+      `"use strict";
+      ({x = 1}) => null
+    `,
+    );
+  });
 });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -3003,4 +3003,32 @@ describe("typescript transform", () => {
       {transforms: ["typescript"]},
     );
   });
+
+  it("allows a line break before an `asserts` clause", () => {
+    assertResult(
+      `
+      function assert(condition: any): 
+      asserts condition {}
+    `,
+      `
+      function assert(condition)
+ {}
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
+
+  it("properly handles ASI for variable followed by exclamation point", () => {
+    assertResult(
+      `
+      let a
+      !function(){}()
+    `,
+      `
+      let a
+      !function(){}()
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
 });


### PR DESCRIPTION
Instructions: https://github.com/alangpierce/sucrase/wiki/Porting-changes-from-Babel's-parser

976bfbbf69 fix: assure left bracket is not consumed after dot (#13695)
🚫 Bug doesn't seem to apply to Sucrase, and fix is validation only.

1d4bd31950 add missing ExportNamespaceSpecifier in spec.md (#13691)
🚫 Docs only.

b141c85b17 fix(babel-parser): delete `static` property from class static block for TS (#13680)
🚫 Only affects AST.

64d116bd6a fix(parser): [Babel8] Align error codes between Flow and TypeScript (#13294)
🚫 Only affects error reporting.

a54f041440 test(parser): add no_plugin tests for module blocks (#13714)
🚫 Test only.

b2376757d7 v7.15.4
🚫 Release only.

44388e6e81 Disallow `#a in #b in c` and similar expressions (#13727)
🚫 Only affects validation.

e82e43ca33 v7.15.5
🚫 Release only.

62e42a3f60 fix(babel-parser): Fix end of `range` of `SequenceExpression` (#13731)
🚫 AST only.

c25ec3e069 [babel-parser] add tests for static blocks with line breaks (#13734)
✅ Added similar test for Sucrase (though nothing was broken).

3c3f5205c9 Fix right precedence of Hack pipes (#13668)
✅ Given the active spec work, I filed https://github.com/alangpierce/sucrase/issues/674 to revisit in the future.

34a27e46f8 v7.15.6
🚫 Release only.

710b3919fa [estree] Fix conversion of `PrivateName` in `MemberExpression` (#13755)
🚫 Only affects estree.

da79c90f2a fix(babel-parser): Allow line break before `assert` return type (#13771)
✅ Ported fix.

d2076a531f Store token type as number (#13768)
🚫 Optimization that's pretty much already in Sucrase.

8d0294edf8 v7.15.7
🚫 Release only.

2e2d202694 [babel 8] Materialize ESTree's `classFeatures` option (#13752)
🚫 Not relevant for Sucrase.

178d43ff17 Tokenize keywords-like identifier as new tokens (#13769)
🚫 Interesting alternative approach to Sucrase's contextual keyword enums. Doesn't seem worth it to switch to Babel's approach for now.

64f14b05fa Collect comments around parentheses in expressions (#13803)
🚫 AST only.

c4b13725aa v7.15.8
🚫 Release only.

b5907ef967 remove executable permission from files that shouldn't have it (#13873)
🚫 Babel-internal change.

62b2c5ebb9 Regenerate parser fixtures (#13882)
🚫 Babel-internal change.

c7ddb1ae93 Use `workspace:^` to specify `@babel/` dependencies (#13772)
🚫 Babel-internal change.

fb7ddf4d38 [ts] Support private methods overloads (#13876)
🚫 Issue doesn't affect Sucrase.

ddc45a5a50 Enable class static blocks by default (#13713)
🚫 Already enabled by default for Sucrase.

ad59a2c618 Caret topic (pipe operator) (#13749)
🚫 Not implementing topic token changes for now until it's finalized, see https://github.com/alangpierce/sucrase/issues/674

718c6cb7de Handle `.mts` and `.cts` files in `@babel/preset-typescript` (#13838)
🚫 Only adds error handling to the parser. Sucrase integrations should better handle .mts and .cts, but that can be done in follow-up work.

872086a9a0 feat: support `startColumn` option (#13887)
🚫 Not relevant to Sucrase.

d5ba355867 Support TypeScript 4.5 type-only import/export specifiers (#13802)
✅ Implemented separately as https://github.com/alangpierce/sucrase/pull/713

45308f3cba v7.16.0
🚫 Release only.

cba7f9e503 Add missing assertions type (#13905)
🚫 AST only.

68fad796b1 v7.16.2
🚫 Release only.

1fa759f989 refactor: extract tt.lt and tt.gt from tt.relation (#13892)
🚫 Already done in Sucrase. Also includes a refactor that could be reasonable to incorporate, but I'll skip that for now.

7250d2562b Simplifiy tracking of valid JSX positions (#13891)
🚫 The relevant code has changed enough that this probably isn't worth porting.

a6a526968d fix: incorrect await rejection following arrow function in parameters (#13928)
🚫 Bug fix is in code not relevant to Sucrase.

3b6f061e18 v7.16.3
🚫 Release only.

135ab837bc Throw on duplicate `__proto__` props followed by assignment (#13951)
🚫 Only affects error handling.

54c539ecc1 Refactor bindingProperty parsing (#13929)
🚫 Nothing stands out as relevant to Sucrase.

966387d263 Always expose `expressionValue` in `DirectiveLiteral` nodes (#13960)
🚫 AST only.

87fc2e76d7 Add `assertions` to `ExportNamedDeclaration` without `from` (#13957)
🚫 AST only.

99774ee9fa v7.16.4
🚫 Release only.

d30308fe8e fix: update UnexpectedPrivateField error message (#13975)
🚫 Validation only.

a470f7b479 Recover from shorthand assign exprs (#13968)
✅ We already handled this case, but I added a test to confirm.

75996cb62b Use full import specifier path in tests (#13938)
🚫 Babel-internal change.

ad1798ed48 Only bundle the release build, and don't import `src` in tests (#13978)
🚫 Babel-internal change.

f4236f43a1 Extend `hasPlugin` to accept plugin-configuration array pairs (#13982)
🚫 Sucrase uses a different config system.

2d989a983d Run tests in a native Node.js ESM environment (#13966)
🚫 Babel-internal change. (Though very cool to see!)

94af0e5c62 Improve template tokenizing (#13919)
🚫 Sucrase got rid of context, so it looks like this change isn't as relevant.

39080492f4 maintain estree string literal shape when cloned (#14039)
🚫 AST only.

7b7ab94066 v7.16.5
🚫 Release only.

7794201940 fix: handle tokens for invalid template element (#14055)
🚫 Bug not relevant to Sucrase.

5687ade5e7 v7.16.6
🚫 Release only.

ad17fe1cce fix: check preceding line break before exclamation (#14049)
✅ Fixed bug in the same way and added a test.

d1cabf6bc8 [babel 8] Add `"exports"` to every package (#14013)
🚫 Babel-internal change.

23e884048a v7.16.7
🚫 Release only.