### PR TITLE
Remove mz

### DIFF
--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -4,8 +4,7 @@
 import * as babel from "@babel/core";
 import * as swc from "@swc/core";
 import * as esbuild from "esbuild";
-import {fs} from "mz";
-import {exists} from "mz/fs";
+import fs from "fs";
 import * as TypeScript from "typescript";
 
 import run from "../script/run";
@@ -86,7 +85,7 @@ async function benchmarkJest(): Promise<void> {
 }
 
 async function getJestFiles(): Promise<Array<FileInfo>> {
-  if (!(await exists("./sample/jest"))) {
+  if (!fs.existsSync("./sample/jest")) {
     await run("git clone https://github.com/facebook/jest.git ./sample/jest");
     process.chdir("./sample/jest");
     await run("git checkout 7430a7824421c122cd07035d800d22e1007408fa");

--- a/benchmark/compare-performance.ts
+++ b/benchmark/compare-performance.ts
@@ -1,9 +1,12 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
-import {exec} from "mz/child_process";
-import {writeFile} from "mz/fs";
+import * as childProcess from "child_process";
+import {writeFile} from "fs/promises";
+import {promisify} from "util";
 
 import run from "../script/run";
+
+const exec = promisify(childProcess.exec);
 
 interface BenchmarkResult {
   name: string;
@@ -50,9 +53,9 @@ double-check the git state after running.
 }
 
 async function getBranchRef(): Promise<string> {
-  let branchRef = (await exec("git rev-parse --abbrev-ref HEAD"))[0].toString().trim();
+  let branchRef = (await exec("git rev-parse --abbrev-ref HEAD")).stdout.toString().trim();
   if (branchRef === "HEAD") {
-    branchRef = (await exec("git rev-parse HEAD"))[0].toString().trim();
+    branchRef = (await exec("git rev-parse HEAD")).stdout.toString().trim();
   }
   return branchRef;
 }
@@ -128,7 +131,7 @@ function summarizeChange(
 
 async function runBenchmark(): Promise<BenchmarkResult> {
   return JSON.parse(
-    (await exec("node -r sucrase/register benchmark/benchmark.ts jest-diff"))[0].toString(),
+    (await exec("node -r sucrase/register benchmark/benchmark.ts jest-diff")).stdout.toString(),
   );
 }
 

--- a/benchmark/loadProjectFiles.ts
+++ b/benchmark/loadProjectFiles.ts
@@ -1,4 +1,4 @@
-import {readdir, readFile, stat} from "mz/fs";
+import {readdir, readFile, stat} from "fs/promises";
 import {join} from "path";
 
 export interface FileInfo {

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -13,7 +13,6 @@
     "@swc/core": "^1.2.215",
     "@types/yargs-parser": "^20.2.0",
     "esbuild": "^0.14.49",
-    "mz": "^2.7.0",
     "typescript": "^4.7.4",
     "yargs-parser": "^20.2.4"
   }

--- a/benchmark/yarn.lock
+++ b/benchmark/yarn.lock
@@ -500,11 +500,6 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-any-promise@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
-
 browserslist@^4.21.3:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
@@ -737,24 +732,10 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mz@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
-  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
-  dependencies:
-    any-promise "^1.0.0"
-    object-assign "^4.0.1"
-    thenify-all "^1.0.0"
-
 node-releases@^2.0.8:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
-
-object-assign@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -772,20 +753,6 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-thenify-all@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
-  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
-  dependencies:
-    thenify ">= 3.1.0 < 4"
-
-"thenify@>= 3.1.0 < 4":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
-  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
-  dependencies:
-    any-promise "^1.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"

--- a/example-runner/example-runner.ts
+++ b/example-runner/example-runner.ts
@@ -1,6 +1,7 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
-import {exists, readFile} from "mz/fs";
+import {existsSync} from "fs";
+import {readFile} from "fs/promises";
 
 import run from "../script/run";
 
@@ -64,7 +65,7 @@ async function runProject(project: string, shouldSave: boolean): Promise<boolean
   const originalCwd = process.cwd();
   const repoDir = `./example-runner/example-repos/${project}`;
 
-  if (!(await exists(repoDir))) {
+  if (!existsSync(repoDir)) {
     console.log(`Directory ${repoDir} not found, cloning a new one.`);
     await run(`git clone ${repoURL} ${repoDir}`);
   }
@@ -72,7 +73,7 @@ async function runProject(project: string, shouldSave: boolean): Promise<boolean
 
   const revPath = `../../example-configs/${project}.revision`;
   const patchPath = `../../example-configs/${project}.patch`;
-  if (!(await exists(revPath)) || !(await exists(patchPath)) || shouldSave) {
+  if (!existsSync(revPath) || !existsSync(patchPath) || shouldSave) {
     console.log(`Generating metadata for ${project}`);
     await run(`git rev-parse HEAD > ${revPath}`);
     await run(`git diff HEAD > ${patchPath}`);

--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -1,6 +1,6 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
-import {writeFile} from "mz/fs";
+import {writeFile} from "fs/promises";
 
 import run from "../script/run";
 import generateReadWordTree from "./generateReadWordTree";

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@babel/core": "^7.22.5",
     "@jridgewell/trace-mapping": "^0.3.18",
     "@types/mocha": "^9.1.1",
-    "@types/mz": "^2.7.4",
     "@types/node": "^20.3.2",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
@@ -75,7 +74,6 @@
     "commander": "^4.0.0",
     "glob": "^10.3.10",
     "lines-and-columns": "^1.1.6",
-    "mz": "^2.7.0",
     "pirates": "^4.0.1",
     "ts-interface-checker": "^0.1.9"
   },

--- a/script/lint.ts
+++ b/script/lint.ts
@@ -1,6 +1,6 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
-import {exists} from "mz/fs";
+import {existsSync} from "fs";
 
 import run from "./run";
 
@@ -13,7 +13,7 @@ function isFix(): boolean {
 
 async function main(): Promise<void> {
   // Linting sub-projects requires the latest Sucrase types, so require a build first.
-  if (!(await exists("./dist"))) {
+  if (!existsSync("./dist")) {
     console.log("Must run build before lint, running build...");
     await run("yarn build");
   }

--- a/script/mergeDirectoryContents.ts
+++ b/script/mergeDirectoryContents.ts
@@ -1,11 +1,12 @@
-import {copyFile, exists, mkdir, readdir, stat} from "mz/fs";
+import {existsSync} from "fs";
+import {copyFile, mkdir, readdir, stat} from "fs/promises";
 import {join} from "path";
 
 export default async function mergeDirectoryContents(
   srcDirPath: string,
   destDirPath: string,
 ): Promise<void> {
-  if (!(await exists(destDirPath))) {
+  if (!existsSync(destDirPath)) {
     await mkdir(destDirPath);
   }
   for (const child of await readdir(srcDirPath)) {

--- a/script/mz.d.ts
+++ b/script/mz.d.ts
@@ -1,6 +1,0 @@
-import "mz/fs";
-
-declare module "mz/fs" {
-  // copyFile isn't in the typedefs yet, so add it manually.
-  export function copyFile(oldPath: string, newPath: string): Promise<void>;
-}

--- a/script/release.ts
+++ b/script/release.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {readFile} from "mz/fs";
+import {readFile} from "fs/promises";
 
 import run from "./run";
 import sleep from "./sleep";

--- a/spec-compliance-tests/babel-tests/check-babel-tests.ts
+++ b/spec-compliance-tests/babel-tests/check-babel-tests.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 // @ts-ignore: Babel package missing types.
 import * as babel from "@babel/core";
-import {exists, readdir, readFile, stat} from "mz/fs";
+import {existsSync} from "fs";
+import {readdir, readFile, stat} from "fs/promises";
 import {join, relative, resolve} from "path";
 
 import run from "../../script/run";
@@ -103,7 +104,7 @@ interface ResultSummary {
  * handling the important language edge cases.
  */
 async function main(): Promise<void> {
-  if (!(await exists(BABEL_TESTS_DIR))) {
+  if (!existsSync(BABEL_TESTS_DIR)) {
     console.log(`Directory ${BABEL_TESTS_DIR} not found, cloning a new one.`);
     await run(`git clone ${BABEL_REPO_URL} ${BABEL_TESTS_DIR}`);
   }
@@ -175,7 +176,7 @@ async function checkTests(dir: string, resultSummary: ResultSummary): Promise<vo
 async function checkTestForDir(dir: string, resultSummary: ResultSummary): Promise<void> {
   const displayDir = relative(FIXTURES_DIR, dir);
   const outputJSONPath = join(dir, "output.json");
-  if (!(await exists(outputJSONPath))) {
+  if (!existsSync(outputJSONPath)) {
     return;
   }
 
@@ -216,7 +217,7 @@ async function checkTestForDir(dir: string, resultSummary: ResultSummary): Promi
 async function getTestCode(dir: string): Promise<string> {
   for (const extension of [".js", ".ts", ".tsx", ".mjs", ".cjs"]) {
     const filePath = join(dir, `input${extension}`);
-    if (await exists(filePath)) {
+    if (existsSync(filePath)) {
       return readFileContents(filePath);
     }
   }
@@ -232,7 +233,7 @@ async function getBabelPlugins(testDir: string): Promise<Array<string>> {
   let dir = testDir;
   while (resolve(dir) !== resolve(FIXTURES_DIR)) {
     const optionsJSONPath = join(dir, "options.json");
-    if (await exists(optionsJSONPath)) {
+    if (existsSync(optionsJSONPath)) {
       const options = await readJSONFileContents(optionsJSONPath);
       if (options.plugins) {
         plugins.push(

--- a/spec-compliance-tests/test262/run-test262.ts
+++ b/spec-compliance-tests/test262/run-test262.ts
@@ -1,10 +1,13 @@
 #!./node_modules/.bin/sucrase-node
 /* eslint-disable no-console */
 import chalk from "chalk";
-import {exec} from "mz/child_process";
-import {exists} from "mz/fs";
+import * as childProcess from "child_process";
+import {existsSync} from "fs";
+import {promisify} from "util";
 
 import run from "../../script/run";
+
+const exec = promisify(childProcess.exec);
 
 const TEST262_HARNESS = "./node_modules/.bin/test262-harness";
 const TEST262_DIR = "./spec-compliance-tests/test262/test262-checkout";
@@ -25,7 +28,7 @@ const SKIPPED_TESTS = [
  * Run the test262 suite on some tests that we know are useful.
  */
 async function main(): Promise<void> {
-  if (!(await exists(TEST262_DIR))) {
+  if (!existsSync(TEST262_DIR)) {
     console.log(`Directory ${TEST262_DIR} not found, cloning a new one.`);
     await run(`git clone ${TEST262_REPO_URL} ${TEST262_DIR}`);
   }
@@ -51,7 +54,7 @@ async function main(): Promise<void> {
     --reporter "json" \
     "${TEST262_DIR}/test/language/expressions/coalesce/**/*.js" \
     "${TEST262_DIR}/test/language/expressions/optional-chaining/**/*.js"`)
-  )[0].toString();
+  ).stdout.toString();
 
   const harnessOutput = JSON.parse(harnessStdout);
   let numPassed = 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 import commander from "commander";
+import {existsSync} from "fs";
+import {mkdir, readdir, readFile, stat, writeFile} from "fs/promises";
 import {glob} from "glob";
-import {exists, mkdir, readdir, readFile, stat, writeFile} from "mz/fs";
 import {dirname, join, relative} from "path";
 
 import {type Options, transform} from "./index";
@@ -132,7 +133,7 @@ async function findFiles(options: CLIOptions): Promise<Array<FileInfo>> {
     ? [".ts", ".tsx"]
     : [".js", ".jsx"];
 
-  if (!(await exists(outDirPath))) {
+  if (!existsSync(outDirPath)) {
     await mkdir(outDirPath);
   }
 
@@ -183,7 +184,7 @@ async function runGlob(options: CLIOptions): Promise<Array<FileInfo>> {
   const absProject = join(process.cwd(), options.project);
   const outDirs: Array<string> = [];
 
-  if (!(await exists(options.outDirPath))) {
+  if (!existsSync(options.outDirPath)) {
     await mkdir(options.outDirPath);
   }
 
@@ -240,7 +241,7 @@ async function runGlob(options: CLIOptions): Promise<Array<FileInfo>> {
   }
 
   for (const outDirPath of outDirs) {
-    if (!(await exists(outDirPath))) {
+    if (!existsSync(outDirPath)) {
       await mkdir(outDirPath);
     }
   }

--- a/website/config/jest/cssTransform.js
+++ b/website/config/jest/cssTransform.js
@@ -1,14 +1,14 @@
-'use strict';
+"use strict";
 
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/tutorial-webpack.html
 
 module.exports = {
   process() {
-    return 'module.exports = {};';
+    return "module.exports = {};";
   },
   getCacheKey() {
     // The output is always the same.
-    return 'cssTransform';
+    return "cssTransform";
   },
 };

--- a/website/config/jest/fileTransform.js
+++ b/website/config/jest/fileTransform.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-const path = require('path');
+const path = require("path");
 
 // This is a custom Jest transformer turning file imports into filenames.
 // http://facebook.github.io/jest/docs/tutorial-webpack.html

--- a/website/scripts/test.js
+++ b/website/scripts/test.js
@@ -1,26 +1,25 @@
-'use strict';
+"use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_URL = '';
+process.env.NODE_ENV = "test";
+process.env.PUBLIC_URL = "";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
+process.on("unhandledRejection", (err) => {
   throw err;
 });
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env");
 
-const jest = require('jest');
+const jest = require("jest");
 const argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
+if (!process.env.CI && argv.indexOf("--coverage") < 0) {
+  argv.push("--watch");
 }
-
 
 jest.run(argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,13 +375,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
-"@types/mz@^2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@types/mz/-/mz-2.7.4.tgz#f9d1535cb5171199b28ae6abd6ec29e856551401"
-  integrity sha512-Zs0imXxyWT20j3Z2NwKpr0IO2LmLactBblNyLua5Az4UHuqOQ02V3jPTgyKwDkuc33/ahw+C3O1PIZdrhFMuQA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@^20.3.2":
   version "20.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.2.tgz#fa6a90f2600e052a03c18b8cb3fd83dd4e599898"


### PR DESCRIPTION
`fs/promises` has been supported since Node v10, a version released 6 years ago and have long been EOL. This pull request removes an unnecessary dependency on non-EOL Node.js platforms. Async `fs.exists` is discouraged by Node.js, so I replaced them with `existsSync`, which should have no tangible impact on performance.