### PR TITLE
Add CLI flags for all Sucrase options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 dist-self-build
 dist-types
 example-runner/example-repos
+integration-test/test-cases/**/dist-actual
 spec-compliance-tests/test262/test262-checkout
 spec-compliance-tests/babel-tests/babel-tests-checkout
 integrations/gulp-plugin/dist

--- a/integration-test/test-cases/cli-cases/respects-disable-es-transforms/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-disable-es-transforms/dist-expected/main.js
@@ -1,0 +1,4 @@
+class A {
+  x = 1;
+  constructor( y) {;this.y = y;}
+}

--- a/integration-test/test-cases/cli-cases/respects-disable-es-transforms/src/main.ts
+++ b/integration-test/test-cases/cli-cases/respects-disable-es-transforms/src/main.ts
@@ -1,0 +1,4 @@
+class A {
+  x: number = 1;
+  constructor(readonly y: string) {}
+}

--- a/integration-test/test-cases/cli-cases/respects-disable-es-transforms/test.json
+++ b/integration-test/test-cases/cli-cases/respects-disable-es-transforms/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms typescript --disable-es-transforms"
+}

--- a/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/dist-expected/main.js
@@ -1,4 +1,4 @@
-import {createRequire as _createRequire} from "module"; const _require = _createRequire(import.meta.url);
+ import {createRequire as _createRequire} from "module"; const _require = _createRequire(import.meta.url);
 const A = _require('../A');
 
 function foo() {

--- a/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/dist-expected/main.js
@@ -1,0 +1,6 @@
+import {createRequire as _createRequire} from "module"; const _require = _createRequire(import.meta.url);
+const A = _require('../A');
+
+function foo() {
+  console.log(A);
+}

--- a/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/src/main.ts
+++ b/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/src/main.ts
@@ -1,0 +1,6 @@
+
+import A = require('../A');
+
+function foo(): void {
+  console.log(A);
+}

--- a/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/test.json
+++ b/integration-test/test-cases/cli-cases/respects-inject-create-require-for-import-require/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms typescript --inject-create-require-for-import-require"
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-defaults/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-jsx-defaults/dist-expected/main.js
@@ -1,0 +1,5 @@
+const _jsxFileName = "src/main.jsx";import React from 'react';
+
+function Foo() {
+  return React.createElement(React.Fragment, null, React.createElement('div', {__self: this, __source: {fileName: _jsxFileName, lineNumber: 4}} ));
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-defaults/src/main.jsx
+++ b/integration-test/test-cases/cli-cases/respects-jsx-defaults/src/main.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+function Foo() {
+  return <><div /></>;
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-defaults/test.json
+++ b/integration-test/test-cases/cli-cases/respects-jsx-defaults/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms jsx"
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/dist-expected/main.js
@@ -1,0 +1,4 @@
+const _jsxFileName = "src/main.tsx";import {jsxDEV as _jsxDEV} from "preact/jsx-dev-runtime";
+function Foo() {
+  return _jsxDEV('div', {}, void 0, false, {fileName: _jsxFileName, lineNumber: 3}, this );
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/src/main.tsx
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/src/main.tsx
@@ -1,0 +1,4 @@
+
+function Foo(): JSX.Element {
+  return <div />;
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/test.json
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-automatic/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms jsx,typescript --jsx-runtime automatic --jsx-import-source preact"
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/dist-expected/main.js
@@ -1,0 +1,4 @@
+
+function Foo() {
+  return h(React.Fragment, null, h('div', null ));
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/src/main.jsx
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/src/main.jsx
@@ -1,0 +1,4 @@
+
+function Foo() {
+  return <><div /></>;
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/test.json
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-classic/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms jsx --production --jsx-pragma h jsx-fragment-pragma Frag"
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/dist-expected/main.js
@@ -1,0 +1,3 @@
+function Foo() {
+  return <div />;
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/src/main.tsx
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/src/main.tsx
@@ -1,0 +1,3 @@
+function Foo(): JSX.Element {
+  return <div />;
+}

--- a/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/test.json
+++ b/integration-test/test-cases/cli-cases/respects-jsx-runtime-preserve/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms jsx,typescript --jsx-runtime preserve"
+}

--- a/integration-test/test-cases/cli-cases/respects-keep-unused-imports/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-keep-unused-imports/dist-expected/main.js
@@ -1,0 +1,4 @@
+import A from '../A';
+import B from '../B';
+
+console.log(A);

--- a/integration-test/test-cases/cli-cases/respects-keep-unused-imports/src/main.ts
+++ b/integration-test/test-cases/cli-cases/respects-keep-unused-imports/src/main.ts
@@ -1,0 +1,4 @@
+import A from '../A';
+import B from '../B';
+
+console.log(A);

--- a/integration-test/test-cases/cli-cases/respects-keep-unused-imports/test.json
+++ b/integration-test/test-cases/cli-cases/respects-keep-unused-imports/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms typescript --keep-unused-imports"
+}

--- a/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/dist-expected/main.js
+++ b/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/dist-expected/main.js
@@ -1,0 +1,6 @@
+"use strict"; function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }var _A = require('../A'); var _A2 = _interopRequireDefault(_A);
+
+async function foo() {
+  const B = (await import("../B")).default;
+  console.log(_A2.default + B);
+}

--- a/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/src/main.js
+++ b/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/src/main.js
@@ -1,0 +1,6 @@
+import A from "../A";
+
+async function foo() {
+  const B = (await import("../B")).default;
+  console.log(A + B);
+}

--- a/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/test.json
+++ b/integration-test/test-cases/cli-cases/respects-preserve-dynamic-import/test.json
@@ -1,0 +1,3 @@
+{
+  "cliOptions": "--transforms imports --preserve-dynamic-import"
+}

--- a/integration-test/util/assertDirectoriesEqual.ts
+++ b/integration-test/util/assertDirectoriesEqual.ts
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+import {readdir, readFile, stat} from "fs/promises";
+import {join} from "path";
+
+export default async function assertDirectoriesEqual(dir1: string, dir2: string): Promise<void> {
+  const dir1Files = (await readdir(dir1)).sort();
+  const dir2Files = (await readdir(dir2)).sort();
+  assert.strictEqual(
+    dir1Files.join(", "),
+    dir2Files.join(", "),
+    `Unexpected different lists of files for directories:\n${dir1}\n${dir2}`,
+  );
+  for (const filename of dir1Files) {
+    const path1 = join(dir1, filename);
+    const path2 = join(dir2, filename);
+    const isDir1 = (await stat(path1)).isDirectory();
+    const isDir2 = (await stat(path2)).isDirectory();
+    assert.strictEqual(isDir1, isDir2, `Paths are different types:\n${path1}\n${path2}`);
+    if (isDir1) {
+      await assertDirectoriesEqual(path1, path2);
+    } else {
+      const contents1 = (await readFile(path1)).toString();
+      const contents2 = (await readFile(path2)).toString();
+      assert.strictEqual(contents1, contents2, `File contents differed:\n${path1}\n${path2}`);
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ export default function run(): void {
     .option("--exclude-dirs <paths>", "Names of directories that should not be traversed.")
     .option("-q, --quiet", "Don't print the names of converted files.")
     .option("-t, --transforms <transforms>", "Comma-separated list of transforms to run.")
-    .option("--disable-es-transforms", "Opts out of all ES syntax transforms.")
+    .option("--disable-es-transforms", "Opt out of all ES syntax transforms.")
     .option("--jsx-runtime <string>", "Transformation mode for the JSX transform.")
     .option("--production", "Disable debugging information from JSX in output.")
     .option(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,16 +33,34 @@ export default function run(): void {
     )
     .option("--out-extension <extension>", "File extension to use for all output files.", "js")
     .option("--exclude-dirs <paths>", "Names of directories that should not be traversed.")
-    .option("-t, --transforms <transforms>", "Comma-separated list of transforms to run.")
     .option("-q, --quiet", "Don't print the names of converted files.")
+    .option("-t, --transforms <transforms>", "Comma-separated list of transforms to run.")
+    .option("--disable-es-transforms", "Opts out of all ES syntax transforms.")
+    .option("--jsx-runtime <string>", "Transformation mode for the JSX transform.")
+    .option("--production", "Disable debugging information from JSX in output.")
+    .option(
+      "--jsx-import-source <string>",
+      "Automatic JSX transform import path prefix, defaults to `React.Fragment`.",
+    )
+    .option(
+      "--jsx-pragma <string>",
+      "Classic JSX transform element creation function, defaults to `React.createElement`.",
+    )
+    .option(
+      "--jsx-fragment-pragma <string>",
+      "Classic JSX transform fragment component, defaults to `React.Fragment`.",
+    )
+    .option("--keep-unused-imports", "Disable automatic removal of type-only imports/exports.")
+    .option("--preserve-dynamic-import", "Don't transpile dynamic import() to require.")
+    .option(
+      "--inject-create-require-for-import-require",
+      "Use `createRequire` when transpiling TS `import = require` to ESM.",
+    )
     .option(
       "--enable-legacy-typescript-module-interop",
       "Use default TypeScript ESM/CJS interop strategy.",
     )
     .option("--enable-legacy-babel5-module-interop", "Use Babel 5 ESM/CJS interop strategy.")
-    .option("--jsx-pragma <string>", "Element creation function, defaults to `React.createElement`")
-    .option("--jsx-fragment-pragma <string>", "Fragment component, defaults to `React.Fragment`")
-    .option("--production", "Disable debugging information from JSX in output.")
     .parse(process.argv);
 
   if (commander.project) {
@@ -84,11 +102,17 @@ export default function run(): void {
     quiet: commander.quiet,
     sucraseOptions: {
       transforms: commander.transforms ? commander.transforms.split(",") : [],
-      enableLegacyTypeScriptModuleInterop: commander.enableLegacyTypescriptModuleInterop,
-      enableLegacyBabel5ModuleInterop: commander.enableLegacyBabel5ModuleInterop,
+      disableESTransforms: commander.disableEsTransforms,
+      jsxRuntime: commander.jsxRuntime,
+      production: commander.production,
+      jsxImportSource: commander.jsxImportSource,
       jsxPragma: commander.jsxPragma || "React.createElement",
       jsxFragmentPragma: commander.jsxFragmentPragma || "React.Fragment",
-      production: commander.production,
+      keepUnusedImports: commander.keepUnusedImports,
+      preserveDynamicImport: commander.preserveDynamicImport,
+      injectCreateRequireForImportRequire: commander.injectCreateRequireForImportRequire,
+      enableLegacyTypeScriptModuleInterop: commander.enableLegacyTypescriptModuleInterop,
+      enableLegacyBabel5ModuleInterop: commander.enableLegacyBabel5ModuleInterop,
     },
   };
 


### PR DESCRIPTION
Supersedes #670
Progress toward #792

This PR adds to the CLI a number of options that had been added. The CLI could still use some work in terms of error reporting and behavior, but this should hopefully get it closer to parity with other use cases.

The CLI previously had no tests, so this also adds an integration test suite exercising each new and existing Sucrase option (though it's not yet at full coverage).