### PR TITLE
Add flag to emit createRequire matching TS nodenext behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ transforms are available:
   the same way as [babel-plugin-jest-hoist](https://github.com/facebook/jest/tree/master/packages/babel-plugin-jest-hoist).
   Does not validate the arguments passed to `jest.mock`, but the same rules still apply.
 
+When the `imports` transform is *not* specified (i.e. when targeting ESM), the
+`injectCreateRequireForImportRequire` option can be specified to transform TS
+`import foo = require("foo");` in a way that matches the
+[TypeScript 4.7 behavior](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#commonjs-interoperability)
+with `module: nodenext`.
+
 These newer JS features are transformed by default:
 
 * [Optional chaining](https://github.com/tc39/proposal-optional-chaining): `a?.b`

--- a/src/HelperManager.ts
+++ b/src/HelperManager.ts
@@ -1,6 +1,10 @@
 import type NameManager from "./NameManager";
 
 const HELPERS: {[name: string]: string} = {
+  require: `
+    import {createRequire as CREATE_REQUIRE_NAME} from "module";
+    const require = CREATE_REQUIRE_NAME(import.meta.url);
+  `,
   interopRequireWildcard: `
     function interopRequireWildcard(obj) {
       if (obj && obj.__esModule) {
@@ -125,6 +129,7 @@ const HELPERS: {[name: string]: string} = {
 
 export class HelperManager {
   helperNames: {[baseName in keyof typeof HELPERS]?: string} = {};
+  createRequireName: string | null = null;
   constructor(readonly nameManager: NameManager) {}
 
   getHelperName(baseName: keyof typeof HELPERS): string {
@@ -155,6 +160,11 @@ export class HelperManager {
           "ASYNC_OPTIONAL_CHAIN_NAME",
           this.helperNames.asyncOptionalChain!,
         );
+      } else if (baseName === "require") {
+        if (this.createRequireName === null) {
+          this.createRequireName = this.nameManager.claimFreeName("_createRequire");
+        }
+        helperCode = helperCode.replace(/CREATE_REQUIRE_NAME/g, this.createRequireName);
       }
       if (helperName) {
         resultCode += " ";

--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -28,6 +28,7 @@ export const Options = t.iface([], {
   production: t.opt("boolean"),
   disableESTransforms: t.opt("boolean"),
   preserveDynamicImport: t.opt("boolean"),
+  injectCreateRequireForImportRequire: t.opt("boolean"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -56,6 +56,17 @@ export interface Options {
    * expressions into require() calls.
    */
   preserveDynamicImport?: boolean;
+  /**
+   * Only relevant when targeting ESM (i.e. when the imports transform is *not*
+   * specified). This flag changes the behavior of TS require imports:
+   *
+   * import Foo = require("foo");
+   *
+   * to import createRequire, create a require function, and use that function.
+   * This is the TS behavior with module: nodenext and makes it easier for the
+   * same code to target ESM and CJS.
+   */
+  injectCreateRequireForImportRequire?: boolean;
 }
 
 export function validateOptions(options: Options): void {

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -92,6 +92,7 @@ export default class RootTransformer {
         new ESMImportTransformer(
           tokenProcessor,
           this.nameManager,
+          this.helperManager,
           reactHotLoaderTransformer,
           transforms.includes("typescript"),
           options,

--- a/test/prefixes.ts
+++ b/test/prefixes.ts
@@ -1,4 +1,6 @@
 export const JSX_PREFIX = 'const _jsxFileName = "";';
+export const CREATE_REQUIRE_PREFIX = ` import {createRequire as _createRequire} from "module"; \
+const _require = _createRequire(import.meta.url);`;
 export const IMPORT_DEFAULT_PREFIX = ` function _interopRequireDefault(obj) { \
 return obj && obj.__esModule ? obj : { default: obj }; }`;
 export const IMPORT_WILDCARD_PREFIX = ` function _interopRequireWildcard(obj) { \

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1,5 +1,6 @@
 import type {Options} from "../src/Options";
 import {
+  CREATE_REQUIRE_PREFIX,
   CREATE_STAR_EXPORT_PREFIX,
   ESMODULE_PREFIX,
   IMPORT_DEFAULT_PREFIX,
@@ -890,6 +891,47 @@ describe("typescript transform", () => {
       console.log(a);
       module.exports = 3;
     `,
+    );
+  });
+
+  it("ignores injectCreateRequireForImportRequire when targeting CJS", () => {
+    assertTypeScriptResult(
+      `
+      import a = require('a');
+      console.log(a);
+    `,
+      `"use strict";
+      const a = require('a');
+      console.log(a);
+    `,
+      {injectCreateRequireForImportRequire: true},
+    );
+  });
+
+  it("preserves import = require by default when targeting ESM", () => {
+    assertTypeScriptESMResult(
+      `
+      import a = require('a');
+      console.log(a);
+    `,
+      `
+      const a = require('a');
+      console.log(a);
+    `,
+    );
+  });
+
+  it("transforms import = require when targeting ESM and injectCreateRequireForImportRequire is enabled", () => {
+    assertTypeScriptESMResult(
+      `
+      import a = require('a');
+      console.log(a);
+    `,
+      `${CREATE_REQUIRE_PREFIX}
+      const a = _require('a');
+      console.log(a);
+    `,
+      {injectCreateRequireForImportRequire: true},
     );
   });
 


### PR DESCRIPTION
Progress toward #726

This is currently an opt-in flag handling a nuance in how TS transpiles imports
like these:
```ts
import foo = require('foo');
```
In the new nodenext mode when targeting ESM, TS now transforms this code to use
`createRequire`. The change is described here:
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#commonjs-interoperability

This PR adds a flag `injectCreateRequireForImportRequire` to enable this
different behavior. I'm gating this behind a flag out of caution, though it's
worth noting that TS gives an error when using this syntax and targeting
module esnext, so it will likely be safe to switch to this new emit strategy as
the default behavior in the future.

As I understand it, the main benefit of this change over explicit `createRequire`
is that it allows a single codebase to be transpiled to Node ESM and Node CJS
while using this syntax. A downside is that `createRequire` is Node-specific and
needs special support from bundlers, but it looks like webpack can recognize the
pattern. In most situations, real ESM `import` syntax is probably preferable,
but this syntax makes it possible to force the use of CJS.

The ts-node transpiler plugin system expects transpilers to have this mode as an
option, so this is a step closer to having a compliant ts-node plugin.