### PR TITLE
Port babel-parser changes from 2022-07-04 to 2022-10-26

### DIFF
--- a/spec-compliance-tests/babel-tests/check-babel-tests.ts
+++ b/spec-compliance-tests/babel-tests/check-babel-tests.ts
@@ -38,6 +38,8 @@ estree/class-private-property/flow
 estree/module-string-names/mixed
 experimental/decorators/export-decorated-class
 experimental/decorators/export-default-decorated-class
+experimental/decorators/parenthesized  // Uses obsolete syntax @(a)()
+experimental/decorators/parenthesized-createParenthesizedExpressions  // Uses obsolete syntax @(a)()
 flow/anonymous-function-no-parens-types/good_15
 flow/arrows-in-ternaries/issue-13644
 flow/arrows-in-ternaries/issue-58
@@ -88,7 +90,8 @@ typescript/import/type-asi
 typescript/import/type-equals-require
 `
   .split("\n")
-  .filter((s) => s);
+  .filter((s) => s)
+  .map((s) => s.split(" ")[0]);
 
 interface ResultSummary {
   numPassed: number;

--- a/src/parser/traverser/statement.ts
+++ b/src/parser/traverser/statement.ts
@@ -260,8 +260,8 @@ function parseDecorator(): void {
     while (eat(tt.dot)) {
       parseIdentifier();
     }
+    parseMaybeDecoratorArguments();
   }
-  parseMaybeDecoratorArguments();
 }
 
 function parseMaybeDecoratorArguments(): void {

--- a/test/sucrase-test.ts
+++ b/test/sucrase-test.ts
@@ -1588,6 +1588,26 @@ describe("sucrase", () => {
     );
   });
 
+  it("handles private field syntax for decorators", () => {
+    assertResult(
+      `
+      class C {
+        static #a;
+        @C.#a
+        foo() {}
+      }
+    `,
+      `
+      class C {
+        static #a;
+        @C.#a
+        foo() {}
+      }
+    `,
+      {disableESTransforms: true, transforms: []},
+    );
+  });
+
   it("allows destructuring private fields", () => {
     // Example from https://github.com/tc39/proposal-destructuring-private
     assertResult(

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -3318,6 +3318,18 @@ describe("typescript transform", () => {
     );
   });
 
+  it("distinguishes between instantiation expressions and right-shift", () => {
+    assertResult(
+      `
+      a<b>>>c
+    `,
+      `
+      a<b>>>c
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
+
   it("allows new instantiation expressions", () => {
     assertResult(
       `
@@ -3509,6 +3521,22 @@ describe("typescript transform", () => {
       } ;
     `,
       {transforms: ["typescript"]},
+    );
+  });
+
+  it("parses and removes the satisfies operator", () => {
+    assertResult(
+      `
+      class Foo {
+        declare readonly a = 0;
+      }
+    `,
+      `
+      class Foo {
+        declare  a = 0;
+      }
+    `,
+      {transforms: ["typescript"], disableESTransforms: true},
     );
   });
 });


### PR DESCRIPTION
Instructions: https://github.com/alangpierce/sucrase/wiki/Porting-changes-from-Babel's-parser

6fd6ce1df8 Add json schema of fixture runner options (#12619)
🚫 Babel-internal.

1c79224431 Misc fixes to `@babel/types` AST definitions (#14730)
🚫 Plugin-related change that doesn't affect Sucrase.

ea1eedaa35 v7.18.8
🚫 Release only.

2b163d8082 Prepare for compiling Babel to native ESM (#13414)
🚫 Babel-internal.

f1ac2906b1 v7.18.9
🚫 Release only.

ea5ff29f3e Extract string parsing to a separate package (#14772)
🚫 Refactor within Babel (though it looks like it may be best to keep an eye on changes/fixes to @babel/helper-string-parser).

a483aa2fbf Convert `@babel/parser` to TypeScript (#14783)
🚫 Babel-internal (but cool to see!).

acee429ebf chore: remove flow check scripts (#14785)
🚫 Babel-internal.

24d5fce6a2 Make ParseError much simpler now that we can use TypeScript (#14796)
🚫 Only affects error handling, not relevant to Sucrase.

b7e09455c8 Fix position of errors in template literals after newlines (#14798)
🚫 Only affects position information.

b0114cc9f7 parser node types improvements (#14791)
🚫 Babel-internal.

a5a8a31de3 fix(parser): allow TS declare readonly fields with initializers (#14817)
✅ Already worked in Sucrase, but I added a test.

9f603cf84c v7.18.10
🚫 Release only.

8d17ae62da babel parser type improvements (#14801)
🚫 Babel-internal.

757a425bd1 v7.18.11
🚫 Release only.

81158a58c5 [parser] Improve `getPluginOptions` type (#14861)
🚫 Babel-internal.

e5ab1512fc v7.18.13
🚫 Release only.

6c5ebd12fa fix: parse a<b>>>c as a<(b>>>c) (#14819)
✅ Already worked in Sucrase, presumably due to some tokenizer differences, so I just added a test.

2626f18c57 Update typescript to 4.8 (#14880)
🚫 Babel-internal.

eec95740ca chore: add eslint rule `consistent-type-imports` (#14901)
🚫 Babel-internal.

14ea25fbb3 Default to hash syntax for Record&Tuple (#14744)
🚫 Record and tuple not currently supported.

05deb60405 Enable `ban-ts-comment` (#14908)
🚫 Babel-internal.

d855f9d60c [parser] Make `decoratorsBeforeExport` default to `false` (#14695)
🚫 Seems to only affect error handling.

85ce832a7a support private name in decorator member expr (#14666)
✅ Already worked in Sucrase (with disableESTransforms).

16d3220bbf Add 2022-03 decorators version (stage 3) (#14836)
✅ Made small tweak to skip extra args in the `@()` case.

70a13e49be v7.19.0
🚫 Release only.

642adbcd98 [ts] allow redeclaring a var/type with the same name as import (#14900)
🚫 Error handling fix that doesn't affect Sucrase.

580d730186 [estree] attach comments after directives at the end of file (#14920)
🚫 Sucrase doesn't support estree.

eb621ac822 v7.19.1
🚫 Release only.

ae10b496d0 fix: allow ts redeclaration with `import =` and `var` (#14940)
🚫 Error handling fix that doesn't affect Sucrase.

40dfe9ac46 fix: Support local exports in TS `declare module`s (#14941)
🚫 Error handling fix that doesn't affect Sucrase.

c602be9315 chore: use `c8` for coverage testing (#14961)
🚫 Babel-internal.

6be6e04f39 fix: parsing of `JSXText` following `JSXSpreadChild` (#14974)
🚫 Fix for context system that was removed from Sucrase.

3d46a59956 v7.19.3
🚫 Release only.

98c3bb99e2 Improve module expression parsing/printing (#14980)
🚫 Appears to be an AST-specific fix, not relevant to Sucrase.

4fb29a372b Never throw for invalid escapes in tagged templates (#14964)
🚫 Error reporting only.

7a38850a83 v7.19.4
🚫 Release only.

ef0749df26 Use `startLoc.index` instead of carrying around `start` (#15056)
🚫 Refactor not relevant to Sucrase.

66d4fe9d3f fix: improve module block program location tracking (#15052)
🚫 AST only.

73c9aef872 Fix parsing of block comments nested in flow comments (#15062)
🚫 AST only.

aadd7a3d52 v7.19.6
🚫 Release only.

362f15b83c Fix handling of comments with decorators before `export` (#15032)
🚫 Only appears to affect AST and error handling.

df733b18ae [ts] Add support for `expr satisfies Type` expressions (#14211)
✅ Already done in https://github.com/alangpierce/sucrase/pull/766