### PR TITLE
Replace `glob` with faster alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/mocha": "^9.1.1",
     "@types/mz": "^2.7.4",
     "@types/node": "^20.3.2",
+    "@types/picomatch": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "chalk": "^4",
@@ -73,9 +74,10 @@
   "dependencies": {
     "@jridgewell/gen-mapping": "^0.3.2",
     "commander": "^4.0.0",
-    "glob": "^10.3.10",
+    "fdir": "^6.2.0",
     "lines-and-columns": "^1.1.6",
     "mz": "^2.7.0",
+    "picomatch": "^4.0.2",
     "pirates": "^4.0.1",
     "ts-interface-checker": "^0.1.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,6 +387,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.2.tgz#fa6a90f2600e052a03c18b8cb3fd83dd4e599898"
   integrity sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==
 
+"@types/picomatch@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/picomatch/-/picomatch-3.0.0.tgz#7b746b59c4a72b4f123a5a2a011ed69ddb6b1dba"
+  integrity sha512-iX/Qwk9vU17N/5Q7QrV46wzciloTdCqTRt6z8A7uFFADM2+Sy5oQh9ldZhAiTXH+l0sM/EkXatEhJIs8FUyOBQ==
+
 "@types/semver@^7.3.12":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
@@ -1328,6 +1333,11 @@ fastq@^1.6.0:
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
+
+fdir@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.2.0.tgz#9120f438d566ef3e808ca37864d9dd18e1a4f9b5"
+  integrity sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2515,6 +2525,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pirates@^4.0.1:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -2844,8 +2859,7 @@ stream-events@^1.0.5:
   dependencies:
     stubs "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2862,6 +2876,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -2906,8 +2929,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2920,6 +2942,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -3268,8 +3297,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -3291,6 +3319,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
`glob` is far from ideal considering its [26](https://npmgraph.js.org/?q=glob%4010.4.5) subdependencies and not that fast speed. This PR replaces its use with [`fdir`](https://www.npmjs.com/package/fdir) (the fastest dir crawler out there) and [`picomatch`](https://www.npmjs.com/package/picomatch). They have both a total of zero (0) subdependencies, making this not just a faster approach, but also one that's *way* lighter.

This PR makes `sucrase` go from [41](https://npmgraph.js.org/?q=sucrase%403.35.0) total subdependencies to just [**16**](https://npmgraph.js.org/?q=https%3A%2F%2Fraw.githubusercontent.com%2Falangpierce%2Fsucrase%2F3f4cb35dc475a20aa287552eec36dc52d3eddf56%2Fpackage.json), reducing its total package size from 5.4 MB to about 1.8 MB :O

Note: since `picomatch` supports an array of patterns, the loop that went over the patterns is not necessary anymore and was removed. Also refactored the skipping file types logic into picomatch's built-in `ignore` option

Relevant prior work: https://e18e.dev/guide/cleanup.html, dotenvx/dotenvx#278

<details><summary>Package size report</summary>

([tool source](https://github.com/TheDevMinerTV/package-size-calculator))

```
Package size report
===================

Package info for "sucrase@3.35.0": 5.4 MB
  Released: 2023-12-22 01:34:43.452 +0000 UTC (30w3d ago)
  Downloads last week: 5,870,223 (68.53%)
  Estimated traffic last week: 32 TB
  Subdependencies: 55

Removed dependencies:
  - glob@10.4.5: 3.6 MB (66.30%)
    Downloads last week: 10,260,938 (N/A% from 10.4.5)
    Downloads last week from "sucrase@3.35.0": 5,870,223 (N/A%)
    Traffic last week: N/A
    Traffic from "sucrase@3.35.0": 32 TB (N/A%)
    Subdependencies: 40 (72.72%)

Added dependencies:
  + fdir@6.2.0: 59 kB (1.09%)
    Downloads last week: N/A (N/A% from 6.2.0)
    Estimated traffic last week: N/A
    Subdependencies: 0 (0%)
  + picomatch@4.0.2: 86 kB (1.59%)
    Downloads last week: 1,805,723 (N/A% from 4.0.2)
    Estimated traffic last week: N/A
    Subdependencies: 0 (0%)

Estimated new statistics:
  Package size: 5.4 MB → 817 kB (15.20%)
  Subdependencies: 55 → 16 (-39)
  Traffic with last week's downloads:
    For current version: 32 TB → 4.8 TB (27 TB saved)
    For all versions: 46 TB → 7.0 TB (39 TB saved)
```

</details> 