### PR TITLE
Minor refactors in prep for new JSX runtime

### DIFF
--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -19,16 +19,16 @@ export const SourceMapOptions = t.iface([], {
 
 export const Options = t.iface([], {
   transforms: t.array("Transform"),
+  disableESTransforms: t.opt("boolean"),
+  production: t.opt("boolean"),
   jsxPragma: t.opt("string"),
   jsxFragmentPragma: t.opt("string"),
+  preserveDynamicImport: t.opt("boolean"),
+  injectCreateRequireForImportRequire: t.opt("boolean"),
   enableLegacyTypeScriptModuleInterop: t.opt("boolean"),
   enableLegacyBabel5ModuleInterop: t.opt("boolean"),
   sourceMapOptions: t.opt("SourceMapOptions"),
   filePath: t.opt("string"),
-  production: t.opt("boolean"),
-  disableESTransforms: t.opt("boolean"),
-  preserveDynamicImport: t.opt("boolean"),
-  injectCreateRequireForImportRequire: t.opt("boolean"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -15,7 +15,20 @@ export interface SourceMapOptions {
 }
 
 export interface Options {
+  /**
+   * Unordered array of transform names describing both the allowed syntax
+   * (where applicable) and the transformation behavior.
+   */
   transforms: Array<Transform>;
+  /**
+   * Opts out of all ES syntax transformations: optional chaining, nullish
+   * coalescing, class fields, numeric separators, optional catch binding.
+   */
+  disableESTransforms?: boolean;
+  /**
+   * Compile code for production use. Currently only applies to the JSX transform.
+   */
+  production?: boolean;
   /**
    * If specified, function name to use in place of React.createClass when compiling JSX.
    */
@@ -25,35 +38,8 @@ export interface Options {
    */
   jsxFragmentPragma?: string;
   /**
-   * If true, replicate the import behavior of TypeScript's esModuleInterop: false.
-   */
-  enableLegacyTypeScriptModuleInterop?: boolean;
-  /**
-   * If true, replicate the import behavior Babel 5 and babel-plugin-add-module-exports.
-   */
-  enableLegacyBabel5ModuleInterop?: boolean;
-  /**
-   * If specified, we also return a RawSourceMap object alongside the code. Currently, source maps
-   * simply map each line to the original line without any mappings within lines, since Sucrase
-   * preserves line numbers. filePath must be specified if this option is enabled.
-   */
-  sourceMapOptions?: SourceMapOptions;
-  /**
-   * File path to use in error messages, React display names, and source maps.
-   */
-  filePath?: string;
-  /**
-   * If specified, omit any development-specific code in the output.
-   */
-  production?: boolean;
-  /**
-   * Opts out ES syntax transformations, like optional chaining, nullish coalescing, numeric
-   * separators, etc.
-   */
-  disableESTransforms?: boolean;
-  /**
-   * If specified, the imports transform does not attempt to change dynamic import()
-   * expressions into require() calls.
+   * If specified, the imports transform does not attempt to change dynamic
+   * import() expressions into require() calls.
    */
   preserveDynamicImport?: boolean;
   /**
@@ -67,6 +53,25 @@ export interface Options {
    * same code to target ESM and CJS.
    */
   injectCreateRequireForImportRequire?: boolean;
+  /**
+   * If true, replicate the import behavior of TypeScript's esModuleInterop: false.
+   */
+  enableLegacyTypeScriptModuleInterop?: boolean;
+  /**
+   * If true, replicate the import behavior Babel 5 and babel-plugin-add-module-exports.
+   */
+  enableLegacyBabel5ModuleInterop?: boolean;
+  /**
+   * If specified, we also return a RawSourceMap object alongside the code.
+   * Currently, source maps simply map each line to the original line without
+   * any mappings within lines, since Sucrase preserves line numbers. filePath
+   * must be specified if this option is enabled.
+   */
+  sourceMapOptions?: SourceMapOptions;
+  /**
+   * File path to use in error messages, React display names, and source maps.
+   */
+  filePath?: string;
 }
 
 export function validateOptions(options: Options): void {

--- a/website/src/Constants.ts
+++ b/website/src/Constants.ts
@@ -53,14 +53,14 @@ export type HydratedOptions = Omit<Required<Options>, "filePath" | "sourceMapOpt
  */
 export const DEFAULT_OPTIONS: HydratedOptions = {
   transforms: ["jsx", "typescript", "imports"],
+  disableESTransforms: false,
+  production: false,
   jsxPragma: "React.createElement",
   jsxFragmentPragma: "React.Fragment",
-  enableLegacyTypeScriptModuleInterop: false,
-  enableLegacyBabel5ModuleInterop: false,
-  production: false,
-  disableESTransforms: false,
   preserveDynamicImport: false,
   injectCreateRequireForImportRequire: false,
+  enableLegacyTypeScriptModuleInterop: false,
+  enableLegacyBabel5ModuleInterop: false,
 };
 
 export interface DisplayOptions {

--- a/website/src/SucraseOptionsBox.tsx
+++ b/website/src/SucraseOptionsBox.tsx
@@ -134,45 +134,56 @@ export default function SucraseOptionsBox({
                 options={options}
                 onUpdateOptions={onUpdateOptions}
               />
-              <BooleanOption
-                optionName="production"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <StringOption
-                optionName="jsxPragma"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-                inputWidth={182}
-              />
-              <StringOption
-                optionName="jsxFragmentPragma"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-                inputWidth={120}
-              />
+              {options.transforms.includes("jsx") && (
+                <>
+                  <BooleanOption
+                    optionName="production"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  <StringOption
+                    optionName="jsxPragma"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                    inputWidth={182}
+                  />
+                  <StringOption
+                    optionName="jsxFragmentPragma"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                    inputWidth={120}
+                  />
+                </>
+              )}
             </div>
             <div className={css(styles.secondaryOptionColumn)}>
-              <BooleanOption
-                optionName="preserveDynamicImport"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="injectCreateRequireForImportRequire"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="enableLegacyTypeScriptModuleInterop"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
-              <BooleanOption
-                optionName="enableLegacyBabel5ModuleInterop"
-                options={options}
-                onUpdateOptions={onUpdateOptions}
-              />
+              {options.transforms.includes("imports") && (
+                <>
+                  <BooleanOption
+                    optionName="preserveDynamicImport"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  <BooleanOption
+                    optionName="enableLegacyTypeScriptModuleInterop"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                  <BooleanOption
+                    optionName="enableLegacyBabel5ModuleInterop"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                </>
+              )}
+              {!options.transforms.includes("imports") &&
+                options.transforms.includes("typescript") && (
+                  <BooleanOption
+                    optionName="injectCreateRequireForImportRequire"
+                    options={options}
+                    onUpdateOptions={onUpdateOptions}
+                  />
+                )}
             </div>
           </div>
         )}


### PR DESCRIPTION
This PR has a few details pulled from #740 to make it easier to read the
substantial changes in that PR:
* Reorder the options interface to better group related options together.
* Reorder the methods in JSXTransformer to be in (roughly) top-down topological
  order rather than the more scattered order that it was previously.
* Change website advanced options to dynamically only show the ones relevant
  based on what is selected.