### PR TITLE
Allow building on Windows (using Git Bash)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ more concrete suggestions.
 
 ## Getting started
 
-Sucrase uses `yarn` for everything.
+Sucrase uses `yarn` for everything. On Windows, either use `Git Bash` or
+build from Windows Subsystem for Linux (WSL).
 
 ```bash
 git clone git@github.com:alangpierce/sucrase.git

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,5 @@ module.exports = {
   parser: "typescript",
   printWidth: 100,
   trailingComma: "all",
+  endOfLine: "auto"
 };

--- a/script/run.ts
+++ b/script/run.ts
@@ -11,7 +11,7 @@ import {spawn} from "child_process";
 export default function run(command: string): Promise<void> {
   console.log(`> ${command}`);
   return new Promise((resolve, reject) => {
-    const childProcess = spawn("/bin/bash", ["-c", command], {stdio: "inherit"});
+    const childProcess = spawn("bash", ["-c", command], {stdio: "inherit"});
     childProcess.on("close", (code) => {
       if (code === 0) {
         resolve();


### PR DESCRIPTION
The default build system does not work verbatim on Windows because of the run.ts script spawning `"/bin/bash"` and because of Prettier not liking CRLF line endings. Building from WSL in fine, though.

This simple PR allows for building Sucrase on Windows using Git Bash.