### PR TITLE
Fix parse failures when using ?? just after the end of a type

### DIFF
--- a/spec-compliance-tests/babel-tests/check-babel-tests.ts
+++ b/spec-compliance-tests/babel-tests/check-babel-tests.ts
@@ -67,7 +67,6 @@ flow/scope/declare-module
 flow/this-annotation/function-type
 flow/typecasts/yield
 jsx/basic/3
-typescript/cast/as
 typescript/export/as-namespace
 typescript/import/export-import
 typescript/import/export-import-require
@@ -76,7 +75,6 @@ typescript/import/export-import-type-require
 typescript/import/import-default-id-type
 typescript/import/type-asi
 typescript/import/type-equals-require
-typescript/type-arguments/instantiation-expression-binary-operator
 `
   .split("\n")
   .filter((s) => s);

--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -9,6 +9,7 @@ import {
   nextTemplateToken,
   popTypeContext,
   pushTypeContext,
+  rescanAfterTypeEnd,
 } from "../tokenizer/index";
 import {ContextualKeyword} from "../tokenizer/keywords";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
@@ -1252,6 +1253,11 @@ export function tsParseSubscript(
       // Bail out. We have something like a<b>c, which is not an expression with
       // type arguments but an (a < b) > c comparison.
       unexpected();
+    } else {
+      // This is an instantiation expression, e.g. Array<number>, so we are
+      // leaving a type context, and operators like ?? need to be re-scanned to
+      // pick up the second question mark.
+      rescanAfterTypeEnd();
     }
 
     if (state.error) {

--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -9,7 +9,6 @@ import {
   nextTemplateToken,
   popTypeContext,
   pushTypeContext,
-  rescanAfterTypeEnd,
 } from "../tokenizer/index";
 import {ContextualKeyword} from "../tokenizer/keywords";
 import {TokenType, TokenType as tt} from "../tokenizer/types";
@@ -1243,6 +1242,9 @@ export function tsParseSubscript(
       // Tagged template with a type argument.
       parseTemplate();
     } else if (
+      // The remaining possible case is an instantiation expression, e.g.
+      // Array<number> . Check for a few cases that would disqualify it and
+      // cause us to bail out.
       // a<b>>c is not (a<b>)>c, but a<(b>>c)
       state.type === tt.greaterThan ||
       // a<b>c is (a<b)>c
@@ -1253,11 +1255,6 @@ export function tsParseSubscript(
       // Bail out. We have something like a<b>c, which is not an expression with
       // type arguments but an (a < b) > c comparison.
       unexpected();
-    } else {
-      // This is an instantiation expression, e.g. Array<number>, so we are
-      // leaving a type context, and operators like ?? need to be re-scanned to
-      // pick up the second question mark.
-      rescanAfterTypeEnd();
     }
 
     if (state.error) {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -535,13 +535,20 @@ function readToken_gt(): void {
 }
 
 /**
- * Called after `as` expressions in TS; we're switching from a type to a
- * non-type context, so a > token may actually be >=
+ * Called when switching from a type to non-type context, e.g. after an `as`
+ * expression or after an instantiation expression like `Array<number>`. Since
+ * we always tokenize one token ahead of the current state and tokenization is
+ * sometimes different in type and non-type contexts, we need to re-tokenize
+ * some specific cases to make sure we're picking up the right operator,
+ * particularly recognizing > as >= and recognizing ? as ??.
  */
-export function rescan_gt(): void {
+export function rescanAfterTypeEnd(): void {
   if (state.type === tt.greaterThan) {
     state.pos -= 1;
     readToken_gt();
+  } else if (state.type === tt.question) {
+    state.pos -= 1;
+    readToken_question();
   }
 }
 

--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -51,7 +51,7 @@ import {
   nextTemplateToken,
   popTypeContext,
   pushTypeContext,
-  rescanAfterTypeEnd,
+  rescan_gt,
   retokenizeSlashAsRegex,
 } from "../tokenizer/index";
 import {ContextualKeyword} from "../tokenizer/keywords";
@@ -206,7 +206,7 @@ function parseExprOp(startTokenIndex: number, minPrec: number, noIn: boolean): v
     const oldIsType = pushTypeContext(1);
     tsParseType();
     popTypeContext(oldIsType);
-    rescanAfterTypeEnd();
+    rescan_gt();
     parseExprOp(startTokenIndex, minPrec, noIn);
     return;
   }

--- a/src/parser/traverser/expression.ts
+++ b/src/parser/traverser/expression.ts
@@ -51,7 +51,7 @@ import {
   nextTemplateToken,
   popTypeContext,
   pushTypeContext,
-  rescan_gt,
+  rescanAfterTypeEnd,
   retokenizeSlashAsRegex,
 } from "../tokenizer/index";
 import {ContextualKeyword} from "../tokenizer/keywords";
@@ -206,7 +206,7 @@ function parseExprOp(startTokenIndex: number, minPrec: number, noIn: boolean): v
     const oldIsType = pushTypeContext(1);
     tsParseType();
     popTypeContext(oldIsType);
-    rescan_gt();
+    rescanAfterTypeEnd();
     parseExprOp(startTokenIndex, minPrec, noIn);
     return;
   }

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -688,4 +688,15 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("handles two ? operators in a row", () => {
+    assertFlowResult(
+      `
+      type T = ??number;
+    `,
+      `"use strict";
+      
+    `,
+    );
+  });
 });


### PR DESCRIPTION
This was detected when running Sucrase on the Babel test suite.