### PR TITLE
fix: handle specifier as default

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -292,6 +292,9 @@ export default class CJSImportTransformer extends Transformer {
       }
       this.processExportDefault();
       return true;
+    } else if (this.tokens.matches2(tt._export, tt.braceL)) {
+      this.processExportBindings();
+      return true;
     }
     this.hadNamedExport = true;
     if (
@@ -314,9 +317,6 @@ export default class CJSImportTransformer extends Transformer {
       this.tokens.matches2(tt._export, tt.at)
     ) {
       this.processExportClass();
-      return true;
-    } else if (this.tokens.matches2(tt._export, tt.braceL)) {
-      this.processExportBindings();
       return true;
     } else if (this.tokens.matches2(tt._export, tt.star)) {
       this.processExportStar();
@@ -798,6 +798,7 @@ export default class CJSImportTransformer extends Transformer {
       }
 
       const specifierInfo = getImportExportSpecifierInfo(this.tokens);
+
       while (this.tokens.currentIndex() < specifierInfo.endIndex) {
         this.tokens.removeToken();
       }
@@ -806,6 +807,12 @@ export default class CJSImportTransformer extends Transformer {
         const exportedName = specifierInfo.rightName;
         const newLocalName = this.importProcessor.getIdentifierReplacement(localName);
         exportStatements.push(`exports.${exportedName} = ${newLocalName || localName};`);
+
+        if (exportedName === "default") {
+          this.hadDefaultExport = true;
+        } else {
+          this.hadNamedExport = true;
+        }
       }
 
       if (this.tokens.matches1(tt.braceR)) {

--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -295,32 +295,6 @@ export default class CJSImportTransformer extends Transformer {
     } else if (this.tokens.matches2(tt._export, tt.braceL)) {
       this.processExportBindings();
       return true;
-    }
-    this.hadNamedExport = true;
-    if (
-      this.tokens.matches2(tt._export, tt._var) ||
-      this.tokens.matches2(tt._export, tt._let) ||
-      this.tokens.matches2(tt._export, tt._const)
-    ) {
-      this.processExportVar();
-      return true;
-    } else if (
-      this.tokens.matches2(tt._export, tt._function) ||
-      // export async function
-      this.tokens.matches3(tt._export, tt.name, tt._function)
-    ) {
-      this.processExportFunction();
-      return true;
-    } else if (
-      this.tokens.matches2(tt._export, tt._class) ||
-      this.tokens.matches3(tt._export, tt._abstract, tt._class) ||
-      this.tokens.matches2(tt._export, tt.at)
-    ) {
-      this.processExportClass();
-      return true;
-    } else if (this.tokens.matches2(tt._export, tt.star)) {
-      this.processExportStar();
-      return true;
     } else if (
       this.tokens.matches2(tt._export, tt.name) &&
       this.tokens.matchesContextualAtIndex(this.tokens.currentIndex() + 1, ContextualKeyword._type)
@@ -356,6 +330,32 @@ export default class CJSImportTransformer extends Transformer {
         this.tokens.removeToken();
         removeMaybeImportAttributes(this.tokens);
       }
+      return true;
+    }
+    this.hadNamedExport = true;
+    if (
+      this.tokens.matches2(tt._export, tt._var) ||
+      this.tokens.matches2(tt._export, tt._let) ||
+      this.tokens.matches2(tt._export, tt._const)
+    ) {
+      this.processExportVar();
+      return true;
+    } else if (
+      this.tokens.matches2(tt._export, tt._function) ||
+      // export async function
+      this.tokens.matches3(tt._export, tt.name, tt._function)
+    ) {
+      this.processExportFunction();
+      return true;
+    } else if (
+      this.tokens.matches2(tt._export, tt._class) ||
+      this.tokens.matches3(tt._export, tt._abstract, tt._class) ||
+      this.tokens.matches2(tt._export, tt.at)
+    ) {
+      this.processExportClass();
+      return true;
+    } else if (this.tokens.matches2(tt._export, tt.star)) {
+      this.processExportStar();
       return true;
     } else {
       throw new Error("Unrecognized export syntax.");
@@ -802,16 +802,18 @@ export default class CJSImportTransformer extends Transformer {
       while (this.tokens.currentIndex() < specifierInfo.endIndex) {
         this.tokens.removeToken();
       }
-      if (!specifierInfo.isType && !this.shouldElideExportedIdentifier(specifierInfo.leftName)) {
-        const localName = specifierInfo.leftName;
-        const exportedName = specifierInfo.rightName;
-        const newLocalName = this.importProcessor.getIdentifierReplacement(localName);
-        exportStatements.push(`exports.${exportedName} = ${newLocalName || localName};`);
 
+      if (!specifierInfo.isType) {
+        const exportedName = specifierInfo.rightName;
         if (exportedName === "default") {
           this.hadDefaultExport = true;
         } else {
           this.hadNamedExport = true;
+        }
+        if (!this.shouldElideExportedIdentifier(specifierInfo.leftName)) {
+          const localName = specifierInfo.leftName;
+          const newLocalName = this.importProcessor.getIdentifierReplacement(localName);
+          exportStatements.push(`exports.${exportedName} = ${newLocalName || localName};`);
         }
       }
 

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -768,6 +768,20 @@ module.exports = exports.default;
 `,
       {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
     );
+
+    assertResult(
+      `
+      const x = 1;
+      export { x as default };
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      const x = 1;
+      exports.default = x;
+    
+module.exports = exports.default;
+`,
+      {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
+    );
   });
 
   it("does not add module exports suffix when there is a named export", () => {

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -771,16 +771,20 @@ module.exports = exports.default;
 
     assertResult(
       `
-      const x = 1;
-      export { x as default };
+      export { x as default } from './foo'
+      export {}
+      export type A = string
+      export { type A as B }
     `,
-      `"use strict";${ESMODULE_PREFIX}
-      const x = 1;
-      exports.default = x;
+      `"use strict";${ESMODULE_PREFIX}${CREATE_NAMED_EXPORT_FROM_PREFIX}
+      var _foo = require('./foo'); _createNamedExportFrom(_foo, 'default', 'x');
+      
+      
+      
     
 module.exports = exports.default;
 `,
-      {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
+      {transforms: ["imports", "typescript"], enableLegacyBabel5ModuleInterop: true},
     );
   });
 


### PR DESCRIPTION
Add `module.exports = exports.default;` for case:
```ts
export { x as default } from './foo'
export { x as default }
export { }
export type A = string
export { type A as B }
```