### PR TITLE
Fix broken error messages in Jest integration

### DIFF
--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -32,7 +32,11 @@ export function process(
       filePath: filename,
     });
     const mapBase64 = Buffer.from(JSON.stringify(sourceMap)).toString("base64");
-    const suffix = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${mapBase64}`;
+    // Split the source map comment across two strings so that tools like
+    // source-map-support don't accidentally interpret it as a source map
+    // comment for this file.
+    let suffix = "//# sourceMapping";
+    suffix += `URL=data:application/json;charset=utf-8;base64,${mapBase64}`;
     // sourceMappingURL is necessary for breakpoints to work in WebStorm, so
     // include it in addition to specifying the source map normally.
     return {code: `${code}\n${suffix}`, map: sourceMap};


### PR DESCRIPTION
The source-map-support library was using a simple regex-based approach to detect the sourceMappingURL string in files, and it had a false positive on the integration file itself. This meant that any crash was showing a JSON parsing error rather on the invalid source map rather than the actual error.

To fix, I hacked the code to build the snippet across two strings. This now shows correct error validation when you have a syntax error or a mistake in your Sucrase configuration, for example.