### PR TITLE
Fix dynamic import with enableLegacyTypeScriptModuleInterop

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -34,6 +34,7 @@ export default class CJSImportTransformer extends Transformer {
     readonly helperManager: HelperManager,
     readonly reactHotLoaderTransformer: ReactHotLoaderTransformer | null,
     readonly enableLegacyBabel5ModuleInterop: boolean,
+    readonly enableLegacyTypeScriptModuleInterop: boolean,
     readonly isTypeScriptTransformEnabled: boolean,
     readonly preserveDynamicImport: boolean,
   ) {
@@ -124,10 +125,10 @@ export default class CJSImportTransformer extends Transformer {
         this.tokens.copyToken();
         return;
       }
-      const interopRequireWildcardName = this.helperManager.getHelperName("interopRequireWildcard");
-      this.tokens.replaceToken(
-        `Promise.resolve().then(() => ${interopRequireWildcardName}(require`,
-      );
+      const requireWrapper = this.enableLegacyTypeScriptModuleInterop
+        ? ""
+        : `${this.helperManager.getHelperName("interopRequireWildcard")}(`;
+      this.tokens.replaceToken(`Promise.resolve().then(() => ${requireWrapper}require`);
       const contextId = this.tokens.currentToken().contextId;
       if (contextId == null) {
         throw new Error("Expected context ID on dynamic import invocation.");
@@ -136,7 +137,7 @@ export default class CJSImportTransformer extends Transformer {
       while (!this.tokens.matchesContextIdAndLabel(tt.parenR, contextId)) {
         this.rootTransformer.processToken();
       }
-      this.tokens.replaceToken(")))");
+      this.tokens.replaceToken(requireWrapper ? ")))" : "))");
       return;
     }
 

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -86,6 +86,7 @@ export default class RootTransformer {
           this.helperManager,
           reactHotLoaderTransformer,
           enableLegacyBabel5ModuleInterop,
+          Boolean(options.enableLegacyTypeScriptModuleInterop),
           transforms.includes("typescript"),
           Boolean(options.preserveDynamicImport),
         ),

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -1063,6 +1063,22 @@ module.exports = exports.default;
     );
   });
 
+  it("uses plain require for dynamic import with enableLegacyTypeScriptModuleInterop", () => {
+    assertResult(
+      `
+      async function loadThing() {
+        const foo = await import('foo');
+      }
+    `,
+      `"use strict";
+      async function loadThing() {
+        const foo = await Promise.resolve().then(() => require('foo'));
+      }
+    `,
+      {transforms: ["imports"], enableLegacyTypeScriptModuleInterop: true},
+    );
+  });
+
   it("preserves dynamic import when configured to do so", () => {
     assertResult(
       `


### PR DESCRIPTION
In #789, I changed dynamic `import()` to use `_interopRequireWildcard`. However, after some more testing, I realized that `enableLegacyTypeScriptModuleInterop` mode should *not* do this, since it's an older interpretation of interop that generally doesn't use these helpers. This PR adds that as a new special case.