### PR TITLE
chore: add jest plugin package support metadata

### DIFF
--- a/integrations/jest-plugin/package.json
+++ b/integrations/jest-plugin/package.json
@@ -4,6 +4,10 @@
   "description": "Jest plugin for Sucrase",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/jest-plugin",
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/jest-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add npm homepage metadata for `@sucrase/jest-plugin`
- add npm `bugs.url` metadata pointing to the Sucrase issue tracker

This is metadata-only. It does not change runtime code, exports, dependencies, generated files, package versioning, or build behavior.

## Verification
```sh
node -e "const p=require('./integrations/jest-plugin/package.json'); if(p.name!=='@sucrase/jest-plugin'||p.homepage!=='https://github.com/alangpierce/sucrase/tree/main/integrations/jest-plugin#readme'||p.bugs?.url!=='https://github.com/alangpierce/sucrase/issues') process.exit(1); console.log('package metadata OK')"
cd integrations/jest-plugin && npm pack --dry-run --ignore-scripts --json
cd ../.. && git diff --check
```