### PR TITLE
chore: add integration package support metadata

### DIFF
--- a/integrations/gulp-plugin/package.json
+++ b/integrations/gulp-plugin/package.json
@@ -6,6 +6,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/gulp-plugin",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/gulp-plugin#readme",
   "files": [
     "dist"
   ],

--- a/integrations/jest-plugin/package.json
+++ b/integrations/jest-plugin/package.json
@@ -4,6 +4,10 @@
   "description": "Jest plugin for Sucrase",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/jest-plugin",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/jest-plugin#readme",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "devDependencies": {

--- a/integrations/webpack-loader/package.json
+++ b/integrations/webpack-loader/package.json
@@ -4,6 +4,10 @@
   "description": "Webpack loader for Sucrase",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-loader",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-loader#readme",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "peerDependencies": {

--- a/integrations/webpack-object-rest-spread-plugin/package.json
+++ b/integrations/webpack-object-rest-spread-plugin/package.json
@@ -4,6 +4,10 @@
   "description": "Webpack plugin to enable object rest/spread syntax",
   "main": "dist/index.js",
   "repository": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-object-rest-spread-plugin",
+  "bugs": {
+    "url": "https://github.com/alangpierce/sucrase/issues"
+  },
+  "homepage": "https://github.com/alangpierce/sucrase/tree/main/integrations/webpack-object-rest-spread-plugin#readme",
   "author": "Alan Pierce <alangpierce@gmail.com>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- add `bugs.url` and `homepage` metadata for `@sucrase/gulp-plugin`
- add `bugs.url` and `homepage` metadata for `@sucrase/jest-plugin`
- add `bugs.url` and `homepage` metadata for `@sucrase/webpack-loader`
- add `bugs.url` and `homepage` metadata for `@sucrase/webpack-object-rest-spread-plugin`

## Why
These integration packages already publish repository metadata, but npm consumers do not currently get standard issue tracker and README links from the `bugs` and `homepage` fields.

## Validation
- `node` manifest assertion for all four package files
- `npm pack --dry-run --ignore-scripts --json ./integrations/gulp-plugin`
- `npm pack --dry-run --ignore-scripts --json ./integrations/jest-plugin`
- `npm pack --dry-run --ignore-scripts --json ./integrations/webpack-loader`
- `npm pack --dry-run --ignore-scripts --json ./integrations/webpack-object-rest-spread-plugin`
- `git diff --check`