### PR TITLE
Properly elide type-only re-export statements when targeting ESM

### DIFF
--- a/src/transformers/CJSImportTransformer.ts
+++ b/src/transformers/CJSImportTransformer.ts
@@ -790,7 +790,7 @@ export default class CJSImportTransformer extends Transformer {
     this.tokens.removeInitialToken();
     this.tokens.removeToken();
 
-    const exportStatements = [];
+    const exportStatements: Array<string> = [];
     while (true) {
       if (this.tokens.matches1(tt.braceR)) {
         this.tokens.removeToken();


### PR DESCRIPTION
Fixes #803
Fixes #805

When handling TypeScript, fix two issues involving statements starting with `export {`:
* Re-exports need to remove the module import if all exported names are explicitly elided.
* Re-exports should NOT do the implicit export elision that's needed for normal multi-exports.