### PR TITLE
Specify disableESTransforms by default in Jest plugin

### DIFF
--- a/integrations/jest-plugin/src/index.ts
+++ b/integrations/jest-plugin/src/index.ts
@@ -30,6 +30,7 @@ export function process(
   if (transforms !== null) {
     const {code, sourceMap} = transform(src, {
       transforms,
+      disableESTransforms: true,
       preserveDynamicImport: options.supportsDynamicImport,
       ...options.transformerConfig,
       sourceMapOptions: {compiledFilename: filename},


### PR DESCRIPTION
Sucrase's ES transforms are pretty much never relevant when working in Node these days, and the Jest plugin is getting a semver-major release, so this changes the default to disable the ES transforms.