### PR TITLE
Revert jest plugin sucrase peer dependency, update sucrase version

### DIFF
--- a/integrations/jest-plugin/package.json
+++ b/integrations/jest-plugin/package.json
@@ -7,14 +7,13 @@
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "sucrase": "^3.18.0"
+    "sucrase": "^3.28.0"
   },
   "devDependencies": {
     "@jest/transform": "^29.1.2",
     "@types/node": "^16.11.4"
   },
   "peerDependencies": {
-    "jest": ">=27",
-    "sucrase": ">=3"
+    "jest": ">=27"
   }
 }

--- a/integrations/jest-plugin/yarn.lock
+++ b/integrations/jest-plugin/yarn.lock
@@ -878,10 +878,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sucrase@^3.18.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.27.0.tgz#32b8e8735ae0e78c6e1e917d2dd61ecad69e5604"
-  integrity sha512-IjpEeFzOWCGrB/e2DnPawkFajW6ONFFgs+lQT1+Ts5Z5ZM9gPnxpDh0q8tu7HVLt6IfRiUTbSsjfhqjHOP/cwQ==
+sucrase@^3.28.0:
+  version "3.28.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.28.0.tgz#7fd8b3118d2155fcdf291088ab77fa6eefd63c4c"
+  integrity sha512-TK9600YInjuiIhVM3729rH4ZKPOsGeyXUwY+Ugu9eilNbdTFyHr6XcAGYbRVZPDgWj6tgI7bx95aaJjHnbffag==
   dependencies:
     commander "^4.0.0"
     glob "7.1.6"


### PR DESCRIPTION
In #753, I overlooked that Sucrase is already installed as a regular dependency, so there's no need to specify it as a peer dependency. The regular dependency is a little less flexible, but makes installation a little easier, so it's a tradeoff, and for now I'll just keep it the way it was. I do need to upgrade the Sucrase version to a more recent one so that the `preserveDynamicImport` is recognized.