### PR TITLE
Fix some additional enableLegacyBabel5ModuleInterop cases

### DIFF
--- a/src/transformers/ESMImportTransformer.ts
+++ b/src/transformers/ESMImportTransformer.ts
@@ -11,6 +11,7 @@ import getDeclarationInfo, {
 } from "../util/getDeclarationInfo";
 import getImportExportSpecifierInfo from "../util/getImportExportSpecifierInfo";
 import {getNonTypeIdentifiers} from "../util/getNonTypeIdentifiers";
+import isExportFrom from "../util/isExportFrom";
 import {removeMaybeImportAttributes} from "../util/removeMaybeImportAttributes";
 import shouldElideDefaultExport from "../util/shouldElideDefaultExport";
 import type ReactHotLoaderTransformer from "./ReactHotLoaderTransformer";
@@ -330,7 +331,7 @@ export default class ESMImportTransformer extends Transformer {
     this.tokens.copyExpectedToken(tt._export);
     this.tokens.copyExpectedToken(tt.braceL);
 
-    const isReExport = this.isReExport();
+    const isReExport = isExportFrom(this.tokens);
     let foundNonTypeExport = false;
     while (!this.tokens.matches1(tt.braceR)) {
       const specifierInfo = getImportExportSpecifierInfo(this.tokens);
@@ -367,21 +368,6 @@ export default class ESMImportTransformer extends Transformer {
     }
 
     return true;
-  }
-
-  /**
-   * Starting at `export {`, look ahead and return `true` if this is an
-   * `export {...} from` statement and `false` if this is a plain multi-export.
-   */
-  private isReExport(): boolean {
-    let closeBraceIndex = this.tokens.currentIndex();
-    while (!this.tokens.matches1AtIndex(closeBraceIndex, tt.braceR)) {
-      closeBraceIndex++;
-    }
-    return (
-      this.tokens.matchesContextualAtIndex(closeBraceIndex + 1, ContextualKeyword._from) &&
-      this.tokens.matches1AtIndex(closeBraceIndex + 2, tt.string)
-    );
   }
 
   /**

--- a/src/util/isExportFrom.ts
+++ b/src/util/isExportFrom.ts
@@ -1,0 +1,18 @@
+import {ContextualKeyword} from "../parser/tokenizer/keywords";
+import {TokenType as tt} from "../parser/tokenizer/types";
+import type TokenProcessor from "../TokenProcessor";
+
+/**
+ * Starting at `export {`, look ahead and return `true` if this is an
+ * `export {...} from` statement and `false` if this is a plain multi-export.
+ */
+export default function isExportFrom(tokens: TokenProcessor): boolean {
+  let closeBraceIndex = tokens.currentIndex();
+  while (!tokens.matches1AtIndex(closeBraceIndex, tt.braceR)) {
+    closeBraceIndex++;
+  }
+  return (
+    tokens.matchesContextualAtIndex(closeBraceIndex + 1, ContextualKeyword._from) &&
+    tokens.matches1AtIndex(closeBraceIndex + 2, tt.string)
+  );
+}

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -768,7 +768,9 @@ module.exports = exports.default;
 `,
       {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
     );
+  });
 
+  it("properly treats `as default` as a default export when adding module exports suffix", () => {
     assertResult(
       `
       export { x as default } from './foo'
@@ -788,6 +790,34 @@ module.exports = exports.default;
     );
   });
 
+  it("properly ignores regular default-exported types when deciding to add module exports suffix", () => {
+    assertResult(
+      `
+      type T = number;
+      export default T;
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      
+      ;
+    `,
+      {transforms: ["imports", "typescript"], enableLegacyBabel5ModuleInterop: true},
+    );
+  });
+
+  it("properly ignores `{T as default}` when deciding to add module exports suffix", () => {
+    assertResult(
+      `
+      type T = number;
+      export { T as default };
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      
+      
+    `,
+      {transforms: ["imports", "typescript"], enableLegacyBabel5ModuleInterop: true},
+    );
+  });
+
   it("does not add module exports suffix when there is a named export", () => {
     assertResult(
       `
@@ -799,6 +829,20 @@ module.exports = exports.default;
       exports. default = 4;
     `,
       {transforms: ["imports"], enableLegacyBabel5ModuleInterop: true},
+    );
+  });
+
+  it("properly treats exported TS enums as a named export when adding module exports suffix", () => {
+    assertResult(
+      `
+      export enum E {}
+      export default 4;
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      var E; (function (E) {})(E || (exports.E = E = {}));
+      exports. default = 4;
+    `,
+      {transforms: ["imports", "typescript"], enableLegacyBabel5ModuleInterop: true},
     );
   });
 


### PR DESCRIPTION
Follow-up from #804.
* When exporting `{T as default}`, treat it as a type-only export that doesn't count as a real default export.
* When explicitly doing `export default T`, treat it as a type-only export.
* Treat `export enum` as a named export.