### PR TITLE
Fix invalid output code when eliding TS star imports

### DIFF
--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1549,6 +1549,29 @@ describe("typescript transform", () => {
     );
   });
 
+  it("produces proper import statements when eliding ESM imported names", () => {
+    assertTypeScriptESMResult(
+      `
+      import keep1, * as elide1 from "./m1";
+      import keep2, * as keep3 from "./m2";
+      import elide2, * as keep4 from "./m3";
+      import keep5, {elide3} from "./m4";
+      import keep6, {keep7} from "./m5";
+      import elide4, {keep8} from "./m6";
+      console.log(keep1, keep2, keep3, keep4, keep5, keep6, keep7, keep8);
+    `,
+      `
+      import keep1 from "./m1";
+      import keep2, * as keep3 from "./m2";
+      import * as keep4 from "./m3";
+      import keep5, {} from "./m4";
+      import keep6, {keep7} from "./m5";
+      import {keep8} from "./m6";
+      console.log(keep1, keep2, keep3, keep4, keep5, keep6, keep7, keep8);
+    `,
+    );
+  });
+
   it("handles import() types", () => {
     assertTypeScriptESMResult(
       `


### PR DESCRIPTION
From some manual testing, I noticed that the code:
```ts
import A, * as B from "./A";
console.log(A);
```
becomes this invalid code:
```ts
import A, from "./A";
console.log(A);
```
The `* as B` was being elided because it's treated as a type-only import, but in
this case we need to elide the comma as well since there's no concept of
"trailing commas" here. The code to do that is a little clunky, but I ended up
always removing the comma and using a boolean to track whether it should be
added back.