### PR TITLE
Properly elide or preserve empty imports/exports

### DIFF
--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -95,6 +95,7 @@ export default class RootTransformer {
           enableLegacyBabel5ModuleInterop,
           Boolean(options.enableLegacyTypeScriptModuleInterop),
           transforms.includes("typescript"),
+          transforms.includes("flow"),
           Boolean(options.preserveDynamicImport),
         ),
       );
@@ -106,6 +107,7 @@ export default class RootTransformer {
           this.helperManager,
           reactHotLoaderTransformer,
           transforms.includes("typescript"),
+          transforms.includes("flow"),
           options,
         ),
       );

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -42,6 +42,50 @@ describe("transform flow", () => {
     );
   });
 
+  it("preserves import {} statements when targeting CJS", () => {
+    assertFlowResult(
+      `
+      import {} from 'a';
+    `,
+      `"use strict";
+      require('a');
+    `,
+    );
+  });
+
+  it("preserves import {} statements when targeting ESM", () => {
+    assertFlowESMResult(
+      `
+      import {} from 'a';
+    `,
+      `
+      import {} from 'a';
+    `,
+    );
+  });
+
+  it("preserves re-export {} statements when targeting CJS", () => {
+    assertFlowResult(
+      `
+      export {} from 'a';
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      require('a');
+    `,
+    );
+  });
+
+  it("preserves re-export {} statements when targeting ESM", () => {
+    assertFlowESMResult(
+      `
+      export {} from 'a';
+    `,
+      `
+      export {} from 'a';
+    `,
+    );
+  });
+
   it("does not mistake ? in types for a ternary operator", () => {
     assertFlowResult(
       `
@@ -231,10 +275,14 @@ describe("transform flow", () => {
       `
       import a, {type n as b, m as c, type d} from './e';
       import type f from './g';
+      import {type h} from './i';
+      import j, {} from './k';
     `,
       `
       import a, { m as c,} from './e';
 
+
+      import j, {} from './k';
     `,
     );
   });

--- a/test/imports-test.ts
+++ b/test/imports-test.ts
@@ -373,17 +373,6 @@ return obj && obj.__esModule ? obj : { default: obj }; }
     );
   });
 
-  it("allows an import statement with no import bindings", () => {
-    assertResult(
-      `
-      import {} from 'moduleName';
-    `,
-      `"use strict";
-      
-    `,
-    );
-  });
-
   it("handles trailing commas in named imports", () => {
     assertResult(
       `
@@ -1521,6 +1510,54 @@ module.exports = exports.default;
       @dec1  @dec2 class Foo {} exports.Foo = Foo;
       @dec3  @dec4 class Bar {} exports.default = Bar;
        @(1 + 1) @(foo.bar()) @a.b.c @d.e() @g.h(1, 2, 3) class Baz {} exports.default = Baz;
+    `,
+      {transforms: ["imports"]},
+    );
+  });
+
+  it("does not elide `import {}` with TS transform disabled when targeting ESM", () => {
+    assertResult(
+      `
+      import {} from './a';
+    `,
+      `
+      import {} from './a';
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("does not elide `import {}` with TS transform disabled when targeting CJS", () => {
+    assertResult(
+      `
+      import {} from './a';
+    `,
+      `"use strict";
+      require('./a');
+    `,
+      {transforms: ["imports"]},
+    );
+  });
+
+  it("does not elide `export {}` with TS transform disabled when targeting ESM", () => {
+    assertResult(
+      `
+      export {} from './a';
+    `,
+      `
+      export {} from './a';
+    `,
+      {transforms: []},
+    );
+  });
+
+  it("does not elide `export {}` with TS transform disabled when targeting CJS", () => {
+    assertResult(
+      `
+      export {} from './a';
+    `,
+      `"use strict";${ESMODULE_PREFIX}
+      require('./a');
     `,
       {transforms: ["imports"]},
     );

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -3804,4 +3804,20 @@ describe("typescript transform", () => {
       },
     );
   });
+
+  it("removes `import {}` statements when targeting TypeScript", () => {
+    assertTypeScriptImportResult(
+      `
+      import {} from 'a';
+    `,
+      {
+        expectedESMResult: `
+
+    `,
+        expectedCJSResult: `"use strict";
+      
+    `,
+      },
+    );
+  });
 });


### PR DESCRIPTION
Fixes #801

Sucrase previously had a somewhat unified approach to import/export elision, but this caused an issue with `import {}` statements, which should be removed in TypeScript, but not in Flow or with neither transform enabled. Now, we plumb the full configuration to both transforms and use the configuration to decide which strategy is relevant.