### PR TITLE
Add keepUnusedImports option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ transforms are available:
   annotations and handling features like enums. Does not check types. Sucrase
   transforms each file independently, so you should enable the `isolatedModules`
   TypeScript flag so that the typechecker will disallow the few features like
-  `const enum`s that need cross-file compilation.
+  `const enum`s that need cross-file compilation. The Sucrase option `keepUnusedImports`
+  can be used to disable all automatic removal of imports and exports, analogous to TS
+  `verbatimModuleSyntax`.
 * **flow**:  Removes Flow type annotations. Does not check types.
 * **imports**: Transforms ES Modules (`import`/`export`) to CommonJS
   (`require`/`module.exports`) using the same approach as Babel and TypeScript

--- a/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/main.ts
+++ b/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/main.ts
@@ -1,0 +1,6 @@
+// This import should be preserved.
+import A from './set-global-to-3.js'
+
+if (global.testValue !== 3) {
+  throw new Error();
+}

--- a/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/package.json
+++ b/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/set-global-to-3.ts
+++ b/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/set-global-to-3.ts
@@ -1,0 +1,2 @@
+global.testValue = 3;
+export default 2;

--- a/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/tsconfig.json
+++ b/integration-test/test-cases/ts-node-cases/option-cases/respects-verbatim-module-syntax/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true
+  },
+  "ts-node": {
+    "experimentalResolver": true
+  }
+}

--- a/src/Options-gen-types.ts
+++ b/src/Options-gen-types.ts
@@ -25,6 +25,7 @@ export const Options = t.iface([], {
   jsxImportSource: t.opt("string"),
   jsxPragma: t.opt("string"),
   jsxFragmentPragma: t.opt("string"),
+  keepUnusedImports: t.opt("boolean"),
   preserveDynamicImport: t.opt("boolean"),
   injectCreateRequireForImportRequire: t.opt("boolean"),
   enableLegacyTypeScriptModuleInterop: t.opt("boolean"),

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -56,6 +56,12 @@ export interface Options {
    */
   jsxFragmentPragma?: string;
   /**
+   * If specified, disable automatic removal of type-only import and export
+   * statements and names. Only statements and names that explicitly use the
+   * `type` keyword are removed.
+   */
+  keepUnusedImports?: boolean;
+  /**
    * If specified, the imports transform does not attempt to change dynamic
    * import() expressions into require() calls.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,16 +115,18 @@ function getSucraseContext(code: string, options: Options): SucraseContext {
       enableLegacyTypeScriptModuleInterop,
       options,
       options.transforms.includes("typescript"),
+      Boolean(options.keepUnusedImports),
       helperManager,
     );
     importProcessor.preprocessTokens();
     // We need to mark shadowed globals after processing imports so we know that the globals are,
     // but before type-only import pruning, since that relies on shadowing information.
     identifyShadowedGlobals(tokenProcessor, scopes, importProcessor.getGlobalNames());
-    if (options.transforms.includes("typescript")) {
+    if (options.transforms.includes("typescript") && !options.keepUnusedImports) {
       importProcessor.pruneTypeOnlyImports();
     }
-  } else if (options.transforms.includes("typescript")) {
+  } else if (options.transforms.includes("typescript") && !options.keepUnusedImports) {
+    // Shadowed global detection is needed for TS implicit elision of imported names.
     identifyShadowedGlobals(tokenProcessor, scopes, getTSImportedNames(tokenProcessor));
   }
   return {tokenProcessor, scopes, nameManager, importProcessor, helperManager};

--- a/src/transformers/RootTransformer.ts
+++ b/src/transformers/RootTransformer.ts
@@ -97,6 +97,7 @@ export default class RootTransformer {
           transforms.includes("typescript"),
           transforms.includes("flow"),
           Boolean(options.preserveDynamicImport),
+          Boolean(options.keepUnusedImports),
         ),
       );
     } else {
@@ -108,6 +109,7 @@ export default class RootTransformer {
           reactHotLoaderTransformer,
           transforms.includes("typescript"),
           transforms.includes("flow"),
+          Boolean(options.keepUnusedImports),
           options,
         ),
       );

--- a/src/util/shouldElideDefaultExport.ts
+++ b/src/util/shouldElideDefaultExport.ts
@@ -7,10 +7,11 @@ import type {DeclarationInfo} from "./getDeclarationInfo";
  */
 export default function shouldElideDefaultExport(
   isTypeScriptTransformEnabled: boolean,
+  keepUnusedImports: boolean,
   tokens: TokenProcessor,
   declarationInfo: DeclarationInfo,
 ): boolean {
-  if (!isTypeScriptTransformEnabled) {
+  if (!isTypeScriptTransformEnabled || keepUnusedImports) {
     return false;
   }
   const exportToken = tokens.currentToken();

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -71,7 +71,7 @@ describe("transform flow", () => {
     );
   });
 
-  it("properly prunes flow imported names when when targeting ESM", () => {
+  it("respects keepUnusedImports when targeting ESM", () => {
     assertFlowESMResult(
       `
       import {type T} from 'a';

--- a/test/flow-test.ts
+++ b/test/flow-test.ts
@@ -21,7 +21,7 @@ function assertFlowESMResult(
 }
 
 describe("transform flow", () => {
-  it("removes `import type` statements", () => {
+  it("removes `import type` statements when targeting CJS", () => {
     assertFlowResult(
       `
       import type {a} from 'b';
@@ -39,6 +39,47 @@ describe("transform flow", () => {
       
       
     `,
+    );
+  });
+
+  it("properly prunes flow imported names when when targeting ESM", () => {
+    assertFlowESMResult(
+      `
+      import a, {type n as b, m as c, type d} from './e';
+      import type f from './g';
+      import {type h} from './i';
+      import j, {} from './k';
+    `,
+      `
+      import a, { m as c,} from './e';
+
+
+      import j, {} from './k';
+    `,
+    );
+  });
+
+  it("respects keepUnusedImports when targeting CJS", () => {
+    assertFlowResult(
+      `
+      import {type T} from 'a';
+    `,
+      `"use strict";
+      require('a');
+    `,
+      {keepUnusedImports: true},
+    );
+  });
+
+  it("properly prunes flow imported names when when targeting ESM", () => {
+    assertFlowESMResult(
+      `
+      import {type T} from 'a';
+    `,
+      `
+      import {} from 'a';
+    `,
+      {keepUnusedImports: true},
     );
   });
 
@@ -266,23 +307,6 @@ describe("transform flow", () => {
     `,
       `"use strict";
       
-    `,
-    );
-  });
-
-  it("properly prunes flow imported names", () => {
-    assertFlowESMResult(
-      `
-      import a, {type n as b, m as c, type d} from './e';
-      import type f from './g';
-      import {type h} from './i';
-      import j, {} from './k';
-    `,
-      `
-      import a, { m as c,} from './e';
-
-
-      import j, {} from './k';
     `,
     );
   });

--- a/test/identifyShadowedGlobals-test.ts
+++ b/test/identifyShadowedGlobals-test.ts
@@ -20,6 +20,7 @@ function assertHasShadowedGlobals(code: string, expected: boolean): void {
       transforms: [],
     },
     false,
+    false,
     helperManager,
   );
   importProcessor.preprocessTokens();

--- a/ts-node-plugin/index.js
+++ b/ts-node-plugin/index.js
@@ -21,14 +21,20 @@ const JsxEmitReactJSXDev = 5;
  * JS syntax downleveling (at least not in a way that is useful for Node).
  *
  * One notable caveat is that importsNotUsedAsValues and preserveValueImports
- * are ignored right now, and Sucrase uses TypeScript's default behavior of
- * eliding imports only used as types. This usually makes no difference when
- * running the code, so for now we ignore these options without a warning.
+ * are ignored right now, since they are deprecated and don't have exact Sucrase
+ * equivalents. To preserve imports and exports, use verbatimModuleSyntax.
  */
 function create(createOptions) {
   const {nodeModuleEmitKind} = createOptions;
-  const {module, jsx, jsxFactory, jsxFragmentFactory, jsxImportSource, esModuleInterop} =
-    createOptions.service.config.options;
+  const {
+    module,
+    jsx,
+    jsxFactory,
+    jsxFragmentFactory,
+    jsxImportSource,
+    esModuleInterop,
+    verbatimModuleSyntax,
+  } = createOptions.service.config.options;
 
   return {
     transpile(input, transpileOptions) {
@@ -59,6 +65,7 @@ function create(createOptions) {
         jsxImportSource,
         jsxPragma: jsxFactory,
         jsxFragmentPragma: jsxFragmentFactory,
+        keepUnusedImports: verbatimModuleSyntax,
         preserveDynamicImport: nodeModuleEmitKind === "nodecjs",
         injectCreateRequireForImportRequire: nodeModuleEmitKind === "nodeesm",
         enableLegacyTypeScriptModuleInterop: !esModuleInterop,

--- a/website/src/Constants.ts
+++ b/website/src/Constants.ts
@@ -59,6 +59,7 @@ export const DEFAULT_OPTIONS: HydratedOptions = {
   jsxImportSource: "react",
   jsxPragma: "React.createElement",
   jsxFragmentPragma: "React.Fragment",
+  keepUnusedImports: false,
   preserveDynamicImport: false,
   injectCreateRequireForImportRequire: false,
   enableLegacyTypeScriptModuleInterop: false,

--- a/website/src/SucraseOptionsBox.tsx
+++ b/website/src/SucraseOptionsBox.tsx
@@ -33,6 +33,7 @@ interface BooleanOptionProps {
     | "enableLegacyBabel5ModuleInterop"
     | "production"
     | "disableESTransforms"
+    | "keepUnusedImports"
     | "preserveDynamicImport"
     | "injectCreateRequireForImportRequire";
   options: HydratedOptions;
@@ -200,6 +201,13 @@ export default function SucraseOptionsBox({
               )}
             </div>
             <div className={css(styles.secondaryOptionColumn)}>
+              {options.transforms.includes("typescript") && (
+                <BooleanOption
+                  optionName="keepUnusedImports"
+                  options={options}
+                  onUpdateOptions={onUpdateOptions}
+                />
+              )}
               {options.transforms.includes("imports") && (
                 <>
                   <BooleanOption

--- a/website/src/SucraseOptionsBox.tsx
+++ b/website/src/SucraseOptionsBox.tsx
@@ -201,7 +201,8 @@ export default function SucraseOptionsBox({
               )}
             </div>
             <div className={css(styles.secondaryOptionColumn)}>
-              {options.transforms.includes("typescript") && (
+              {(options.transforms.includes("typescript") ||
+                options.transforms.includes("flow")) && (
                 <BooleanOption
                   optionName="keepUnusedImports"
                   options={options}

--- a/website/src/worker/Worker.worker.ts
+++ b/website/src/worker/Worker.worker.ts
@@ -159,7 +159,10 @@ function runBabel(): {code: string; time: number | null} {
     }
   }
   if (sucraseOptions.transforms.includes("typescript")) {
-    presets.push(["typescript", {allowDeclareFields: true}]);
+    presets.push([
+      "typescript",
+      {allowDeclareFields: true, onlyRemoveTypeImports: sucraseOptions.keepUnusedImports},
+    ]);
   }
   if (sucraseOptions.transforms.includes("flow")) {
     presets.push("flow");
@@ -257,6 +260,7 @@ function runTypeScript(): {code: string; time: number | null} {
           esModuleInterop: !sucraseOptions.enableLegacyTypeScriptModuleInterop,
           jsxFactory: sucraseOptions.jsxPragma,
           jsxFragmentFactory: sucraseOptions.jsxFragmentPragma,
+          verbatimModuleSyntax: sucraseOptions.keepUnusedImports,
         },
       }).outputText,
   );


### PR DESCRIPTION
Supersedes #615
Fixes #791

This PR builds off of #615 with a number of additional tests and cases. High-level, it introduces a new option `keepUnusedImports` that disables all automatic import and export elision done by TypeScript, somewhat analogous to the `verbatimModuleSyntax` TS option. For the most part, this is just a matter of flagging off the name tracking and elision code
for both imports and exports in the various places that they happen.

When this mode is enabled, some of the preprocessing steps can be skipped, and scope handling can be fully skipped with
the imports transform also disabled. Performance numbers measured by `yarn benchmark jest-dev`:
* With `imports` and `typescript` transforms: 855k -> 910k lines per second (6% faster)
* With only `typescript` transform: 935k -> 1110k lines per second (19% faster)

Some additional details:
* While this feature is intended to be used with TypeScript, I decided to also implement the behavior for Flow as well. Flow's implementation in Babel will remove an import statement if all individual names are removed, but `flow-remove-types` won't do this, so Sucrase `keepUnusedImports` matches the behavior of `flow-remove-types`.
* Babel doesn't currently implement this option, so for the playground I mapped it to `onlyRemoveTypeImports`, which
  seems to have the closest behavior.