### PR TITLE
Preserve imports when needed in Jest integration

### DIFF
--- a/integration-test/integration-tests.ts
+++ b/integration-test/integration-tests.ts
@@ -43,14 +43,14 @@ describe("integration tests", () => {
       const testConfig = await readJSONFileContentsIfExists("./test.json");
       if (testConfig?.expectedError) {
         try {
-          await execPromise(`npx jest`);
+          await execPromise(`NODE_OPTIONS=--experimental-vm-modules npx jest --no-cache`);
           assert.fail("Expected Jest to fail");
         } catch (e) {
           assert((e as {stderr: string}).stderr.includes(testConfig.expectedError));
         }
       } else {
         // Should not crash.
-        await execPromise(`npx jest`);
+        await execPromise(`NODE_OPTIONS=--experimental-vm-modules npx jest --no-cache`);
       }
     });
   }

--- a/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/jest.config.js
+++ b/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  transform: {"\\.ts$": "@sucrase/jest-plugin"},
+};

--- a/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/main.js
+++ b/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/main.js
@@ -1,0 +1,2 @@
+// This file isn't transpiled, so it remains ESM at runtime.
+export const one = 1;

--- a/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/main.test.ts
+++ b/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/main.test.ts
@@ -1,0 +1,8 @@
+test("addition", async () => {
+  // Assert that module is defined to confirm that this is a CJS file.
+  expect(module).toBeTruthy();
+
+  // This dynamic import should be preserved, not transformed to require.
+  const {one} = await import("./main");
+  expect(one + one).toBe(2 as number);
+});

--- a/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/package.json
+++ b/integration-test/test-cases/jest-cases/allows-dynamic-import-of-esm-from-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/jest.config.js
+++ b/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  transform: {"\\.ts$": "@sucrase/jest-plugin"},
+  extensionsToTreatAsEsm: ['.ts'],
+};

--- a/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/main.js
+++ b/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/main.js
@@ -1,0 +1,2 @@
+// This file isn't transpiled, so it remains ESM at runtime.
+export const one = 1;

--- a/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/main.test.ts
+++ b/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/main.test.ts
@@ -1,0 +1,6 @@
+// This static import should be preserved rather than transformed to require.
+import {one} from "./main";
+
+test("addition", () => {
+  expect(one + one).toBe(2 as number);
+});

--- a/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/package.json
+++ b/integration-test/test-cases/jest-cases/preserves-imports-in-esm-mode/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -3,13 +3,14 @@ import {Transform, transform} from "sucrase";
 
 import type {Options} from "../../../src/Options";
 
-function getTransforms(filename: string): Array<Transform> | null {
+function getTransforms(filename: string, supportsStaticESM: boolean): Array<Transform> | null {
+  const maybeImports: Array<Transform> = supportsStaticESM ? [] : ["imports"];
   if (filename.endsWith(".js") || filename.endsWith(".jsx")) {
-    return ["flow", "jsx", "imports", "jest"];
+    return [...maybeImports, "flow", "jsx", "jest"];
   } else if (filename.endsWith(".ts")) {
-    return ["typescript", "imports", "jest"];
+    return [...maybeImports, "typescript", "jest"];
   } else if (filename.endsWith(".tsx")) {
-    return ["typescript", "jsx", "imports", "jest"];
+    return [...maybeImports, "typescript", "jsx", "jest"];
   }
   return null;
 }
@@ -23,10 +24,11 @@ export function process(
   filename: string,
   options: TransformOptions<Partial<Options>>,
 ): {code: string; map?: RawSourceMap | string | null} {
-  const transforms = getTransforms(filename);
+  const transforms = getTransforms(filename, options.supportsStaticESM);
   if (transforms !== null) {
     const {code, sourceMap} = transform(src, {
       transforms,
+      preserveDynamicImport: options.supportsDynamicImport,
       ...options.transformerConfig,
       sourceMapOptions: {compiledFilename: filename},
       filePath: filename,

--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -1,15 +1,17 @@
 import type {TransformOptions} from "@jest/transform";
+import {extname} from "path";
 import {Transform, transform} from "sucrase";
 
 import type {Options} from "../../../src/Options";
 
 function getTransforms(filename: string, supportsStaticESM: boolean): Array<Transform> | null {
+  const extension = extname(filename);
   const maybeImports: Array<Transform> = supportsStaticESM ? [] : ["imports"];
-  if (filename.endsWith(".js") || filename.endsWith(".jsx")) {
+  if ([".js", ".jsx", ".mjs", ".cjs"].includes(extension)) {
     return [...maybeImports, "flow", "jsx", "jest"];
-  } else if (filename.endsWith(".ts")) {
+  } else if (extension === ".ts") {
     return [...maybeImports, "typescript", "jest"];
-  } else if (filename.endsWith(".tsx")) {
+  } else if ([".tsx", ".mts", ".cts"].includes(extension)) {
     return [...maybeImports, "typescript", "jsx", "jest"];
   }
   return null;


### PR DESCRIPTION
Fixes #741

When Jest is run with ESM enabled, it passes in either `supportsDynamicImport` or `supportsStaticESM` depending on whether the code is targeting ESM or CJS. The integration now configures Sucrase accordingly, which should be enough for the integration to just work with an ESM Jest configuration.