### PR TITLE
Add test script to try Sucrase against Babel test cases

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 benchmark/sample/*
 benchmark/node_modules/*
 example-runner/example-repos
+spec-compliance-tests/babel-tests/babel-tests-checkout
+spec-compliance-tests/test262/test262-checkout

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
           "**/example-runner/**",
           "**/generator/**",
           "**/test/**",
-          "**/test262/**",
+          "**/spec-compliance-tests/**",
           "**/script/**",
         ],
         optionalDependencies: false,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-and-test:
-    name: "Lint and core tests"
+    name: "Lint, core tests, and spec compliance tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +20,7 @@ jobs:
       - run: yarn lint
       - run: yarn test-with-coverage && yarn report-coverage
       - run: yarn test262
+      - run: yarn check-babel-tests
   test-older-node:
     name: "Test on older node versions"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ dist
 dist-self-build
 dist-types
 example-runner/example-repos
-test262/test262-checkout
+spec-compliance-tests/test262/test262-checkout
+spec-compliance-tests/babel-tests/babel-tests-checkout
 integrations/gulp-plugin/dist
 .nyc_output
 coverage.lcov

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "sucrase-node script/build.ts",
     "fast-build": "sucrase-node script/build.ts --fast",
-    "clean": "rm -rf ./build ./dist ./dist-self-build ./dist-types ./example-runner/example-repos ./test262/test262-checkout",
+    "clean": "rm -rf ./build ./dist ./dist-self-build ./dist-types ./example-runner/example-repos ./spec-compliance-tests/test262/test262-checkout ./spec-compliance-tests/babel-tests/babel-tests-checkout",
     "generate": "sucrase-node generator/generate.ts",
     "benchmark": "cd benchmark && yarn && sucrase-node ./benchmark.ts",
     "benchmark-compare": "sucrase-node ./benchmark/compare-performance.ts",
@@ -27,7 +27,8 @@
     "run-examples": "sucrase-node example-runner/example-runner.ts",
     "test": "yarn lint && yarn test-only",
     "test-only": "mocha './test/**/*.ts'",
-    "test262": "sucrase-node test262/run-test262.ts",
+    "test262": "sucrase-node spec-compliance-tests/test262/run-test262.ts",
+    "check-babel-tests": "sucrase-node spec-compliance-tests/babel-tests/check-babel-tests.ts",
     "test-with-coverage": "nyc mocha './test/**/*.ts'",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
@@ -45,6 +46,7 @@
     "url": "https://github.com/alangpierce/sucrase/issues"
   },
   "devDependencies": {
+    "@babel/core": "^7.18.6",
     "@types/glob": "^7",
     "@types/mocha": "^9.1.1",
     "@types/mz": "^2.7.4",

--- a/script/lint.ts
+++ b/script/lint.ts
@@ -27,7 +27,15 @@ async function checkSucrase(): Promise<void> {
   await Promise.all([
     run(`${TSC} --project . --noEmit`),
     run(
-      `${ESLINT} ${["benchmark", "example-runner", "generator", "script", "src", "test", "test262"]
+      `${ESLINT} ${[
+        "benchmark",
+        "example-runner",
+        "generator",
+        "script",
+        "spec-compliance-tests",
+        "src",
+        "test",
+      ]
         .map((dir) => `'${dir}/**/*.ts'`)
         .join(" ")}`,
     ),

--- a/script/util/readFileContents.ts
+++ b/script/util/readFileContents.ts
@@ -1,0 +1,9 @@
+import {readFile} from "mz/fs";
+
+export async function readFileContents(path: string): Promise<string> {
+  return (await readFile(path)).toString();
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function readJSONFileContents(path: string): Promise<any> {
+  return JSON.parse(await readFileContents(path));
+}

--- a/spec-compliance-tests/README.md
+++ b/spec-compliance-tests/README.md
@@ -1,0 +1,6 @@
+# Spec compliance tests
+
+This directory consists of integrations with externally-written test suites that
+are designed to surface tricky cases. This is in contrast to the example-runner
+directory, which  tests Sucrase on realistic codebases, and the test directory,
+which is the core test suite for Sucrase.

--- a/spec-compliance-tests/babel-tests/check-babel-tests.ts
+++ b/spec-compliance-tests/babel-tests/check-babel-tests.ts
@@ -1,0 +1,264 @@
+/* eslint-disable no-console */
+// @ts-ignore: Babel package missing types.
+import * as babel from "@babel/core";
+import {exists, readdir, readFile, stat} from "mz/fs";
+import {join, relative, resolve} from "path";
+
+import run from "../../script/run";
+import {readFileContents, readJSONFileContents} from "../../script/util/readFileContents";
+import {transform, Transform} from "../../src";
+
+const BABEL_TESTS_DIR = "./spec-compliance-tests/babel-tests/babel-tests-checkout";
+const FIXTURES_DIR = `${BABEL_TESTS_DIR}/packages/babel-parser/test/fixtures`;
+const BABEL_REPO_URL = "https://github.com/babel/babel.git";
+const BABEL_REVISION = "bcf8b2273b8cba44c9b93c8977f05d508bfc1b91";
+
+const KNOWN_FAILURES = `
+es2015/let/let-declaration-in-escape-id
+es2015/yield/accessor-name-inst-computed-yield-expr
+es2015/yield/basic-without-argument
+es2015/yield/without-argument
+es2018/async-generators/for-await-async-of
+es2020/bigint/decimal-as-property-name
+es2020/export-ns-from/ns-and-named
+es2022/module-string-names/mixed
+estree/class-private-property/flow
+estree/module-string-names/mixed
+experimental/decorators/export-decorated-class
+experimental/decorators/export-default-decorated-class
+flow/anonymous-function-no-parens-types/good_15
+flow/arrows-in-ternaries/issue-13644
+flow/arrows-in-ternaries/issue-58
+flow/arrows-in-ternaries/param-type-and-return-type-like
+flow/class-private-property/declare-field
+flow/class-properties/declare-after-decorators
+flow/class-properties/declare-field
+flow/class-properties/declare-field-computed
+flow/class-properties/declare-field-named-static
+flow/class-properties/declare-field-with-type
+flow/class-properties/declare-static-field
+flow/classes/good_01
+flow/declare-export/export-class
+flow/declare-export/export-default-union
+flow/declare-export/export-from
+flow/declare-export/export-function
+flow/declare-export/export-interface
+flow/declare-export/export-interface-and-var
+flow/declare-export/export-interface-commonjs
+flow/declare-export/export-named-pattern
+flow/declare-export/export-star
+flow/declare-export/export-type
+flow/declare-export/export-type-and-var
+flow/declare-export/export-type-commonjs
+flow/declare-export/export-type-star-from
+flow/declare-export/export-var
+flow/declare-module/3
+flow/declare-module/4
+flow/declare-module/5
+flow/declare-module/6
+flow/declare-module/9
+flow/module-string-names/mixed
+flow/multiple-declarations/declare-class
+flow/object-types/getter-key-is-keyword
+flow/opaque-type-alias/opaque_subtype_allow_export
+flow/opaque-type-alias/opaque_type_allow_export
+flow/regression/issue-166
+flow/scope/declare-module
+flow/this-annotation/function-type
+flow/typecasts/yield
+jsx/basic/3
+typescript/cast/as
+typescript/export/as-namespace
+typescript/import/export-import
+typescript/import/export-import-require
+typescript/import/export-import-type-as-identifier
+typescript/import/export-import-type-require
+typescript/import/import-default-id-type
+typescript/import/type-asi
+typescript/import/type-equals-require
+typescript/type-arguments/instantiation-expression-binary-operator
+`
+  .split("\n")
+  .filter((s) => s);
+
+interface ResultSummary {
+  numPassed: number;
+  numFailed: number;
+  numSkipped: number;
+  failures: Array<string>;
+}
+
+/**
+ * Script that clones the Babel repo, walks its parser tests, and tries them in
+ * Sucrase. If they fail in Sucrase but pass with Babel in a Sucrase-like
+ * configuration, this likely indicates a syntax edge case that Sucrase isn't
+ * handling correctly. With any fixes, new tests should be added to the core
+ * Sucrase test suite, but this suite helps provide confidence that Sucrase is
+ * handling the important language edge cases.
+ */
+async function main(): Promise<void> {
+  if (!(await exists(BABEL_TESTS_DIR))) {
+    console.log(`Directory ${BABEL_TESTS_DIR} not found, cloning a new one.`);
+    await run(`git clone ${BABEL_REPO_URL} ${BABEL_TESTS_DIR}`);
+  }
+
+  // Force a specific revision so we don't get a breakage from changes to the main branch.
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(BABEL_TESTS_DIR);
+    await run(`git reset --hard ${BABEL_REVISION}`);
+    await run(`git clean -f`);
+  } catch (e) {
+    await run("git fetch");
+    await run(`git reset --hard ${BABEL_REVISION}`);
+    await run(`git clean -f`);
+  } finally {
+    process.chdir(originalCwd);
+  }
+
+  console.log("Checking babel tests...");
+  const resultSummary: ResultSummary = {
+    numPassed: 0,
+    numFailed: 0,
+    numSkipped: 0,
+    failures: [],
+  };
+
+  await checkTests(FIXTURES_DIR, resultSummary);
+  reportSummary(resultSummary);
+}
+
+function reportSummary({numPassed, numFailed, numSkipped, failures}: ResultSummary): void {
+  const unexpectedFailures = failures.filter((dir) => !KNOWN_FAILURES.includes(dir));
+  const unexpectedPassed = KNOWN_FAILURES.filter((dir) => !failures.includes(dir));
+
+  console.log();
+  console.log("Failures, including expected failures:");
+  console.log(failures.join("\n"));
+  console.log();
+  console.log(
+    `Summary: ${numFailed} failed (${KNOWN_FAILURES.length} expected), ${numPassed} passed, ${numSkipped} skipped`,
+  );
+  console.log();
+
+  if (unexpectedPassed.length > 0) {
+    console.log("The following tests passed even though they are marked as failing:");
+    console.log(unexpectedPassed.join("\n"));
+    console.log();
+    process.exitCode = 1;
+  }
+
+  if (unexpectedFailures.length > 0) {
+    console.log("The following tests failed unexpectedly:");
+    console.log(unexpectedFailures.join("\n"));
+    console.log();
+    process.exitCode = 1;
+  }
+}
+
+async function checkTests(dir: string, resultSummary: ResultSummary): Promise<void> {
+  for (const child of await readdir(dir)) {
+    const childPath = join(dir, child);
+    if ((await stat(childPath)).isDirectory()) {
+      await checkTests(childPath, resultSummary);
+    }
+  }
+  await checkTestForDir(dir, resultSummary);
+}
+
+async function checkTestForDir(dir: string, resultSummary: ResultSummary): Promise<void> {
+  const displayDir = relative(FIXTURES_DIR, dir);
+  const outputJSONPath = join(dir, "output.json");
+  if (!(await exists(outputJSONPath))) {
+    return;
+  }
+
+  const outputJSON = JSON.parse((await readFile(outputJSONPath)).toString());
+  if (outputJSON.throws || outputJSON.errors) {
+    console.log(`SKIPPED: ${displayDir} (expects error)`);
+    resultSummary.numSkipped++;
+  } else {
+    const code = await getTestCode(dir);
+    const babelPlugins = await getBabelPlugins(dir);
+
+    const sucraseTransforms = [];
+    if (babelPlugins.includes("typescript")) {
+      sucraseTransforms.push("typescript");
+    }
+
+    try {
+      runSucrase(code, babelPlugins);
+      console.log(`PASSED: ${displayDir}`);
+      resultSummary.numPassed++;
+    } catch (e) {
+      // If Babel fails on this case as well, don't consider it an error.
+      try {
+        runBabel(code, babelPlugins);
+        console.log(`FAILED: ${displayDir}`);
+        console.log(e);
+        resultSummary.numFailed++;
+        resultSummary.failures.push(displayDir);
+      } catch (e2) {
+        console.log(`SKIPPED: ${displayDir} (Babel had parsing error)`);
+        console.log(e2);
+        resultSummary.numSkipped++;
+      }
+    }
+  }
+}
+
+async function getTestCode(dir: string): Promise<string> {
+  for (const extension of [".js", ".ts", ".tsx", ".mjs", ".cjs"]) {
+    const filePath = join(dir, `input${extension}`);
+    if (await exists(filePath)) {
+      return readFileContents(filePath);
+    }
+  }
+  throw new Error(`Unable to find code file in ${dir}`);
+}
+
+/**
+ * Get the configured babel plugins for the given test, which requires
+ * traversing parent directories for options.json files.
+ */
+async function getBabelPlugins(testDir: string): Promise<Array<string>> {
+  const plugins: Array<string> = [];
+  let dir = testDir;
+  while (resolve(dir) !== resolve(FIXTURES_DIR)) {
+    const optionsJSONPath = join(dir, "options.json");
+    if (await exists(optionsJSONPath)) {
+      const options = await readJSONFileContents(optionsJSONPath);
+      if (options.plugins) {
+        plugins.push(
+          ...options.plugins.map((option: string | [string, ...Array<unknown>]) =>
+            typeof option === "string" ? option : option[0],
+          ),
+        );
+      }
+    }
+    dir = resolve(dir, "..");
+  }
+  return plugins;
+}
+
+function runSucrase(code: string, babelPlugins: Array<string>): void {
+  const transforms: Array<Transform> = (["jsx", "flow", "typescript"] as const).filter((t) =>
+    babelPlugins.includes(t),
+  );
+  transform(code, {transforms});
+  transform(code, {transforms: [...transforms, "imports"]});
+}
+
+function runBabel(code: string, babelPlugins: Array<string>): void {
+  const plugins: Array<unknown> = ["jsx", "flow", "typescript"].filter((t) =>
+    babelPlugins.includes(t),
+  );
+  plugins.push(["decorators", {version: "2021-12", decoratorsBeforeExport: false}]);
+  babel.parse(code, {sourceType: "module", parserOpts: {plugins}});
+}
+
+main().catch((e) => {
+  console.error("Unhandled error:");
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/spec-compliance-tests/test262/run-test262.ts
+++ b/spec-compliance-tests/test262/run-test262.ts
@@ -4,10 +4,10 @@ import chalk from "chalk";
 import {exec} from "mz/child_process";
 import {exists} from "mz/fs";
 
-import run from "../script/run";
+import run from "../../script/run";
 
 const TEST262_HARNESS = "./node_modules/.bin/test262-harness";
-const TEST262_DIR = "./test262/test262-checkout";
+const TEST262_DIR = "./spec-compliance-tests/test262/test262-checkout";
 const TEST262_REPO_URL = "https://github.com/tc39/test262.git";
 const TEST262_REVISION = "157b18d16b5d52501c4d75ac422d3a80bfad1c17";
 
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
   console.log("Running test262...");
   const harnessStdout = (
     await exec(`${TEST262_HARNESS} \
-    --preprocessor "./test262/test262Preprocessor.js" \
+    --preprocessor "./spec-compliance-tests/test262/test262Preprocessor.js" \
     --reporter "json" \
     "${TEST262_DIR}/test/language/expressions/coalesce/**/*.js" \
     "${TEST262_DIR}/test/language/expressions/optional-chaining/**/*.js"`)

--- a/spec-compliance-tests/test262/test262Preprocessor.js
+++ b/spec-compliance-tests/test262/test262Preprocessor.js
@@ -1,10 +1,10 @@
-const sucrase = require("..");
+const sucrase = require("../..");
 
 /**
  * test262-harness preprocessor documented here:
  https://github.com/bterlson/test262-harness#preprocessor
  */
-module.exports = function(test) {
+module.exports = function (test) {
   // Sucrase doesn't attempt to throw SyntaxError on bad syntax, so skip those tests.
   if (test.attrs.negative) {
     return null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,11 +20,12 @@
     "script",
     "src",
     "test",
-    "test262"
+    "spec-compliance-tests"
   ],
   "exclude": [
     "benchmark/sample",
     "example-runner/example-repos",
-    "test262/test262-checkout"
+    "spec-compliance-tests/test262/test262-checkout",
+    "spec-compliance-tests/babel-tests/babel-tests-checkout"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,43 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
+"@babel/code-frame@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
   integrity sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
+
+"@babel/compat-data@^7.18.6":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
+  integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
+
+"@babel/core@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.6.tgz#54a107a3c298aee3fe5e1947a6464b9b6faca03d"
+  integrity sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.6"
+    "@babel/helper-compilation-targets" "^7.18.6"
+    "@babel/helper-module-transforms" "^7.18.6"
+    "@babel/helpers" "^7.18.6"
+    "@babel/parser" "^7.18.6"
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.6"
+    "@babel/types" "^7.18.6"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
 
 "@babel/core@^7.7.5":
   version "7.18.2"
@@ -52,6 +85,15 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.18.6", "@babel/generator@^7.18.7":
+  version "7.18.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.7.tgz#2aa78da3c05aadfc82dbac16c99552fc802284bd"
+  integrity sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==
+  dependencies:
+    "@babel/types" "^7.18.7"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/helper-compilation-targets@^7.18.2":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz#67a85a10cbd5fc7f1457fec2e7f45441dc6c754b"
@@ -62,10 +104,25 @@
     browserslist "^4.20.2"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.6.tgz#18d35bfb9f83b1293c22c55b3d576c1315b6ed96"
+  integrity sha512-vFjbfhNCzqdeAtZflUFrG5YIFqGTqsctrtkZ1D/NB0mDW9TwW3GmmUepYY4G9wCET5rY5ugz4OGTcLd614IzQg==
+  dependencies:
+    "@babel/compat-data" "^7.18.6"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.20.2"
+    semver "^6.3.0"
+
 "@babel/helper-environment-visitor@^7.16.7", "@babel/helper-environment-visitor@^7.18.2":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz#8a6d2dedb53f6bf248e31b4baf38739ee4a637bd"
   integrity sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==
+
+"@babel/helper-environment-visitor@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz#b7eee2b5b9d70602e59d1a6cad7dd24de7ca6cd7"
+  integrity sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
 
 "@babel/helper-function-name@^7.17.9":
   version "7.17.9"
@@ -75,6 +132,14 @@
     "@babel/template" "^7.16.7"
     "@babel/types" "^7.17.0"
 
+"@babel/helper-function-name@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz#8334fecb0afba66e6d87a7e8c6bb7fed79926b83"
+  integrity sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-hoist-variables@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
@@ -82,12 +147,26 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-hoist-variables@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
+  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-module-imports@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
   dependencies:
     "@babel/types" "^7.16.7"
+
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-module-transforms@^7.18.0":
   version "7.18.0"
@@ -103,12 +182,33 @@
     "@babel/traverse" "^7.18.0"
     "@babel/types" "^7.18.0"
 
+"@babel/helper-module-transforms@^7.18.6":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.18.8.tgz#4f8408afead0188cfa48672f9d0e5787b61778c8"
+  integrity sha512-che3jvZwIcZxrwh63VfnFTUzcAM9v/lznYkkRxIBGMPt1SudOKHAEec0SIRCfiuIzTcF7VGj/CaTT6gY4eWxvA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.6"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.8"
+    "@babel/types" "^7.18.8"
+
 "@babel/helper-simple-access@^7.17.7":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz#4dc473c2169ac3a1c9f4a51cfcd091d1c36fcff9"
   integrity sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==
   dependencies:
     "@babel/types" "^7.18.2"
+
+"@babel/helper-simple-access@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz#d6d8f51f4ac2978068df934b569f08f29788c7ea"
+  integrity sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-split-export-declaration@^7.16.7":
   version "7.16.7"
@@ -117,15 +217,32 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-split-export-declaration@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
+  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
   integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
+
+"@babel/helper-validator-option@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
+  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helpers@^7.18.2":
   version "7.18.2"
@@ -136,6 +253,15 @@
     "@babel/traverse" "^7.18.2"
     "@babel/types" "^7.18.2"
 
+"@babel/helpers@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.18.6.tgz#4c966140eaa1fcaa3d5a8c09d7db61077d4debfd"
+  integrity sha512-vzSiiqbQOghPngUYt/zWGvK3LAsPhz55vc9XNN0xAl2gV4ieShI2OQli5duxWHD+72PZPTKAcfcZDE1Cwc5zsQ==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.6"
+    "@babel/types" "^7.18.6"
+
 "@babel/highlight@^7.16.7":
   version "7.17.12"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.12.tgz#257de56ee5afbd20451ac0a75686b6b404257351"
@@ -145,10 +271,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.16.7", "@babel/parser@^7.18.0":
   version "7.18.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.4.tgz#6774231779dd700e0af29f6ad8d479582d7ce5ef"
   integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
+
+"@babel/parser@^7.18.6", "@babel/parser@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
+  integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
 
 "@babel/template@^7.16.7":
   version "7.16.7"
@@ -158,6 +298,15 @@
     "@babel/code-frame" "^7.16.7"
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
+
+"@babel/template@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
+  integrity sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.6"
+    "@babel/types" "^7.18.6"
 
 "@babel/traverse@^7.18.0", "@babel/traverse@^7.18.2":
   version "7.18.2"
@@ -175,12 +324,36 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.18.6", "@babel/traverse@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.8.tgz#f095e62ab46abf1da35e5a2011f43aee72d8d5b0"
+  integrity sha512-UNg/AcSySJYR/+mIcJQDCv00T+AqRO7j/ZEJLzpaYtgM48rMg5MnkJgyNqkzo88+p4tfRvZJCEiwwfG6h4jkRg==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.7"
+    "@babel/helper-environment-visitor" "^7.18.6"
+    "@babel/helper-function-name" "^7.18.6"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.18.8"
+    "@babel/types" "^7.18.8"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.18.0", "@babel/types@^7.18.2":
   version "7.18.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.4.tgz#27eae9b9fd18e9dccc3f9d6ad051336f307be354"
   integrity sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.6", "@babel/types@^7.18.7", "@babel/types@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.8.tgz#c5af199951bf41ba4a6a9a6d0d8ad722b30cd42f"
+  integrity sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
 "@eslint/eslintrc@^1.3.0":
@@ -245,6 +418,15 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz#30cd49820a962aff48c8fffc5cd760151fca61fe"
@@ -254,6 +436,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.1.tgz#36a6acc93987adcf0ba50c66908bd0b70de8afea"
   integrity sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.13"


### PR DESCRIPTION
As I was porting Babel changes and reworking bits of the parser, I was worried
that I might introduce regressions in various language corner cases, so it
seemed like a good idea to extend the test suite to more proactively find known
tricky syntax cases. The Babel test suite itself has many fixtures showing off
various syntax cases, so this PR adds a script that clones the Babel repo and
tries Sucrase on every babel-parser test case where the parse is expected to
pass. If Sucrase fails, we try Babel with a Sucrase-like configuration, since
Babel tests somtimes assume sloppy mode or experimental features that Sucrase
doesn't support. For now, the test runner is just its own file rather than using
a real test framework, and we run it in CI to avoid regressions on future code
changes.

This also refactors the directory structure to create a "spec compliance tests"
directory that includes this new one and test262. In the future, it might have
a similar runner for the TypeScript test suite and possibly other test suites.