### PR TITLE
Switch to tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
   "dependencies": {
     "@jridgewell/gen-mapping": "^0.3.2",
     "commander": "^4.0.0",
-    "glob": "^10.3.10",
     "lines-and-columns": "^1.1.6",
     "mz": "^2.7.0",
     "pirates": "^4.0.1",
+    "tinyglobby": "^0.2.11",
     "ts-interface-checker": "^0.1.9"
   },
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import commander from "commander";
-import {glob} from "glob";
+import {glob} from "tinyglobby";
 import {exists, mkdir, readdir, readFile, stat, writeFile} from "mz/fs";
 import {dirname, join, relative} from "path";
 
@@ -213,7 +213,7 @@ async function runGlob(options: CLIOptions): Promise<Array<FileInfo>> {
   }
   if (include) {
     for (const pattern of include) {
-      const globFiles = await glob(join(absProject, pattern));
+      const globFiles = await glob(join(absProject, pattern), {expandDirectories: false});
       for (const file of globFiles) {
         if (!file.endsWith(".ts") && !file.endsWith(".js")) {
           continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fdir@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
+  integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -2515,6 +2520,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pirates@^4.0.1:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -3044,6 +3054,14 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+tinyglobby@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.11.tgz#9182cff655a0e272aad850d1a84c5e8e0f700426"
+  integrity sha512-32TmKeeKUahv0Go8WmQgiEp9Y21NuxjwjqiRC1nrUB51YacfSwuB44xgXD+HdIppmMRgjQNPdrHyA6vIybYZ+g==
+  dependencies:
+    fdir "^6.4.3"
+    picomatch "^4.0.2"
 
 tmp@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This removes more than half of sucrase's transitive dependencies. Fewer dependencies avoid issues like https://github.com/alangpierce/sucrase/pull/822, reduces supply chain risk, and makes the install smaller for consumers.

https://npmgraph.js.org/?q=glob - 26 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies