### PR TITLE
Fix Template strings break sourcemaps #825

### DIFF
--- a/src/computeSourceMap.ts
+++ b/src/computeSourceMap.ts
@@ -2,6 +2,7 @@ import {GenMapping, maybeAddSegment, toEncodedMap} from "@jridgewell/gen-mapping
 
 import type {SourceMapOptions} from "./index";
 import type {Token} from "./parser/tokenizer";
+import {TokenType as tt} from "./parser/tokenizer/types";
 import {charCodes} from "./parser/util/charcodes";
 import type {RootTransformerResult} from "./transformers/RootTransformer";
 
@@ -71,6 +72,8 @@ export default function computeSourceMap(
  * position of the token.
  */
 function computeSourceColumns(code: string, tokens: Array<Token>): Array<number> {
+  tokens = tokens.filter((token) => token.end > token.start || token.type === tt.eof);
+
   const sourceColumns: Array<number> = new Array(tokens.length);
   let tokenIndex = 0;
   let currentMapping = tokens[tokenIndex].start;


### PR DESCRIPTION
Simply filter out empty tokens in `computeSourceColumns()`.

Passes all tests.
