### PR TITLE
Remove constructor return type annotations

### DIFF
--- a/src/util/getClassInfo.ts
+++ b/src/util/getClassInfo.ts
@@ -278,6 +278,11 @@ function processConstructor(tokens: TokenProcessor): {
   }
   // )
   tokens.nextToken();
+  // Constructor type annotations are invalid, but skip them anyway since
+  // they're easy to skip.
+  while (tokens.currentToken().isType) {
+    tokens.nextToken();
+  }
   let constructorInsertPos = tokens.currentIndex();
 
   // Advance through body looking for a super call.

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -3714,4 +3714,26 @@ describe("typescript transform", () => {
       {transforms: ["typescript"]},
     );
   });
+
+  it("removes return type annotations from constructors", () => {
+    // Constructor return types aren't valid, but we return them anyway since
+    // it's easy and improves the DX when people make the mistake.
+    assertResult(
+      `
+      class A {
+        constructor(): A {
+          return this;
+        }
+      }
+    `,
+      `
+      class A {
+        constructor() {
+          return this;
+        }
+      }
+    `,
+      {transforms: ["typescript"]},
+    );
+  });
 });


### PR DESCRIPTION
Fixes #795

This syntax isn't actually valid, but it's easy enough to product working JS to avoid blocking the developer, so this implements that.