### PR TITLE
Refactor jsx-test to better support testing the automatic runtime

### DIFF
--- a/test/util.ts
+++ b/test/util.ts
@@ -12,10 +12,11 @@ export function assertExpectations(
   code: string,
   expectations: Expectations,
   options: Options,
+  message?: string,
 ): void {
   const resultCode = transform(code, options).code;
   if ("expectedResult" in expectations) {
-    assert.strictEqual(resultCode, expectations.expectedResult);
+    assert.strictEqual(resultCode, expectations.expectedResult, message);
   }
   if ("expectedOutput" in expectations) {
     const outputs: Array<unknown> = [];
@@ -25,8 +26,7 @@ export function assertExpectations(
       setOutput: (value: unknown) => outputs.push(JSON.parse(JSON.stringify(value))),
     });
     assert.strictEqual(outputs.length, 1, "setOutput should be called exactly once");
-    assert.deepStrictEqual([1, 2], [1, 2]);
-    assert.deepStrictEqual(outputs[0], expectations.expectedOutput);
+    assert.deepStrictEqual(outputs[0], expectations.expectedOutput, message);
   }
 }
 
@@ -34,8 +34,9 @@ export function assertResult(
   code: string,
   expectedResult: string,
   options: Options = {transforms: ["jsx", "imports"]},
+  message: string | undefined = undefined,
 ): void {
-  assertExpectations(code, {expectedResult}, options);
+  assertExpectations(code, {expectedResult}, options, message);
 }
 
 export function assertOutput(


### PR DESCRIPTION
Since the automatic runtime effectively doubles the number of cases needing test
coverage, plus has a number of cases within itself, this PR refactors the JSX
tests to make it easy to declare the result for multiple configurations in the
same test. This should make it smoother to write the automatic case for each
test where it feels relevant, plus makes it easier to test ESM vs CJS and dev vs
prod for the same syntax case.