### PR TITLE
Add support for automatic JSX runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ by your JS runtime. For example:
 By default, JSX is compiled to React functions in development mode. This can be
 configured with a few options:
 
-* **jsxRuntime**: a string specifying the transform mode, which can be one of two values:
+* **jsxRuntime**: A string specifying the transform mode, which can be one of two values:
   * `"classic"` (default): The original JSX transform that calls `React.createElement` by default.
     To configure for non-React use cases, specify:
     * **jsxPragma**: Element creation function, defaults to `React.createElement`.

--- a/README.md
+++ b/README.md
@@ -115,11 +115,20 @@ by your JS runtime. For example:
 
 ### JSX Options
 
-Like Babel, Sucrase compiles JSX to React functions by default, but can be
-configured for any JSX use case.
+By default, JSX is compiled to React functions in development mode. This can be
+configured with a few options:
 
-* **jsxPragma**: Element creation function, defaults to `React.createElement`.
-* **jsxFragmentPragma**: Fragment component, defaults to `React.Fragment`.
+* **jsxRuntime**: a string specifying the transform mode, which can be one of two values:
+  * `"classic"` (default): The original JSX transform that calls `React.createElement` by default.
+    To configure for non-React use cases, specify:
+    * **jsxPragma**: Element creation function, defaults to `React.createElement`.
+    * **jsxFragmentPragma**: Fragment component, defaults to `React.Fragment`.
+  * `"automatic"`: The [new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
+      introduced with React 17, which calls `jsx` functions and auto-adds import statements.
+    To configure for non-React use cases, specify:
+    * **jsxImportSource**: Package name for auto-generated import statements, defaults to `react`.
+* **production**: If `true`, don't include extra debugging information. When using
+  React in production mode with the automatic transform, this *must* be set to true.
 
 ### Legacy CommonJS interop
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ configured with a few options:
       introduced with React 17, which calls `jsx` functions and auto-adds import statements.
     To configure for non-React use cases, specify:
     * **jsxImportSource**: Package name for auto-generated import statements, defaults to `react`.
-* **production**: If `true`, don't include extra debugging information. When using
-  React in production mode with the automatic transform, this *must* be set to true.
+* **production**: If `true`, use production version of functions and don't include debugging
+  information. When using React in production mode with the automatic transform, this *must* be
+  set to true to avoid an error about `jsxDEV` being missing.
 
 ### Legacy CommonJS interop
 

--- a/src/CJSImportProcessor.ts
+++ b/src/CJSImportProcessor.ts
@@ -169,7 +169,7 @@ export default class CJSImportProcessor {
     }
   }
 
-  private getFreeIdentifierForPath(path: string): string {
+  getFreeIdentifierForPath(path: string): string {
     const components = path.split("/");
     const lastComponent = components[components.length - 1];
     const baseName = lastComponent.replace(/\W/g, "");

--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -19,16 +19,18 @@ export const SourceMapOptions = t.iface([], {
 
 export const Options = t.iface([], {
   transforms: t.array("Transform"),
+  disableESTransforms: t.opt("boolean"),
+  jsxRuntime: t.opt(t.union(t.lit("classic"), t.lit("automatic"))),
+  production: t.opt("boolean"),
+  jsxImportSource: t.opt("string"),
   jsxPragma: t.opt("string"),
   jsxFragmentPragma: t.opt("string"),
   enableLegacyTypeScriptModuleInterop: t.opt("boolean"),
   enableLegacyBabel5ModuleInterop: t.opt("boolean"),
-  sourceMapOptions: t.opt("SourceMapOptions"),
-  filePath: t.opt("string"),
-  production: t.opt("boolean"),
-  disableESTransforms: t.opt("boolean"),
   preserveDynamicImport: t.opt("boolean"),
   injectCreateRequireForImportRequire: t.opt("boolean"),
+  sourceMapOptions: t.opt("SourceMapOptions"),
+  filePath: t.opt("string"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -15,13 +15,44 @@ export interface SourceMapOptions {
 }
 
 export interface Options {
+  /**
+   * Unordered array of transform names, describing both the allowed syntax
+   * (where applicable) and the transformation behavior.
+   */
   transforms: Array<Transform>;
   /**
-   * If specified, function name to use in place of React.createClass when compiling JSX.
+   * Opts out ES syntax transformations, like optional chaining, nullish
+   * coalescing, numeric separators, etc.
+   */
+  disableESTransforms?: boolean;
+  /**
+   * Transformation mode for the JSX transform. The automatic transform refers
+   * to the transform behavior released with React 17, where the `jsx` function
+   * (or a variation) is automatically imported. The classic transform refers to
+   * the previous behavior using `React.createElement`.
+   *
+   * Default value: "classic"
+   */
+  jsxRuntime?: "classic" | "automatic";
+  /**
+   * Compile code for production use. Currently only applies to the JSX
+   * transform.
+   * If specified, omit any development-specific code in the output.
+   */
+  production?: boolean;
+  /**
+   * If specified, import path prefix to use in place of "react" when compiling
+   * JSX with the automatic runtime.
+   */
+  jsxImportSource?: string;
+  /**
+   * If specified, function name to use in place of React.createClass when
+   * compiling JSX with the classic runtime.
    */
   jsxPragma?: string;
   /**
-   * If specified, function name to use in place of React.Fragment when compiling JSX.
+   * If specified, function name to use in place of React.Fragment when
+   * compiling JSX with the classic runtime.
    */
   jsxFragmentPragma?: string;
   /**
@@ -33,27 +64,8 @@ export interface Options {
    */
   enableLegacyBabel5ModuleInterop?: boolean;
   /**
-   * If specified, we also return a RawSourceMap object alongside the code. Currently, source maps
-   * simply map each line to the original line without any mappings within lines, since Sucrase
-   * preserves line numbers. filePath must be specified if this option is enabled.
-   */
-  sourceMapOptions?: SourceMapOptions;
-  /**
-   * File path to use in error messages, React display names, and source maps.
-   */
-  filePath?: string;
-  /**
-   * If specified, omit any development-specific code in the output.
-   */
-  production?: boolean;
-  /**
-   * Opts out ES syntax transformations, like optional chaining, nullish coalescing, numeric
-   * separators, etc.
-   */
-  disableESTransforms?: boolean;
-  /**
-   * If specified, the imports transform does not attempt to change dynamic import()
-   * expressions into require() calls.
+   * If specified, the imports transform does not attempt to change dynamic
+   * import() expressions into require() calls.
    */
   preserveDynamicImport?: boolean;
   /**
@@ -67,6 +79,17 @@ export interface Options {
    * same code to target ESM and CJS.
    */
   injectCreateRequireForImportRequire?: boolean;
+  /**
+   * If specified, we also return a RawSourceMap object alongside the code.
+   * Currently, source maps simply map each line to the original line without
+   * any mappings within lines, since Sucrase preserves line numbers. filePath
+   * must be specified if this option is enabled.
+   */
+  sourceMapOptions?: SourceMapOptions;
+  /**
+   * File path to use in error messages, React display names, and source maps.
+   */
+  filePath?: string;
 }
 
 export function validateOptions(options: Options): void {

--- a/src/TokenProcessor.ts
+++ b/src/TokenProcessor.ts
@@ -33,8 +33,17 @@ export default class TokenProcessor {
     this.tokenIndex = snapshot.tokenIndex;
   }
 
-  getResultCodeIndex(): number {
-    return this.resultCode.length;
+  /**
+   * Remove and return the code generated since the snapshot, leaving the
+   * current token position in-place. Unlike most TokenProcessor operations,
+   * this operation can result in input/output line number mismatches because
+   * the removed code may contain newlines, so this operation should be used
+   * sparingly.
+   */
+  dangerouslyGetAndRemoveCodeSinceSnapshot(snapshot: TokenProcessorSnapshot): string {
+    const result = this.resultCode.slice(snapshot.resultCode.length);
+    this.resultCode = snapshot.resultCode;
+    return result;
   }
 
   reset(): void {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -32,11 +32,18 @@ export enum IdentifierRole {
  * jsx functions are called in the automatic transform.
  */
 export enum JSXRole {
-  Normal,
+  // The element is self-closing or has a body that resolves to empty. We
+  // shouldn't emit children at all in this case.
+  NoChildren,
+  // The element has a single explicit child, which might still be an arbitrary
+  // expression like an array. We should emit that expression as the children.
+  OneChild,
   // The element has at least two explicitly-specified children or has spread
-  // children.
+  // children, so child positions are assumed to be "static". We should wrap
+  // these children in an array.
   StaticChildren,
-  // The element has a prop named "key" after a prop spread.
+  // The element has a prop named "key" after a prop spread, so we should fall
+  // back to the createElement function.
   KeyAfterPropSpread,
 }
 

--- a/src/transformers/JSXTransformer.ts
+++ b/src/transformers/JSXTransformer.ts
@@ -223,22 +223,14 @@ export default class JSXTransformer extends Transformer {
    * target module format.
    */
   getJSXFuncInvocationCode(isStatic: boolean): string {
-    if (this.isAutomaticRuntime) {
-      if (this.options.production) {
-        if (isStatic) {
-          return this.claimAutoImportedFuncInvocation("jsxs", "/jsx-runtime");
-        } else {
-          return this.claimAutoImportedFuncInvocation("jsx", "/jsx-runtime");
-        }
+    if (this.options.production) {
+      if (isStatic) {
+        return this.claimAutoImportedFuncInvocation("jsxs", "/jsx-runtime");
       } else {
-        return this.claimAutoImportedFuncInvocation("jsxDEV", "/jsx-dev-runtime");
+        return this.claimAutoImportedFuncInvocation("jsx", "/jsx-runtime");
       }
     } else {
-      const {jsxPragmaInfo} = this;
-      const resolvedPragmaBaseName = this.importProcessor
-        ? this.importProcessor.getIdentifierReplacement(jsxPragmaInfo.base) || jsxPragmaInfo.base
-        : jsxPragmaInfo.base;
-      return resolvedPragmaBaseName + jsxPragmaInfo.suffix;
+      return this.claimAutoImportedFuncInvocation("jsxDEV", "/jsx-dev-runtime");
     }
   }
 

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -167,7 +167,7 @@ describe("transform JSX", () => {
       _jsxDEV('div', { children: "Some text" }, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this);
       _jsxDEV('div', { children: [...spreadChildrenIntentionallyMarkedStatic]}, void 0, true, {fileName: _jsxFileName, lineNumber: 5}, this);
       _jsxDEV('div', { children: expressionChild}, void 0, false, {fileName: _jsxFileName, lineNumber: 6}, this);
-      _jsxDEV('div', { children: , "Still just one child"   }, void 0, false, {fileName: _jsxFileName, lineNumber: 7}, this);
+      _jsxDEV('div', { children: "Still just one child"   }, void 0, false, {fileName: _jsxFileName, lineNumber: 7}, this);
       _jsxDEV('div', { children: ["Two", "children"]}, void 0, true, {fileName: _jsxFileName, lineNumber: 8}, this);
       _jsxDEV('div', { children: [_jsxDEV(Child1, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 9}, this ), _jsxDEV(Child2, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 9}, this )]}, void 0, true, {fileName: _jsxFileName, lineNumber: 9}, this);
       _jsxDEV('div', { children: ["Child 1" , _jsxDEV(Child2, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 10}, this ), child3]}, void 0, true, {fileName: _jsxFileName, lineNumber: 10}, this);
@@ -181,7 +181,7 @@ describe("transform JSX", () => {
       _jsx('div', { children: "Some text" });
       _jsxs('div', { children: [...spreadChildrenIntentionallyMarkedStatic]});
       _jsx('div', { children: expressionChild});
-      _jsx('div', { children: , "Still just one child"   });
+      _jsx('div', { children: "Still just one child"   });
       _jsxs('div', { children: ["Two", "children"]});
       _jsxs('div', { children: [_jsx(Child1, {} ), _jsx(Child2, {} )]});
       _jsxs('div', { children: ["Child 1" , _jsx(Child2, {} ), child3]});
@@ -255,7 +255,7 @@ describe("transform JSX", () => {
 
         someOtherProp: foo,
  children: 
-        , _jsxDEV('span', { className: "bar",}, computeOtherKey(), false, {fileName: _jsxFileName, lineNumber: 10}, this )
+        _jsxDEV('span', { className: "bar",}, computeOtherKey(), false, {fileName: _jsxFileName, lineNumber: 10}, this )
       }, 
           // We need to call computeKey here.
           computeKey()
@@ -268,7 +268,7 @@ describe("transform JSX", () => {
 
         someOtherProp: foo,
  children: 
-        , _jsx('span', { className: "bar",}, computeOtherKey() )
+        _jsx('span', { className: "bar",}, computeOtherKey() )
       }, 
           // We need to call computeKey here.
           computeKey()
@@ -321,28 +321,28 @@ describe("transform JSX", () => {
         expectedAutomaticDevESMResult: `const _jsxFileName2 = "";import {createElement as _createElement2} from "react";import {jsxDEV as _jsxDEV2, Fragment as _Fragment2} from "react/jsx-dev-runtime";
       let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
       _jsxDEV2(_Fragment2, { children: [
-        , _jsxDEV2('span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
+        _jsxDEV2('span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
         , _createElement2('span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName2, lineNumber: 5}} )
       ]}, void 0, true, {fileName: _jsxFileName2, lineNumber: 3}, this);
     `,
         expectedAutomaticProdESMResult: `import {createElement as _createElement2} from "react";import {jsxs as _jsxs2, Fragment as _Fragment2, jsx as _jsx2} from "react/jsx-runtime";
       let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
       _jsxs2(_Fragment2, { children: [
-        , _jsx2('span', {} )
+        _jsx2('span', {} )
         , _createElement2('span', { ...props, key: "a",} )
       ]});
     `,
         expectedAutomaticDevCJSResult: `"use strict";const _jsxFileName2 = "";var _jsxdevruntime2 = require("react/jsx-dev-runtime");var _react2 = require("react");
       let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
       _jsxdevruntime2.jsxDEV.call(void 0, _jsxdevruntime2.Fragment, { children: [
-        , _jsxdevruntime2.jsxDEV.call(void 0, 'span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
+        _jsxdevruntime2.jsxDEV.call(void 0, 'span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
         , _react2.createElement.call(void 0, 'span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName2, lineNumber: 5}} )
       ]}, void 0, true, {fileName: _jsxFileName2, lineNumber: 3}, this);
     `,
         expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime2 = require("react/jsx-runtime");var _react2 = require("react");
       let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
       _jsxruntime2.jsxs.call(void 0, _jsxruntime2.Fragment, { children: [
-        , _jsxruntime2.jsx.call(void 0, 'span', {} )
+        _jsxruntime2.jsx.call(void 0, 'span', {} )
         , _react2.createElement.call(void 0, 'span', { ...props, key: "a",} )
       ]});
     `,
@@ -887,7 +887,7 @@ describe("transform JSX", () => {
         expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV, Fragment as _Fragment} from "react/jsx-dev-runtime";
       const f = (
         _jsxDEV(_Fragment, { children: [
-          , _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
           , _jsxDEV('span', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 5}, this )
         ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
       );
@@ -895,7 +895,7 @@ describe("transform JSX", () => {
         expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("react/jsx-dev-runtime");
       const f = (
         _jsxdevruntime.jsxDEV.call(void 0, _jsxdevruntime.Fragment, { children: [
-          , _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
           , _jsxdevruntime.jsxDEV.call(void 0, 'span', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 5}, this )
         ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
       );
@@ -903,7 +903,7 @@ describe("transform JSX", () => {
         expectedAutomaticProdESMResult: `import {jsxs as _jsxs, Fragment as _Fragment, jsx as _jsx} from "react/jsx-runtime";
       const f = (
         _jsxs(_Fragment, { children: [
-          , _jsx('div', {} )
+          _jsx('div', {} )
           , _jsx('span', {} )
         ]})
       );
@@ -911,7 +911,7 @@ describe("transform JSX", () => {
         expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("react/jsx-runtime");
       const f = (
         _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, { children: [
-          , _jsxruntime.jsx.call(void 0, 'div', {} )
+          _jsxruntime.jsx.call(void 0, 'div', {} )
           , _jsxruntime.jsx.call(void 0, 'span', {} )
         ]})
       );
@@ -959,7 +959,7 @@ describe("transform JSX", () => {
         expectedAutomaticDevESMResult: `${JSX_PREFIX}import {createElement as _createElement} from "my-lib";import {jsxDEV as _jsxDEV, Fragment as _Fragment} from "my-lib/jsx-dev-runtime";
       const f = (
         _jsxDEV(_Fragment, { children: [
-          , _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
           , _createElement('span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 5}} )
         ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
       );
@@ -967,7 +967,7 @@ describe("transform JSX", () => {
         expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("my-lib/jsx-dev-runtime");var _mylib = require("my-lib");
       const f = (
         _jsxdevruntime.jsxDEV.call(void 0, _jsxdevruntime.Fragment, { children: [
-          , _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
           , _mylib.createElement.call(void 0, 'span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 5}} )
         ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
       );
@@ -975,7 +975,7 @@ describe("transform JSX", () => {
         expectedAutomaticProdESMResult: `import {createElement as _createElement} from "my-lib";import {jsxs as _jsxs, Fragment as _Fragment, jsx as _jsx} from "my-lib/jsx-runtime";
       const f = (
         _jsxs(_Fragment, { children: [
-          , _jsx('div', {} )
+          _jsx('div', {} )
           , _createElement('span', { ...props, key: "a",} )
         ]})
       );
@@ -983,7 +983,7 @@ describe("transform JSX", () => {
         expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("my-lib/jsx-runtime");var _mylib = require("my-lib");
       const f = (
         _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, { children: [
-          , _jsxruntime.jsx.call(void 0, 'div', {} )
+          _jsxruntime.jsx.call(void 0, 'div', {} )
           , _mylib.createElement.call(void 0, 'span', { ...props, key: "a",} )
         ]})
       );

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -3,6 +3,7 @@ import {throws} from "assert";
 import {transform, Options} from "../src";
 import {IMPORT_DEFAULT_PREFIX, JSX_PREFIX} from "./prefixes";
 import * as util from "./util";
+import {jsxDevArgs} from "./util";
 
 const {devProps} = util;
 
@@ -11,13 +12,37 @@ interface JSXExpectations {
   expectedClassicProdESMResult?: string;
   expectedClassicDevCJSResult?: string;
   expectedClassicProdCJSResult?: string;
+  expectedAutomaticDevESMResult?: string;
+  expectedAutomaticProdESMResult?: string;
+  expectedAutomaticDevCJSResult?: string;
+  expectedAutomaticProdCJSResult?: string;
 }
 
 const optionsForMode: {[k in keyof JSXExpectations]-?: Options} = {
-  expectedClassicDevESMResult: {transforms: ["jsx"], production: false},
-  expectedClassicProdESMResult: {transforms: ["jsx"], production: true},
-  expectedClassicDevCJSResult: {transforms: ["jsx", "imports"], production: false},
-  expectedClassicProdCJSResult: {transforms: ["jsx", "imports"], production: true},
+  expectedClassicDevESMResult: {transforms: ["jsx"], jsxRuntime: "classic", production: false},
+  expectedClassicProdESMResult: {transforms: ["jsx"], jsxRuntime: "classic", production: true},
+  expectedClassicDevCJSResult: {
+    transforms: ["jsx", "imports"],
+    jsxRuntime: "classic",
+    production: false,
+  },
+  expectedClassicProdCJSResult: {
+    transforms: ["jsx", "imports"],
+    jsxRuntime: "classic",
+    production: true,
+  },
+  expectedAutomaticDevESMResult: {transforms: ["jsx"], jsxRuntime: "automatic", production: false},
+  expectedAutomaticProdESMResult: {transforms: ["jsx"], jsxRuntime: "automatic", production: true},
+  expectedAutomaticDevCJSResult: {
+    transforms: ["jsx", "imports"],
+    jsxRuntime: "automatic",
+    production: false,
+  },
+  expectedAutomaticProdCJSResult: {
+    transforms: ["jsx", "imports"],
+    jsxRuntime: "automatic",
+    production: true,
+  },
 };
 
 function assertJSXResult(
@@ -48,6 +73,18 @@ describe("transform JSX", () => {
         expectedClassicProdESMResult: `
       React.createElement(Foo, null )
     `,
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV(Foo, {}, void 0, false, ${jsxDevArgs(2)} )
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx(Foo, {} )
+    `,
+        expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("react/jsx-dev-runtime");
+      _jsxdevruntime.jsxDEV.call(void 0, Foo, {}, void 0, false, ${jsxDevArgs(2)} )
+    `,
+        expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("react/jsx-runtime");
+      _jsxruntime.jsx.call(void 0, Foo, {} )
+    `,
       },
     );
   });
@@ -74,6 +111,240 @@ describe("transform JSX", () => {
 
         , React.createElement('span', { className: "some-class",}, "!")
       )
+    `,
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('div', { a: "foo", c: "test", children: ["Hello world"
+
+        , _jsxDEV('span', { className: "some-class", children: "!"}, void 0, false, ${jsxDevArgs(
+          4,
+        )})
+      ]}, "some-key", true, ${jsxDevArgs(2)})
+    `,
+        expectedAutomaticProdESMResult: `import {jsxs as _jsxs, jsx as _jsx} from "react/jsx-runtime";
+      _jsxs('div', { a: "foo", c: "test", children: ["Hello world"
+
+        , _jsx('span', { className: "some-class", children: "!"})
+      ]}, "some-key")
+    `,
+        expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("react/jsx-dev-runtime");
+      _jsxdevruntime.jsxDEV.call(void 0, 'div', { a: "foo", c: "test", children: ["Hello world"
+
+        , _jsxdevruntime.jsxDEV.call(void 0, 'span', { className: "some-class", children: "!"}, void 0, false, ${jsxDevArgs(
+          4,
+        )})
+      ]}, "some-key", true, ${jsxDevArgs(2)})
+    `,
+        expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("react/jsx-runtime");
+      _jsxruntime.jsxs.call(void 0, 'div', { a: "foo", c: "test", children: ["Hello world"
+
+        , _jsxruntime.jsx.call(void 0, 'span', { className: "some-class", children: "!"})
+      ]}, "some-key")
+    `,
+      },
+    );
+  });
+
+  it("recognizes two or more children or spread children as static children in the automatic transform", () => {
+    assertJSXResult(
+      `
+      <div />;
+      <div></div>;
+      <div>Some text</div>;
+      <div>{...spreadChildrenIntentionallyMarkedStatic}</div>;
+      <div>{expressionChild}</div>;
+      <div>{}Still just one child{}</div>;
+      <div>Two{}children</div>;
+      <div><Child1 /><Child2 /></div>;
+      <div>Child 1<Child2 />{child3}</div>;
+      <div>One child{}
+        
+      </div>;
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 2}, this );
+      _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 3}, this);
+      _jsxDEV('div', { children: "Some text" }, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this);
+      _jsxDEV('div', { children: [...spreadChildrenIntentionallyMarkedStatic]}, void 0, true, {fileName: _jsxFileName, lineNumber: 5}, this);
+      _jsxDEV('div', { children: expressionChild}, void 0, false, {fileName: _jsxFileName, lineNumber: 6}, this);
+      _jsxDEV('div', { children: , "Still just one child"   }, void 0, false, {fileName: _jsxFileName, lineNumber: 7}, this);
+      _jsxDEV('div', { children: ["Two", "children"]}, void 0, true, {fileName: _jsxFileName, lineNumber: 8}, this);
+      _jsxDEV('div', { children: [_jsxDEV(Child1, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 9}, this ), _jsxDEV(Child2, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 9}, this )]}, void 0, true, {fileName: _jsxFileName, lineNumber: 9}, this);
+      _jsxDEV('div', { children: ["Child 1" , _jsxDEV(Child2, {}, void 0, false, {fileName: _jsxFileName, lineNumber: 10}, this ), child3]}, void 0, true, {fileName: _jsxFileName, lineNumber: 10}, this);
+      _jsxDEV('div', { children: "One child" 
+
+      }, void 0, false, {fileName: _jsxFileName, lineNumber: 11}, this);
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
+      _jsx('div', {} );
+      _jsx('div', {});
+      _jsx('div', { children: "Some text" });
+      _jsxs('div', { children: [...spreadChildrenIntentionallyMarkedStatic]});
+      _jsx('div', { children: expressionChild});
+      _jsx('div', { children: , "Still just one child"   });
+      _jsxs('div', { children: ["Two", "children"]});
+      _jsxs('div', { children: [_jsx(Child1, {} ), _jsx(Child2, {} )]});
+      _jsxs('div', { children: ["Child 1" , _jsx(Child2, {} ), child3]});
+      _jsx('div', { children: "One child" 
+
+      });
+    `,
+      },
+    );
+  });
+
+  it("falls back to createElement in the automatic transform when a key is after a prop spread", () => {
+    assertJSXResult(
+      `
+      <div {...props} key="a">
+        <span key="b" />
+      </div>;
+      <div {...props} key="a">
+        Static children{}aren't treated differently in this case
+      </div>;
+      <div key="c" {...props} />;
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {createElement as _createElement} from "react";import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _createElement('div', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 2}}
+        , _jsxDEV('span', {}, "b", false, {fileName: _jsxFileName, lineNumber: 3}, this )
+      );
+      _createElement('div', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 5}}, "Static children"
+         , "aren't treated differently in this case"
+      );
+      _jsxDEV('div', { ...props,}, "c", false, {fileName: _jsxFileName, lineNumber: 8}, this );
+    `,
+        expectedAutomaticProdESMResult: `import {createElement as _createElement} from "react";import {jsx as _jsx} from "react/jsx-runtime";
+      _createElement('div', { ...props, key: "a",}
+        , _jsx('span', {}, "b" )
+      );
+      _createElement('div', { ...props, key: "a",}, "Static children"
+         , "aren't treated differently in this case"
+      );
+      _jsx('div', { ...props,}, "c" );
+    `,
+      },
+    );
+  });
+
+  it("repositions multiline keys in the automatic transform", () => {
+    // In all automatic runtime cases, the multiline key is moved to after the
+    // child span, moving 3 newline characters in the process. The total number
+    // of input and output lines should be the same, but the span is shifted up
+    // as a result, which isn't ideal. For more details on the problem and
+    // potential future solutions, see
+    // https://github.com/alangpierce/sucrase/wiki/JSX-Automatic-Runtime-Transform-Technical-Plan#handling-multi-line-keys
+    assertJSXResult(
+      `
+      <div
+        someProp="Hello"
+        key={
+          // We need to call computeKey here.
+          computeKey()
+        }
+        someOtherProp={foo}
+      >
+        <span key={computeOtherKey()} className="bar" />
+      </div>
+      console.log("10 lines after the start of the div");
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('div', {
+        someProp: "Hello",
+
+        someOtherProp: foo,
+ children: 
+        , _jsxDEV('span', { className: "bar",}, computeOtherKey(), false, {fileName: _jsxFileName, lineNumber: 10}, this )
+      }, 
+          // We need to call computeKey here.
+          computeKey()
+        , false, {fileName: _jsxFileName, lineNumber: 2}, this)
+      console.log("10 lines after the start of the div");
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('div', {
+        someProp: "Hello",
+
+        someOtherProp: foo,
+ children: 
+        , _jsx('span', { className: "bar",}, computeOtherKey() )
+      }, 
+          // We need to call computeKey here.
+          computeKey()
+        )
+      console.log("10 lines after the start of the div");
+    `,
+      },
+    );
+  });
+
+  it("preserves total lines before and after with multiple multiline keys", () => {
+    assertJSXResult(
+      `
+      <div
+        key={
+          a
+        }
+        key={
+          b
+        }
+      />
+      console.log("8 lines after the start of the div");
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('div', {
+
+
+
+}, 
+          b
+        , false, {fileName: _jsxFileName, lineNumber: 2}, this
+      )
+      console.log("8 lines after the start of the div");
+    `,
+      },
+    );
+  });
+
+  it("claims free names when autogenerating imports", () => {
+    assertJSXResult(
+      `
+      let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
+      <>
+        <span />
+        <span {...props} key="a" />
+      </>;
+    `,
+      {
+        expectedAutomaticDevESMResult: `const _jsxFileName2 = "";import {createElement as _createElement2} from "react";import {jsxDEV as _jsxDEV2, Fragment as _Fragment2} from "react/jsx-dev-runtime";
+      let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
+      _jsxDEV2(_Fragment2, { children: [
+        , _jsxDEV2('span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
+        , _createElement2('span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName2, lineNumber: 5}} )
+      ]}, void 0, true, {fileName: _jsxFileName2, lineNumber: 3}, this);
+    `,
+        expectedAutomaticProdESMResult: `import {createElement as _createElement2} from "react";import {jsxs as _jsxs2, Fragment as _Fragment2, jsx as _jsx2} from "react/jsx-runtime";
+      let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
+      _jsxs2(_Fragment2, { children: [
+        , _jsx2('span', {} )
+        , _createElement2('span', { ...props, key: "a",} )
+      ]});
+    `,
+        expectedAutomaticDevCJSResult: `"use strict";const _jsxFileName2 = "";var _jsxdevruntime2 = require("react/jsx-dev-runtime");var _react2 = require("react");
+      let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
+      _jsxdevruntime2.jsxDEV.call(void 0, _jsxdevruntime2.Fragment, { children: [
+        , _jsxdevruntime2.jsxDEV.call(void 0, 'span', {}, void 0, false, {fileName: _jsxFileName2, lineNumber: 4}, this )
+        , _react2.createElement.call(void 0, 'span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName2, lineNumber: 5}} )
+      ]}, void 0, true, {fileName: _jsxFileName2, lineNumber: 3}, this);
+    `,
+        expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime2 = require("react/jsx-runtime");var _react2 = require("react");
+      let _jsx, _jsxs, _jsxDEV, _Fragment, _createElement, _jsxFileName, _jsxruntime, _jsxdevruntime, _react;
+      _jsxruntime2.jsxs.call(void 0, _jsxruntime2.Fragment, { children: [
+        , _jsxruntime2.jsx.call(void 0, 'span', {} )
+        , _react2.createElement.call(void 0, 'span', { ...props, key: "a",} )
+      ]});
     `,
       },
     );
@@ -121,6 +392,9 @@ describe("transform JSX", () => {
         expectedClassicDevESMResult: `${JSX_PREFIX}
       React.createElement('div', {${devProps(2)}}, React.createElement('span', {${devProps(2)}}))
     `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('div', { children: _jsx('span', {})})
+    `,
       },
     );
   });
@@ -133,6 +407,9 @@ describe("transform JSX", () => {
       {
         expectedClassicDevESMResult: `${JSX_PREFIX}
       React.createElement('div', {${devProps(2)}}, x)
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('div', { children: x})
     `,
       },
     );
@@ -174,6 +451,9 @@ describe("transform JSX", () => {
       React.createElement(A, { foo: React.createElement(React.Fragment, null, "Hi"), ${devProps(
         2,
       )}} )
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx, Fragment as _Fragment} from "react/jsx-runtime";
+      _jsx(A, { foo: _jsx(_Fragment, { children: "Hi"}),} )
     `,
       },
     );
@@ -277,6 +557,9 @@ describe("transform JSX", () => {
         expectedClassicDevESMResult: `${JSX_PREFIX}
       React.createElement(a.b, { c: "d", ${devProps(2)}} )
     `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx(a.b, { c: "d",} )
+    `,
       },
     );
   });
@@ -292,6 +575,12 @@ describe("transform JSX", () => {
     `,
         expectedClassicProdESMResult: `
       React.createElement('a', { ...b, c: "d",} )
+    `,
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('a', { ...b, c: "d",}, void 0, false, ${jsxDevArgs(2)} )
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('a', { ...b, c: "d",} )
     `,
       },
     );
@@ -481,6 +770,12 @@ describe("transform JSX", () => {
                 , ${devProps(2)}}
       )
     `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('div', {
+        value: "This is a multi-line string."
+                ,}
+      )
+    `,
       },
     );
   });
@@ -537,6 +832,12 @@ describe("transform JSX", () => {
         expectedClassicProdESMResult: `
       const e = React.createElement('div', { a: true,} );
     `,
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      const e = _jsxDEV('div', { a: true,}, void 0, false, ${jsxDevArgs(2)} );
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      const e = _jsx('div', { a: true,} );
+    `,
       },
     );
   });
@@ -583,6 +884,38 @@ describe("transform JSX", () => {
         )
       );
     `,
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV, Fragment as _Fragment} from "react/jsx-dev-runtime";
+      const f = (
+        _jsxDEV(_Fragment, { children: [
+          , _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          , _jsxDEV('span', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 5}, this )
+        ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
+      );
+    `,
+        expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("react/jsx-dev-runtime");
+      const f = (
+        _jsxdevruntime.jsxDEV.call(void 0, _jsxdevruntime.Fragment, { children: [
+          , _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          , _jsxdevruntime.jsxDEV.call(void 0, 'span', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 5}, this )
+        ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
+      );
+    `,
+        expectedAutomaticProdESMResult: `import {jsxs as _jsxs, Fragment as _Fragment, jsx as _jsx} from "react/jsx-runtime";
+      const f = (
+        _jsxs(_Fragment, { children: [
+          , _jsx('div', {} )
+          , _jsx('span', {} )
+        ]})
+      );
+    `,
+        expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("react/jsx-runtime");
+      const f = (
+        _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, { children: [
+          , _jsxruntime.jsx.call(void 0, 'div', {} )
+          , _jsxruntime.jsx.call(void 0, 'span', {} )
+        ]})
+      );
+    `,
       },
     );
   });
@@ -609,6 +942,54 @@ describe("transform JSX", () => {
       );
     `,
       },
+    );
+  });
+
+  it("allows custom JSX import source for automatic transform", () => {
+    assertJSXResult(
+      `
+      const f = (
+        <>
+          <div />
+          <span {...props} key="a" />
+        </>
+      );
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {createElement as _createElement} from "my-lib";import {jsxDEV as _jsxDEV, Fragment as _Fragment} from "my-lib/jsx-dev-runtime";
+      const f = (
+        _jsxDEV(_Fragment, { children: [
+          , _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          , _createElement('span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 5}} )
+        ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
+      );
+    `,
+        expectedAutomaticDevCJSResult: `"use strict";${JSX_PREFIX}var _jsxdevruntime = require("my-lib/jsx-dev-runtime");var _mylib = require("my-lib");
+      const f = (
+        _jsxdevruntime.jsxDEV.call(void 0, _jsxdevruntime.Fragment, { children: [
+          , _jsxdevruntime.jsxDEV.call(void 0, 'div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this )
+          , _mylib.createElement.call(void 0, 'span', { ...props, key: "a", __self: this, __source: {fileName: _jsxFileName, lineNumber: 5}} )
+        ]}, void 0, true, {fileName: _jsxFileName, lineNumber: 3}, this)
+      );
+    `,
+        expectedAutomaticProdESMResult: `import {createElement as _createElement} from "my-lib";import {jsxs as _jsxs, Fragment as _Fragment, jsx as _jsx} from "my-lib/jsx-runtime";
+      const f = (
+        _jsxs(_Fragment, { children: [
+          , _jsx('div', {} )
+          , _createElement('span', { ...props, key: "a",} )
+        ]})
+      );
+    `,
+        expectedAutomaticProdCJSResult: `"use strict";var _jsxruntime = require("my-lib/jsx-runtime");var _mylib = require("my-lib");
+      const f = (
+        _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, { children: [
+          , _jsxruntime.jsx.call(void 0, 'div', {} )
+          , _mylib.createElement.call(void 0, 'span', { ...props, key: "a",} )
+        ]})
+      );
+    `,
+      },
+      {jsxImportSource: "my-lib"},
     );
   });
 
@@ -670,6 +1051,9 @@ describe("transform JSX", () => {
       {
         expectedClassicDevESMResult: `
       const c = React.createElement(React.Fragment, null);
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx, Fragment as _Fragment} from "react/jsx-runtime";
+      const c = _jsx(_Fragment, {});
     `,
       },
     );

--- a/test/jsx-test.ts
+++ b/test/jsx-test.ts
@@ -193,6 +193,58 @@ describe("transform JSX", () => {
     );
   });
 
+  it("properly handles elements with no children", () => {
+    assertJSXResult(
+      `
+      <div />;
+      <div></div>;
+      <div>{/* This is a comment */}</div>;
+      <div>
+        
+        {}
+        
+      </div>;
+      <div>
+        
+        {}   {}
+        
+      </div>;
+    `,
+      {
+        expectedAutomaticDevESMResult: `${JSX_PREFIX}import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";
+      _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 2}, this );
+      _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 3}, this);
+      _jsxDEV('div', {/* This is a comment */}, void 0, false, {fileName: _jsxFileName, lineNumber: 4}, this);
+      _jsxDEV('div', {
+
+        
+
+      }, void 0, false, {fileName: _jsxFileName, lineNumber: 5}, this);
+      _jsxDEV('div', { children: 
+
+        "   "   
+
+      }, void 0, false, {fileName: _jsxFileName, lineNumber: 10}, this);
+    `,
+        expectedAutomaticProdESMResult: `import {jsx as _jsx} from "react/jsx-runtime";
+      _jsx('div', {} );
+      _jsx('div', {});
+      _jsx('div', {/* This is a comment */});
+      _jsx('div', {
+
+        
+
+      });
+      _jsx('div', { children: 
+
+        "   "   
+
+      });
+    `,
+      },
+    );
+  });
+
   it("falls back to createElement in the automatic transform when a key is after a prop spread", () => {
     assertJSXResult(
       `

--- a/test/tokens-test.ts
+++ b/test/tokens-test.ts
@@ -507,11 +507,11 @@ describe("tokens", () => {
   });
 
   it("treats single-child JSX as non-static", () => {
-    assertFirstJSXRole("const elem = <div>Hello</div>;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div>Hello</div>;", JSXRole.OneChild);
   });
 
   it("treats self-closing JSX as non-static", () => {
-    assertFirstJSXRole("const elem = <div />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div />;", JSXRole.NoChildren);
   });
 
   it("treats JSX with two element children as static", () => {
@@ -527,7 +527,7 @@ describe("tokens", () => {
   });
 
   it("treats JSX with non-spread children as non-static", () => {
-    assertFirstJSXRole("const elem = <div>{elements}</div>;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div>{elements}</div>;", JSXRole.OneChild);
   });
 
   it("treats JSX with spread children as static", () => {
@@ -540,7 +540,7 @@ describe("tokens", () => {
       const elem = <div> {} 
       </div>;
     `,
-      JSXRole.Normal,
+      JSXRole.OneChild,
     );
   });
 
@@ -553,7 +553,7 @@ describe("tokens", () => {
         </div>
       );
     `,
-      JSXRole.Normal,
+      JSXRole.NoChildren,
     );
   });
 
@@ -577,15 +577,15 @@ describe("tokens", () => {
   });
 
   it("does not mark as key-after-prop-spread if there is just a key", () => {
-    assertFirstJSXRole("const elem = <div key={1} />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div key={1} />;", JSXRole.NoChildren);
   });
 
   it("does not mark as key-after-prop-spread the key is after regular props", () => {
-    assertFirstJSXRole("const elem = <div foo='a' bar='b' key={1} />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div foo='a' bar='b' key={1} />;", JSXRole.NoChildren);
   });
 
   it("does not mark as key-after-prop-spread if the prop spread is afterward", () => {
-    assertFirstJSXRole("const elem = <div key={1} {...props} />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div key={1} {...props} />;", JSXRole.NoChildren);
   });
 
   it("marks as key-after-prop-spread if there is a prop spread before and after", () => {
@@ -603,11 +603,11 @@ describe("tokens", () => {
   });
 
   it("does not mark as key-after-prop-spread for camelCase props starting with key", () => {
-    assertFirstJSXRole("const elem = <div {...props} keyLimePie={1} />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div {...props} keyLimePie={1} />;", JSXRole.NoChildren);
   });
 
   it("does not mark as key-after-prop-spread for hyphenated props starting with key", () => {
-    assertFirstJSXRole("const elem = <div {...props} key-lime-pie={1} />;", JSXRole.Normal);
+    assertFirstJSXRole("const elem = <div {...props} key-lime-pie={1} />;", JSXRole.NoChildren);
   });
 
   it("marks key-after-prop-spread with higher precedence than static children", () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -47,8 +47,19 @@ export function assertOutput(
   assertExpectations(code, {expectedOutput}, options);
 }
 
+/**
+ * Dev-specific props when using the createElement function, either in the
+ * classic runtime or in the fallback case for the automatic runtime.
+ */
 export function devProps(lineNumber: number): string {
   return `__self: this, __source: {fileName: _jsxFileName, lineNumber: ${lineNumber}}`;
+}
+
+/**
+ * Dev-specific args to the jsxDEV function in the automatic runtime.
+ */
+export function jsxDevArgs(lineNumber: number): string {
+  return `{fileName: _jsxFileName, lineNumber: ${lineNumber}}, this`;
 }
 
 /**

--- a/website/src/Constants.ts
+++ b/website/src/Constants.ts
@@ -53,8 +53,10 @@ export type HydratedOptions = Omit<Required<Options>, "filePath" | "sourceMapOpt
  */
 export const DEFAULT_OPTIONS: HydratedOptions = {
   transforms: ["jsx", "typescript", "imports"],
+  jsxRuntime: "classic",
   jsxPragma: "React.createElement",
   jsxFragmentPragma: "React.Fragment",
+  jsxImportSource: "react",
   enableLegacyTypeScriptModuleInterop: false,
   enableLegacyBabel5ModuleInterop: false,
   production: false,

--- a/website/src/SimpleSelect.tsx
+++ b/website/src/SimpleSelect.tsx
@@ -1,0 +1,40 @@
+import {css, StyleSheet} from "aphrodite";
+import React from "react";
+
+interface SelectProps<T extends string> {
+  options: Array<T>;
+  value: T;
+  onChange: (value: T) => void;
+}
+
+/**
+ * Select component where items are identified directly by their value.
+ */
+export default function SimpleSelect<T extends string>({
+  options,
+  value,
+  onChange,
+}: SelectProps<T>): JSX.Element {
+  return (
+    <select
+      className={css(styles.select)}
+      value={value}
+      onChange={(e) => {
+        onChange(e.target.value as T);
+      }}
+    >
+      {options.map((option) => (
+        <option value={option}>{option}</option>
+      ))}
+    </select>
+  );
+}
+
+const styles = StyleSheet.create({
+  select: {
+    backgroundColor: "#222222",
+    color: "white",
+    border: 0,
+    fontFamily: "monospace",
+  },
+});

--- a/website/src/SucraseOptionsBox.tsx
+++ b/website/src/SucraseOptionsBox.tsx
@@ -5,6 +5,7 @@ import type {Transform} from "sucrase";
 import CheckBox from "./CheckBox";
 import {HydratedOptions, TRANSFORMS} from "./Constants";
 import OptionsBox from "./OptionsBox";
+import SimpleSelect from "./SimpleSelect";
 import TextInput from "./TextInput";
 
 interface SucraseOptionsBoxProps {
@@ -51,7 +52,7 @@ function BooleanOption({optionName, options, onUpdateOptions}: BooleanOptionProp
 }
 
 interface StringOptionProps {
-  optionName: "jsxPragma" | "jsxFragmentPragma";
+  optionName: "jsxPragma" | "jsxFragmentPragma" | "jsxImportSource";
   options: HydratedOptions;
   onUpdateOptions: (options: HydratedOptions) => void;
   inputWidth: number;
@@ -64,7 +65,7 @@ function StringOption({
   inputWidth,
 }: StringOptionProps): JSX.Element {
   return (
-    <div className={css(styles.stringOption)}>
+    <div className={css(styles.option)}>
       {/* Include a hidden checkbox so the option name is vertically aligned
           with the boolean options. */}
       <input type="checkbox" className={css(styles.hiddenCheckbox)} />
@@ -76,6 +77,31 @@ function StringOption({
             onUpdateOptions({...options, [optionName]: value});
           }}
           width={inputWidth}
+        />
+      </span>
+    </div>
+  );
+}
+
+interface JSXRuntimeOptionProps {
+  options: HydratedOptions;
+  onUpdateOptions: (options: HydratedOptions) => void;
+}
+
+function JSXRuntimeOption({options, onUpdateOptions}: JSXRuntimeOptionProps): JSX.Element {
+  return (
+    <div className={css(styles.option)}>
+      {/* Include a hidden checkbox so the option name is vertically aligned
+          with the boolean options. */}
+      <input type="checkbox" className={css(styles.hiddenCheckbox)} />
+      <span className={css(styles.optionName)}>
+        jsxRuntime:{" "}
+        <SimpleSelect
+          options={["classic", "automatic"]}
+          value={options.jsxRuntime}
+          onChange={(value) => {
+            onUpdateOptions({...options, jsxRuntime: value});
+          }}
         />
       </span>
     </div>
@@ -134,45 +160,70 @@ export default function SucraseOptionsBox({
                 options={options}
                 onUpdateOptions={onUpdateOptions}
               />
-              <BooleanOption
-                optionName="production"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <StringOption
-                optionName="jsxPragma"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-                inputWidth={182}
-              />
-              <StringOption
-                optionName="jsxFragmentPragma"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-                inputWidth={120}
-              />
+              {options.transforms.includes("jsx") && (
+                <>
+                  <JSXRuntimeOption options={options} onUpdateOptions={onUpdateOptions} />
+                  <BooleanOption
+                    optionName="production"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  {options.jsxRuntime === "classic" && (
+                    <>
+                      <StringOption
+                        optionName="jsxPragma"
+                        options={options}
+                        onUpdateOptions={onUpdateOptions}
+                        inputWidth={182}
+                      />
+                      <StringOption
+                        optionName="jsxFragmentPragma"
+                        options={options}
+                        onUpdateOptions={onUpdateOptions}
+                        inputWidth={120}
+                      />
+                    </>
+                  )}
+
+                  {options.jsxRuntime === "automatic" && (
+                    <StringOption
+                      optionName="jsxImportSource"
+                      options={options}
+                      onUpdateOptions={onUpdateOptions}
+                      inputWidth={116}
+                    />
+                  )}
+                </>
+              )}
             </div>
             <div className={css(styles.secondaryOptionColumn)}>
-              <BooleanOption
-                optionName="preserveDynamicImport"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="injectCreateRequireForImportRequire"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="enableLegacyTypeScriptModuleInterop"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="enableLegacyBabel5ModuleInterop"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
+              {options.transforms.includes("imports") && (
+                <>
+                  <BooleanOption
+                    optionName="preserveDynamicImport"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  <BooleanOption
+                    optionName="enableLegacyTypeScriptModuleInterop"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  <BooleanOption
+                    optionName="enableLegacyBabel5ModuleInterop"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                </>
+              )}
+              {!options.transforms.includes("imports") &&
+                options.transforms.includes("typescript") && (
+                  <BooleanOption
+                    optionName="injectCreateRequireForImportRequire"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                )}
             </div>
           </div>
         )}
@@ -208,7 +259,7 @@ const styles = StyleSheet.create({
     display: "flex",
     flexDirection: "column",
   },
-  stringOption: {
+  option: {
     marginLeft: 6,
     marginRight: 6,
     display: "flex",


### PR DESCRIPTION
Fixes #585

Tech plan that includes many major details:
https://github.com/alangpierce/sucrase/wiki/JSX-Automatic-Runtime-Transform-Technical-Plan

This PR adds two new options:
* `jsxRuntime`, which can be "classic" (the existing behavior) or "automatic"
  (the transform behavior released with React 17).
* `jsxImportSource`, which configures the import prefix when using the automatic
  runtime.

This PR also adds docs for the new options and makes them available to demo on the website.

While it may have been possible to split the `JSXTransform` code into multiple files, the
configuration space is intertwined enough that it seemed better for now to just have a unified
implementation for now. This leads to a little extra abstraction when resolving function names
as well as some special cases about where to place commas, but the overall flow of logic is the
same.

Unfortunately, it looks like the new implementation is slower than the old one, regardless of
configuration, which isn't too surprising given the added complexity. Some measurements,
using a higher-scale variation of `yarn benchmark sample` (which specifically tests scale for
the JSX transform):
* Before this PR: 968k lines per second
* Classic runtime after this PR: 925k lines per second (4% slower than before)
* Automatic runtime after this PR: 901k lines per second (7% slower than before)

There's certainly some possible room for improvement, e.g. by more aggressively caching/
precomputing resolved names or duplicating and individually simplifying the code path for
each configuration, but that can be done as future work.