### PR TITLE
Fix dynamic import on plain CJS files

### DIFF
--- a/integration-test/integration-tests.ts
+++ b/integration-test/integration-tests.ts
@@ -31,6 +31,19 @@ describe("integration tests", () => {
   }
 
   /**
+   * Find sucrase/register integration tests.
+   *
+   * Each test has a file starting with "main" (e.g. main.ts, main.tsx,
+   * main.mts, etc) that's used as the entry point. The test should be written
+   * in such a way that the execution throws an exception if the test fails.
+   */
+  for (const testFile of discoverTests("test-cases/register-cases", "main")) {
+    it(testFile, async () => {
+      await execPromise(`node -r ${__dirname}/../register ${testFile}`);
+    });
+  }
+
+  /**
    * Find Jest integration tests.
    *
    * Each test directory has a jest.config.js and a test that should pass when

--- a/integration-test/test-cases/register-cases/allows-dynamic-import/main.js
+++ b/integration-test/test-cases/register-cases/allows-dynamic-import/main.js
@@ -1,0 +1,14 @@
+async function main() {
+  const plainCJSFile = await import("./plain-cjs-file");
+  const transpiledESMFile = await import("./transpiled-esm-file");
+  if (plainCJSFile.default !== 15) {
+    throw new Error();
+  }
+  if (transpiledESMFile.a !== 1) {
+    throw new Error();
+  }
+  if (transpiledESMFile.default !== 3) {
+    throw new Error();
+  }
+}
+main();

--- a/integration-test/test-cases/register-cases/allows-dynamic-import/plain-cjs-file.js
+++ b/integration-test/test-cases/register-cases/allows-dynamic-import/plain-cjs-file.js
@@ -1,0 +1,1 @@
+module.exports = 15;

--- a/integration-test/test-cases/register-cases/allows-dynamic-import/transpiled-esm-file.js
+++ b/integration-test/test-cases/register-cases/allows-dynamic-import/transpiled-esm-file.js
@@ -1,0 +1,2 @@
+export const a = 1;
+export default 3;

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -83,6 +83,7 @@ export default class RootTransformer {
           tokenProcessor,
           importProcessor,
           this.nameManager,
+          this.helperManager,
           reactHotLoaderTransformer,
           enableLegacyBabel5ModuleInterop,
           transforms.includes("typescript"),

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -1055,9 +1055,9 @@ module.exports = exports.default;
         const foo = await import('foo');
       }
     `,
-      `"use strict";
+      `"use strict";${IMPORT_WILDCARD_PREFIX}
       async function loadThing() {
-        const foo = await Promise.resolve().then(() => require('foo'));
+        const foo = await Promise.resolve().then(() => _interopRequireWildcard(require('foo')));
       }
     `,
     );


### PR DESCRIPTION
Fixes #778

Previously, `import()` transpiled to a promise-wrapped `require`, which worked fine for ESM-to-CJS-transpiled modules, but when importing plain CJS modules, the behavior was inconsistent with other implementations. In that case, we needed to call `_interopRequireWildcard` to nest the module under a `default` key.

I tested to confirm that this updated behavior is consistent with Node ESM-to-CJS dynamic import, as well as Babel, TypeScript, and swc, so this change will be considered a bug fix rather than a breaking change, even though it is possible that existing use cases may have been relying on the old behavior.