### PR TITLE
Fix default value for jsxFragmentPragma in website

### DIFF
--- a/website/src/Constants.ts
+++ b/website/src/Constants.ts
@@ -54,7 +54,7 @@ export type HydratedOptions = Omit<Required<Options>, "filePath" | "sourceMapOpt
 export const DEFAULT_OPTIONS: HydratedOptions = {
   transforms: ["jsx", "typescript", "imports"],
   jsxPragma: "React.createElement",
-  jsxFragmentPragma: "Fragment",
+  jsxFragmentPragma: "React.Fragment",
   enableLegacyTypeScriptModuleInterop: false,
   enableLegacyBabel5ModuleInterop: false,
   production: false,

--- a/website/src/SucraseOptionsBox.tsx
+++ b/website/src/SucraseOptionsBox.tsx
@@ -143,13 +143,13 @@ export default function SucraseOptionsBox({
                 optionName="jsxPragma"
                 options={options}
                 onUpdateOptions={onUpdateOptions}
-                inputWidth={162}
+                inputWidth={182}
               />
               <StringOption
                 optionName="jsxFragmentPragma"
                 options={options}
                 onUpdateOptions={onUpdateOptions}
-                inputWidth={100}
+                inputWidth={120}
               />
             </div>
             <div className={css(styles.secondaryOptionColumn)}>


### PR DESCRIPTION
The default should be `React.Fragment`, not just `Fragment`.