### PR TITLE
chore: add webpack loader package support metadata

### DIFF
--- a/integrations/webpack-loader/package.json
+++ b/integrations/webpack-loader/package.json
@@ -4,6 +4,10 @@
   "description": "Webpack loader for Sucrase",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-loader",
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-loader#readme",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- add npm homepage metadata for `@sucrase/webpack-loader`
- add npm `bugs.url` metadata pointing to the Sucrase issue tracker

This is metadata-only. It does not change runtime code, exports, dependencies, generated files, package versioning, or build behavior.

## Verification
```sh
node -e "const p=require('./integrations/webpack-loader/package.json'); if(p.name!=='@sucrase/webpack-loader'||p.homepage!=='https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-loader#readme'||p.bugs?.url!=='https://github.com/alangpierce/sucrase/issues') process.exit(1); console.log('package metadata OK')"
cd integrations/webpack-loader && npm pack --dry-run --ignore-scripts --json
cd ../.. && git diff --check
```
