### PR TITLE
Fix parsing of << within a type

### DIFF
--- a/src/parser/plugins/typescript.ts
+++ b/src/parser/plugins/typescript.ts
@@ -1138,9 +1138,7 @@ function tsTryParseGenericAsyncArrowFunction(): boolean {
  * where bitshift would be illegal anyway (e.g. in a class "extends" clause).
  *
  * This hack is useful to handle situations like foo<<T>() => void>() where
- * there can legitimately be two open-angle-brackets in a row in TS. This
- * situation is very obscure and (as of this writing) is handled by Babel but
- * not TypeScript itself, so it may be fine in the future to remove this case.
+ * there can legitimately be two open-angle-brackets in a row in TS.
  */
 function tsParseTypeArgumentsWithPossibleBitshift(): void {
   if (state.type === tt.bitShiftL) {

--- a/src/parser/tokenizer/index.ts
+++ b/src/parser/tokenizer/index.ts
@@ -505,6 +505,12 @@ function readToken_plus_min(code: number): void {
 }
 
 function readToken_lt(): void {
+  if (state.isType) {
+    // Avoid left-shift for things like `Array<<T>() => void>`.
+    finishOp(tt.lessThan, 1);
+    return;
+  }
+
   const nextChar = input.charCodeAt(state.pos + 1);
 
   if (nextChar === charCodes.lessThan) {

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -699,4 +699,15 @@ describe("transform flow", () => {
     `,
     );
   });
+
+  it("properly parses flow type args that look like left shift", () => {
+    assertFlowResult(
+      `
+      type A = B<<T>() => void>;
+    `,
+      `"use strict";
+      
+    `,
+    );
+  });
 });

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -2500,6 +2500,19 @@ describe("typescript transform", () => {
     );
   });
 
+  it("properly handles <= after `as` and `satisfies`", () => {
+    assertTypeScriptResult(
+      `
+      if (x as number <= 5) {}
+      if (x satisfies number <= 5) {}
+    `,
+      `"use strict";
+      if (x  <= 5) {}
+      if (x  <= 5) {}
+    `,
+    );
+  });
+
   it("handles simple template literal interpolations in types", () => {
     assertTypeScriptResult(
       `

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -3161,13 +3161,25 @@ describe("typescript transform", () => {
     );
   });
 
-  it("properly parses TS angle brackets that look like left shift", () => {
+  it("properly parses TS function type args that look like left shift", () => {
     assertResult(
       `
       f<<T>(value: T) => void>(g);
     `,
       `
       f(g);
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
+
+  it("properly parses TS type args that look like left shift", () => {
+    assertResult(
+      `
+      type A = B<<T>() => void>;
+    `,
+      `
+      
     `,
       {transforms: ["typescript"]},
     );


### PR DESCRIPTION
Fixes #758

There was already some logic from #716 to handle cases like `f<<T>() => void>`, where we're transitioning from a non-type context to a type context and need to detect if `<<` is actually two open-type-parameter/argument tokens. There was a simpler missing case, though, which is that `<<` is never allowed within a type, so we should tokenize as a simple `<` in a
type context. To handle the various cases correctly, this extra logic needs to only happen for `<<`, and this PR also adds
some additional comments explaining the nuances.